### PR TITLE
feat: red-ui distribution architecture (ADRs) + Cloudflare Pages deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,33 +155,40 @@ jobs:
           name: pwa-bundle
           path: packages/ui/build
 
-  # pwa-pages is disabled until GitHub Pages is manually enabled in
-  # the repo settings (Settings → Pages → Source: GitHub Actions). The
-  # v0.0.1 attempt failed with HTTP 404 on the Pages API for that reason.
-  # Uncomment after enabling.
+  # Deploy the Web Surface to Cloudflare Pages → ui.reddb.io (ADR-0005).
+  # Built with BASE_PATH='' because this is a dedicated host, not a subpath.
+  # The deploy step self-skips when CLOUDFLARE_* secrets are absent, mirroring
+  # the unsigned-build fallback in the tauri job, so forks/PRs don't fail.
   #
-  # pwa-pages:
-  #   name: pwa · github pages
-  #   runs-on: blacksmith-4vcpu-ubuntu-2404
-  #   permissions:
-  #     contents: read
-  #     pages: write
-  #     id-token: write
-  #   environment:
-  #     name: github-pages
-  #     url: ${{ steps.deploy.outputs.page_url }}
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: pnpm/action-setup@v4
-  #     - uses: actions/setup-node@v4
-  #       with: { node-version: 22, cache: pnpm }
-  #     - run: pnpm install --frozen-lockfile
-  #     - name: build pwa (Pages, BASE_PATH=/red-ui)
-  #       env:
-  #         BASE_PATH: /red-ui
-  #       run: pnpm --filter @red-ui/ui build
-  #     - uses: actions/upload-pages-artifact@v3
-  #       with:
-  #         path: packages/ui/build
-  #     - id: deploy
-  #       uses: actions/deploy-pages@v4
+  # Required repo secrets:
+  #   CLOUDFLARE_API_TOKEN   — scoped token with "Cloudflare Pages: Edit"
+  #   CLOUDFLARE_ACCOUNT_ID  — the reddb.io Cloudflare account id
+  # The ui.reddb.io custom domain / DNS binding is owned by rio-infra.
+  pwa-pages:
+    name: pwa · cloudflare pages
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 22, cache: pnpm }
+      - run: pnpm install --frozen-lockfile
+
+      - name: build pwa (root, for ui.reddb.io)
+        env:
+          BASE_PATH: ''
+        run: pnpm --filter @red-ui/ui build
+
+      - name: deploy to cloudflare pages
+        if: ${{ env.CLOUDFLARE_API_TOKEN != '' }}
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: >-
+            pages deploy packages/ui/build
+            --project-name=red-ui
+            --branch=main
+            --commit-hash=${{ github.sha }}

--- a/.red/CONTEXT.md
+++ b/.red/CONTEXT.md
@@ -1,0 +1,49 @@
+# red-ui
+
+The universal client for reddb. A single static bundle delivered into several contexts, each pointed at a reddb instance with the right session before any screen renders.
+
+## Language
+
+**Connection Bootstrap**:
+The boot-time resolution of which reddb to talk to and with what session, read automatically from whichever channel the current Surface provides.
+_Avoid_: handoff, boot config, deep-link config
+
+**Surface**:
+A delivery context red-ui ships into — one of embedded, standalone, or web — all consuming the same static bundle.
+_Avoid_: distribution channel, build target, mode
+
+**Embedded (Surface)**:
+red-ui vendored into the `red` binary and served same-origin by a `red ui <file>` subcommand against a local file, no auth, offline.
+_Avoid_: local mode
+
+**Standalone (Surface)**:
+The installable Tauri desktop app (`apps/desktop`, `io.reddb.io`) — native window, `.rdb` file association, OS-keychain vault — kept alongside `red ui`, not replaced by it.
+_Avoid_: desktop, native app
+
+**Web (Surface)**:
+red-ui hosted statically under `*.reddb.io` (canonically `ui.reddb.io`, possibly deeply nested like `x.y.z.reddb.io`), reached two ways: a control-plane deep-link that reuses the reddb.io session (cookie scoped `Domain=.reddb.io`), or a generic connect-anywhere entry via the `cs` param.
+_Avoid_: PWA, hosted, cloud
+
+**cs (param)**:
+The `?cs=` URL parameter carrying the Connection Bootstrap target for the Web Surface — always a browser-reachable URL (e.g. `http://127.0.0.1:PORT`), never a filesystem path.
+_Avoid_: connection string when it means a file path
+
+**Open Contract**:
+The shared parameter set both entry points use to open red-ui pre-configured: `cs` (target URL), optional `token` (short-lived handoff, carried in the `#hash` on web), and optional `to` (initial route/view). Same shape for the `red://open?…` deep-link and `ui.reddb.io/?…`.
+_Avoid_: deep-link params, query string
+
+**Session Handoff Token**:
+A short-lived, single-use, target-scoped token minted by reddb.io so an app without the `.reddb.io` cookie (the native Standalone Surface, or any cross-app jump) can authenticate to a target; verified by the target via reddb.io's JWKS — trusted by the managed fleet by default, by BYO servers via opt-in issuer registration.
+_Avoid_: session, credential, API key
+
+## Relationships
+
+- A **Surface** consumes exactly one static bundle; the same bundle serves all **Surfaces**.
+- Every **Surface** feeds the bundle through the **Connection Bootstrap**; only the Bootstrap *source* differs per Surface.
+- The **Embedded (Surface)** is the static bundle vendored into the `red` binary (cross-repo: ../reddb ships our build); `red ui <file>` serves it same-origin and offline by default, `--remote` instead opens the **Web (Surface)** with a `cs` pointing at the local server.
+- A truly private reddb (k8s-internal, firewalled) is reachable only by the **Embedded** or **Standalone** Surfaces, never the **Web** Surface — browser reachability is the boundary.
+
+## Flagged ambiguities
+
+- "embedded" is overloaded: an **Embedded (Surface)** is how *red-ui* is delivered, distinct from reddb's *embedded deployment mode* (how the *database* runs). Same word, different layer.
+- "connection string" / `cs` was used to mean a local file path (`?cs=/home/user/mydb.rdb`) — resolved: a hosted page cannot read a path, so `cs` is always a browser-reachable URL. Turning a file into a URL is the job of a local launcher (`red ui <file>`), not the Web Surface.

--- a/.red/CONTEXT.md
+++ b/.red/CONTEXT.md
@@ -33,8 +33,12 @@ The shared parameter set both entry points use to open red-ui pre-configured: `c
 _Avoid_: deep-link params, query string
 
 **Session Handoff Token**:
-A short-lived, single-use, target-scoped token minted by reddb.io so an app without the `.reddb.io` cookie (the native Standalone Surface, or any cross-app jump) can authenticate to a target; verified by the target via reddb.io's JWKS — trusted by the managed fleet by default, by BYO servers via opt-in issuer registration.
+A short-lived, single-use, target-scoped token minted by reddb.io and used for **all** data-plane access (Web and native alike); verified by the target via reddb.io's JWKS — trusted by the managed fleet by default, by BYO servers via opt-in issuer registration. The `.reddb.io` cookie authenticates only the control plane (to mint this token) and is never presented to a server.
 _Avoid_: session, credential, API key
+
+**Capability negotiation**:
+The boot-time probe by which one red-ui version serves servers of many versions — it reads the target's version/capabilities and *hides* (not greys out) controls the server can't honour, consistent with the project's permission-aware "absent, not disabled" rule. The `client.ts` unsupported-route probe is the seed.
+_Avoid_: version check, feature flag
 
 ## Relationships
 
@@ -47,3 +51,4 @@ _Avoid_: session, credential, API key
 
 - "embedded" is overloaded: an **Embedded (Surface)** is how *red-ui* is delivered, distinct from reddb's *embedded deployment mode* (how the *database* runs). Same word, different layer.
 - "connection string" / `cs` was used to mean a local file path (`?cs=/home/user/mydb.rdb`) — resolved: a hosted page cannot read a path, so `cs` is always a browser-reachable URL. Turning a file into a URL is the job of a local launcher (`red ui <file>`), not the Web Surface.
+- "vault only in Standalone" (an early claim) vs the Web Surface authenticating directly against an untrusted BYO server — resolved: the **Web Surface persists the target label only, never the secret** (secret is session-only, in-memory). The full credential vault (master-password / OS keychain) remains a **Standalone**-only feature. Managed targets use the Session Handoff Token and persist nothing.

--- a/.red/adr/0001-single-bundle-multi-source-bootstrap.md
+++ b/.red/adr/0001-single-bundle-multi-source-bootstrap.md
@@ -1,0 +1,62 @@
+# 0001. Single static bundle with a multi-source Connection Bootstrap
+
+## Status
+
+Proposed
+
+Date: 2026-05-29
+
+## Context
+
+red-ui ships into three delivery contexts (Surfaces): **Embedded** (vendored
+into the `red` binary, served same-origin by `red ui <file>`), **Standalone**
+(the Tauri desktop app), and **Web** (`ui.reddb.io`). Each Surface has a
+different natural channel for learning *which reddb to talk to* and *with what
+session*: Tauri exposes an IPC bridge, the Web Surface is handed a target via
+URL params (and a session cookie or token), and the Embedded Surface knows the
+local server URL it just spawned.
+
+The SvelteKit app is already built with `adapter-static` and the
+`svelte.config.js` comment states the intent that "the same static bundle work
+at the site root (embedded in the `red` server / Tauri / dev) AND under a
+subpath". What does **not** exist yet is any mechanism for a Surface to inject
+the connection target/session at boot — there is no URL-param, injected-global,
+or IPC handling in the codebase today. Connection state is currently read only
+from presets + localStorage, gated behind the encrypted-vault unlock.
+
+## Decision
+
+We will keep **one** static bundle for all Surfaces and introduce a single
+**Connection Bootstrap** reader that resolves the boot target from a fixed
+source priority:
+
+1. Tauri IPC (Standalone)
+2. Host-injected global, e.g. `window.__RED_BOOTSTRAP__` (Web with session)
+3. URL param — the Open Contract (`cs`, `token` in `#hash`, `to`)
+4. Persisted local store (returning users / manual connect)
+
+Each Surface populates whichever source is natural to it; the bundle itself is
+Surface-agnostic. No per-Surface build variants.
+
+## Consequences
+
+- One artifact to build, test, and version — the bundle is the unit that every
+  Surface and consumer (see ADR-0003) embeds or deploys.
+- The Bootstrap becomes the single seam where session/auth differences between
+  Surfaces are expressed (see ADR-0004), keeping the rest of the UI uniform.
+- The boot path must tolerate "no source present" (cold open with no target) and
+  fall back to the Connect screen, so the reader needs a well-defined empty case.
+- The hard vault-lock gate in `+layout.svelte` (which today blocks all network
+  traffic until master-password unlock) must become Surface-aware, or the
+  credential-less Surfaces will be wrongly blocked at boot.
+
+## Alternatives considered
+
+- **Separate builds per Surface.** Cleanest isolation, but triples maintenance
+  and divergence risk for three targets that differ only in how a target URL +
+  session arrive. Rejected — the difference is data, not code.
+- **Single injection mechanism (only URL params, or only injected global).**
+  Simpler reader, but no single channel fits all three Surfaces: URL params leak
+  tokens and don't suit Tauri; an injected global can't express a user-typed
+  ad-hoc URL. A priority-ordered multi-source reader covers all three with one
+  bundle.

--- a/.red/adr/0002-web-surface-reach-via-reddb-cors-allowlist.md
+++ b/.red/adr/0002-web-surface-reach-via-reddb-cors-allowlist.md
@@ -1,0 +1,68 @@
+# 0002. Web Surface reaches reddb via a per-server CORS allowlist, not a central proxy
+
+## Status
+
+Proposed
+
+Date: 2026-05-29
+
+## Context
+
+The Web Surface (`ui.reddb.io`, a statically-hosted PWA) must connect to "any
+reddb the browser can reach" — a managed `*.reddb.io` server, a `localhost`
+server spawned by `red ui --remote`, or a user's public k8s ingress. Two browser
+realities constrain this:
+
+1. **Reachability.** A hosted page can only talk to endpoints the *browser* can
+   route to. A truly private reddb (k8s-internal, firewalled, plain localhost on
+   another machine) is unreachable from a hosted page and from a reddb.io-side
+   gateway alike. Those targets are the exclusive territory of the Embedded and
+   Standalone Surfaces, whose process runs *inside* the reachable network.
+2. **CORS.** reddb sends **no** CORS headers today. Even a managed
+   `cluster.db.reddb.io` is cross-origin to `ui.reddb.io`. The existing dev
+   workaround — a Vite middleware proxy at `/_red` — does not exist on a static
+   host (e.g. Pages), so there is no same-origin proxy to lean on in production.
+
+Browsers exempt `http://localhost` / `127.0.0.1` from mixed-content blocking, so
+an `https` PWA *can* call a local reddb — but still only if that server returns
+CORS headers for the `ui.reddb.io` origin.
+
+## Decision
+
+We will make CORS a first-class, configurable feature of the **reddb server**
+(`../reddb`): an operator-set allowlist of trusted UI origins (defaulting to
+`*.reddb.io` for the managed fleet, operator-extensible for BYO). The Web Surface
+then calls the target reddb **directly** from the browser; no central proxy or
+gateway sits in the data path.
+
+The Web Surface's coverage is explicitly bounded to **browser-reachable**
+servers. Unreachable/private servers are served by the Embedded or Standalone
+Surfaces, by design.
+
+## Consequences
+
+- Cross-repo dependency: `../reddb` must implement and ship the CORS allowlist
+  config. This ADR is a coordination contract with that repo.
+- No proxy/gateway to operate, scale, or pay for; data-plane traffic stays
+  browser↔server (lowest latency, our infra not in the hot path).
+- Each server opts in to which UI origins may call it — security stays with the
+  data-plane operator rather than being implicitly granted by a shared proxy.
+- "Connect to any DB from the hosted UI" is **not** universally true and we must
+  say so in-product: private targets surface an EmptyState pointing the user to
+  `red ui` / the Standalone app instead of failing opaquely.
+- Tokens/credentials travel from the browser to the server directly, so the
+  session-handoff design (ADR-0004) must assume a browser-held credential.
+
+## Alternatives considered
+
+- **Central gateway/proxy at reddb.io.** Sidesteps CORS and hides servers from
+  the browser, but cannot reach private targets either, adds latency and an
+  always-on service we must run, and routes all customer data through our infra.
+  Rejected for the direct-reach default; may return narrowly for specific
+  managed scenarios later.
+- **Edge proxy co-hosted with the static bundle** (`ui.reddb.io/_red`). Recreates
+  the Vite proxy in production, but defeats the point of a static host and still
+  funnels all traffic through one origin. Rejected.
+- **Same-origin only** (UI served by each reddb server). Removes CORS entirely
+  but kills the single canonical `ui.reddb.io` zero-install experience. Retained
+  only as the Embedded Surface's mechanism, not for the Web Surface.

--- a/.red/adr/0003-bundle-delivery-versioned-tarball-embedded-in-red.md
+++ b/.red/adr/0003-bundle-delivery-versioned-tarball-embedded-in-red.md
@@ -1,0 +1,64 @@
+# 0003. Deliver the UI bundle as a versioned release tarball, embedded into `red`
+
+## Status
+
+Proposed
+
+Date: 2026-05-29
+
+## Context
+
+One static bundle (ADR-0001) is consumed by three independent builds:
+
+- **`../reddb`** (Rust) must embed the bundle so `red ui <file>` can serve it
+  same-origin and offline. reddb embeds no static assets today.
+- **`apps/desktop`** (Tauri) packages the bundle into the desktop app.
+- **`ui.reddb.io`** (static host) deploys the bundle.
+
+The release workflow already builds `packages/ui/build` and uploads it as the
+`ui-bundle` artifact, with a placeholder job noting that publishing to the static
+host and producing "the tarball consumed by reddb's build.rs" will be wired
+"once rio-infra exposes the deploy target + credentials". reddb's CI is a Rust
+toolchain; pulling the SvelteKit/pnpm toolchain into it to build the UI in-place
+would be a significant burden and coupling.
+
+## Decision
+
+We will publish the built bundle as a **versioned release tarball**
+(`red-ui-<version>.tar.gz`) from red-ui's CI on tag. Each consumer pins a version
+and pulls the **same** artifact:
+
+- reddb's `build.rs` downloads the pinned tarball and embeds it via
+  `rust-embed` / `include_dir!`.
+- the Tauri build consumes it as its frontend dist.
+- the `ui.reddb.io` deploy publishes it to the static host.
+
+The tarball — not a git submodule, not an npm dependency — is the cross-repo
+interface.
+
+## Consequences
+
+- reddb's Rust CI never needs Node/pnpm/Vite; it depends only on a versioned
+  artifact URL + checksum. Loosest possible coupling.
+- A single immutable artifact guarantees all three Surfaces ship byte-identical
+  UI for a given version — no "works in Tauri, broken embedded" skew within a
+  release.
+- Version pinning makes UI↔server API skew explicit and reviewable: bumping the
+  embedded UI in reddb is a deliberate dependency bump, not an implicit retag.
+- We must run a real release pipeline (versioning, checksums, retention) and the
+  embed step adds the bundle's weight (~MBs) to the `red` binary.
+- The deploy/publish half is blocked until rio-infra exposes a static-host
+  target + credentials (tracked separately).
+
+## Alternatives considered
+
+- **Git submodule / vendored source.** reddb would build the UI itself, dragging
+  the entire SvelteKit/pnpm toolchain into a Rust CI and coupling build graphs.
+  Rejected.
+- **Published npm package of built assets.** Natural for the pnpm workspace and
+  for Tauri, but forces an npm fetch into reddb's Rust build and ties reddb to a
+  registry. A plain tarball + checksum is toolchain-neutral. Rejected for the
+  Rust consumer; npm may still back the JS-side consumers internally.
+- **Each consumer rebuilds from source at its own pin.** Maximises flexibility,
+  destroys the "byte-identical across Surfaces" guarantee and multiplies build
+  cost. Rejected.

--- a/.red/adr/0004-session-handoff-short-lived-token.md
+++ b/.red/adr/0004-session-handoff-short-lived-token.md
@@ -1,0 +1,66 @@
+# 0004. Session handoff via a short-lived, target-scoped OIDC/JWKS token
+
+## Status
+
+Proposed
+
+Date: 2026-05-29
+
+## Context
+
+From the reddb.io control plane a user clicks "open", and we offer **both**
+"open in app" (the native `red://open?…` deep-link into the Standalone Surface)
+and "open in browser" (`ui.reddb.io/?…`). The goal is to open red-ui *already
+connected* to the chosen server, reusing the user's reddb.io identity.
+
+The Web path can lean on the `Domain=.reddb.io` cookie when the target is a
+managed `*.reddb.io` server. The **native** path cannot: a freshly-launched
+Tauri app holds no browser cookie, so the session must cross the app boundary
+explicitly. Putting a durable credential in a URL or process argv would leak a
+long-lived secret into shell history, logs, and referrers.
+
+This also interacts with ADR-0002: because the browser talks to the server
+directly, whatever proves identity must be presentable by the client and
+verifiable by the target server itself.
+
+## Decision
+
+We will have **reddb.io mint a short-lived, single-use, target-scoped token**
+for the handoff, carried in the Open Contract (`token`, in the URL `#hash` on the
+Web path so it never reaches a server log or referrer). The target server
+verifies it against reddb.io's published **JWKS**:
+
+- The **managed fleet** trusts reddb.io's issuer by default — handoff "just
+  works" for bought databases.
+- **BYO servers** can opt in by registering reddb.io as a trusted OIDC/JWKS
+  issuer on their own server.
+
+Targets that don't trust reddb.io (plain localhost, un-registered BYO) fall back
+to that server's own authentication in red-ui.
+
+## Consequences
+
+- Cross-repo dependencies: reddb.io needs a token-minting endpoint; `../reddb`
+  needs JWKS-issuer verification. Both are coordination contracts.
+- The handoff survives the cross-app jump (cookies can't) and the short TTL +
+  single-use property bounds replay risk.
+- reddb.io stays the single identity authority; servers verify offline via JWKS
+  with no callback to reddb.io in the data path (consistent with no-gateway,
+  ADR-0002).
+- The "already connected" magic is **scoped**: automatic only where the target
+  trusts reddb.io. We must make the manual-auth fallback for other targets a
+  first-class, non-surprising path in the UI.
+- Token-in-`#hash` and single-use semantics must be implemented carefully
+  (consume-on-read, never persist, strip from history).
+
+## Alternatives considered
+
+- **Raw reddb.io session/credential in the deep-link.** Simplest, but leaks a
+  durable secret via argv/URL/referrer. Rejected.
+- **App performs its own OAuth login on launch.** Robust and standard, but
+  discards the click-time context — the user re-authenticates instead of landing
+  "already connected". Kept only as the fallback when no handoff token is
+  trusted.
+- **reddb.io gateway validates the token and forwards.** Removes per-server trust
+  config, but reintroduces the central proxy rejected in ADR-0002 and puts our
+  infra in the data path. Rejected.

--- a/.red/adr/0004-session-handoff-short-lived-token.md
+++ b/.red/adr/0004-session-handoff-short-lived-token.md
@@ -13,11 +13,14 @@ From the reddb.io control plane a user clicks "open", and we offer **both**
 and "open in browser" (`ui.reddb.io/?…`). The goal is to open red-ui *already
 connected* to the chosen server, reusing the user's reddb.io identity.
 
-The Web path can lean on the `Domain=.reddb.io` cookie when the target is a
-managed `*.reddb.io` server. The **native** path cannot: a freshly-launched
-Tauri app holds no browser cookie, so the session must cross the app boundary
-explicitly. Putting a durable credential in a URL or process argv would leak a
-long-lived secret into shell history, logs, and referrers.
+A naive design would let the Web path lean on the `Domain=.reddb.io` cookie to
+reach a managed server directly. We reject that (see Decision below): a
+`.reddb.io` cookie is broadcast to every subdomain — including arbitrary nested
+ones — so a cookie that grants *data-plane* access is a standing leak risk, and
+the native path can't use a browser cookie at all. The session must cross app
+and origin boundaries explicitly, and putting a durable credential in a URL or
+process argv would leak a long-lived secret into shell history, logs, and
+referrers.
 
 This also interacts with ADR-0002: because the browser talks to the server
 directly, whatever proves identity must be presentable by the client and
@@ -37,6 +40,13 @@ verifies it against reddb.io's published **JWKS**:
 
 Targets that don't trust reddb.io (plain localhost, un-registered BYO) fall back
 to that server's own authentication in red-ui.
+
+**The `.reddb.io` cookie authenticates the control plane only** — it proves
+reddb.io identity so the control plane can *mint* handoff tokens. It is never
+presented to a data-plane server. Server access is **always** via the
+short-lived token, uniformly for the Web and native paths. This removes any
+broadly-scoped, data-granting cookie, so a leak to an untrusted `*.reddb.io`
+subdomain cannot grant database access.
 
 ## Consequences
 

--- a/.red/adr/0005-host-ui-reddb-io-on-cloudflare-pages.md
+++ b/.red/adr/0005-host-ui-reddb-io-on-cloudflare-pages.md
@@ -1,0 +1,60 @@
+# 0005. Host `ui.reddb.io` on Cloudflare Pages, DNS managed by rio-infra
+
+## Status
+
+Proposed
+
+Date: 2026-05-29
+
+## Context
+
+The Web Surface (ADR-0001) needs a canonical static host at `ui.reddb.io`. Two
+facts shape the choice:
+
+- **rio-infra** (`rdb-infra`) is a Terragrunt + **Cloudflare** stack: it owns the
+  `reddb.io` Cloudflare zone and every DNS record (`www`, `app.reddb.io`, …),
+  plus R2 buckets and Turnstile. CI has `CLOUDFLARE_API_TOKEN` /
+  `CLOUDFLARE_ACCOUNT_ID`. There is **no `ui.reddb.io` record today**.
+- **red-ui's** `release.yml` already builds the embeddable bundle (`BASE_PATH=''`)
+  and ships `red-ui-<tag>-web.zip`. Its `pwa-pages` (GitHub Pages) job is stubbed
+  and disabled; a placeholder notes the static-host publish is blocked "once
+  rio-infra exposes the deploy target + credentials".
+
+The deploy target does not exist yet; this ADR picks it.
+
+## Decision
+
+Host `ui.reddb.io` on **Cloudflare Pages**. red-ui's release workflow deploys the
+built bundle to a Cloudflare Pages project; **rio-infra** owns the `ui.reddb.io`
+DNS/custom-domain binding in the `reddb.io` zone (Terragrunt), consistent with how
+every other reddb.io record is managed.
+
+## Consequences
+
+- Hosting stays native to the rio-infra Cloudflare stack: same provider, same
+  account, CDN + SPA fallback + preview deploys out of the box, one zone of
+  truth for DNS.
+- Cross-repo wiring required:
+  - **red-ui**: add a Pages deploy step (e.g. `cloudflare/wrangler-action`) to
+    `release.yml`; needs a scoped Cloudflare API token + account id as repo
+    secrets. The bundle must be built with the **root** `BASE_PATH=''` for a
+    dedicated host (the `/red-ui` subpath build is GitHub-Pages-specific and is
+    no longer the target).
+  - **rio-infra**: add the `ui.reddb.io` DNS record / Pages custom-domain binding
+    in the `reddb.io` zone via Terragrunt.
+- The disabled `pwa-pages` GitHub Pages job in `release.yml` is superseded and
+  should be removed to avoid two competing hosts.
+- CORS allowlists on reddb servers (ADR-0002) must include the final
+  `ui.reddb.io` origin, and the `.reddb.io` cookie scope (ADR-0004) must account
+  for `ui.reddb.io` being a sibling of `app.reddb.io`.
+
+## Alternatives considered
+
+- **R2 bucket + Cloudflare (public bucket / Worker).** Reuses existing R2 modules
+  and credentials, but SPA routing, cache headers, and the fallback-to-index
+  behaviour must be hand-built (Worker or redirect rules). More moving parts than
+  Pages for a SPA. Rejected as the default.
+- **GitHub Pages + CNAME.** Finishes the already-stubbed `pwa-pages` job with the
+  least Cloudflare-side work, but fragments hosting off the primary provider,
+  splits TLS/CDN/observability away from the zone rio-infra manages, and keeps
+  the `/red-ui` subpath quirk. Rejected.

--- a/.red/adr/0006-capability-negotiation-over-lockstep.md
+++ b/.red/adr/0006-capability-negotiation-over-lockstep.md
@@ -1,0 +1,50 @@
+# 0006. One UI version serves many server versions via capability negotiation
+
+## Status
+
+Proposed
+
+Date: 2026-05-29
+
+## Context
+
+The UI bundle is pinned and embedded into `red` (ADR-0003), shipped in the Tauri
+app, and deployed at `ui.reddb.io` (ADR-0005). In practice all three open
+servers of *varying* versions: a user runs several clusters at different reddb
+versions, `red ui` may point at a remote server, and `ui.reddb.io` connects to
+anything browser-reachable. So the embedded/hosted UI will routinely be older or
+newer than the server it talks to.
+
+`client.ts` already has the seed of a runtime strategy: it probes the
+`GET /collections/:name` route and, on "route not found", disables the
+collection-metadata feature for that server instead of erroring the whole UI.
+
+## Decision
+
+The UI negotiates **capabilities at runtime** and degrades gracefully. At
+Bootstrap it reads the target's version/capabilities (`/stats` carries a version;
+a `capabilities` surface generalises the existing probe) and **hides** controls
+the server can't honour — not greys them out. This mirrors the project's
+permission-aware rule ("if denied, the control is absent, not disabled"). One UI
+version therefore supports a range of server versions.
+
+## Consequences
+
+- The unsupported-route probe in `client.ts` generalises into a capability map
+  consulted by the UI when deciding which controls to render.
+- Cross-repo: `../reddb` should expose a stable version/capabilities surface so
+  negotiation is explicit rather than inferred from 404s.
+- "Absent, not disabled" keeps the UI honest across versions and reuses an
+  existing design principle, so older servers simply show fewer controls.
+- We accept that a newer UI may reference capabilities an old server lacks; the
+  negotiation must fail safe (hide) rather than assume presence.
+
+## Alternatives considered
+
+- **Lockstep** (UI talks only to its exact version). Simple, but breaks the
+  multi-cluster reality and `red ui` against a differently-versioned remote.
+  Rejected.
+- **Hosted UI as sole source of truth** (`red ui --remote` always pulls the
+  newest UI). Removes skew for the remote case, but adds a network dependency to
+  a flow deliberately offline (ADR-0001/Embedded) and doesn't help the embedded
+  or Tauri builds. Rejected as the general answer.

--- a/.red/adr/0007-red-ui-access-mode-lock-aware.md
+++ b/.red/adr/0007-red-ui-access-mode-lock-aware.md
@@ -1,0 +1,48 @@
+# 0007. `red ui <file>` is lock-aware: read-only when the file is in use
+
+## Status
+
+Proposed
+
+Date: 2026-05-29
+
+## Context
+
+The triggering use case for the Embedded Surface is *viewing a memory `.rdb`
+that an agent is actively writing* (the red-skills memory store). reddb's file
+backing is single-writer; a second read-write opener would contend for the lock.
+`red server` already supports `--read-only`, but whether a read-only opener can
+attach to a file that an active writer holds is a `../reddb` capability that must
+be confirmed.
+
+Defaulting `red ui <file>` to read-write (sqlite3-like) is the friendliest
+ergonomic when the file is free, but unsafe/contending when it isn't.
+
+## Decision
+
+`red ui <file>` is **lock-aware**:
+
+- If the file is already open by another process, it opens **read-only** and the
+  UI shows a visible "read-only — file in use" badge.
+- Otherwise it opens read-write.
+- `--read-only` / `--write` override the auto-detection explicitly.
+
+## Consequences
+
+- The common "watch my agent's live memory" case works without fighting the
+  writer, and the read-only state is surfaced, not silent.
+- Cross-repo dependency: `../reddb` must support **concurrent read-only open
+  alongside an active writer** (the `--read-only` flag exists; concurrent-with-
+  writer is the open question). If reddb cannot, the fallback degrades to "file
+  busy — try again" rather than read-only.
+- The UI needs a first-class read-only mode anyway (it pairs with ADR-0006's
+  capability hiding and the Web Surface's read-only-on-untrusted cases).
+
+## Alternatives considered
+
+- **Read-write by default, `--read-only` opt-in.** sqlite3-like, but risks
+  lock contention exactly in the motivating live-memory case. Rejected as the
+  default.
+- **Read-only by default, `--write` opt-in.** Safe, but makes the common
+  "open my own db and edit it" case require a flag. Rejected — auto-detection
+  gives both behaviours without a mode the user must remember.


### PR DESCRIPTION
## What

Records the red-ui distribution architecture decided in a `/start` grilling session, and wires the first piece of CI for it.

- **7 ADRs** (`.red/adr/0001–0007`) — one bundle + multi-source Connection Bootstrap; three Surfaces (Embedded `red ui`, Standalone Tauri, Web `ui.reddb.io`); Web reach via per-server CORS allowlist; bundle as a versioned tarball embedded in `red`; session handoff via short-lived OIDC/JWKS token with the `.reddb.io` cookie scoped to control-plane only; capability negotiation over lockstep; lock-aware `red ui` access mode.
- **Glossary** (`.red/CONTEXT.md`) — Connection Bootstrap, Surface, cs, Open Contract, Session Handoff Token, Capability negotiation.
- **CI** (`release.yml`) — deploy the Web Surface to Cloudflare Pages at `ui.reddb.io` (ADR-0005). Builds with `BASE_PATH=''`; the deploy step self-skips when `CLOUDFLARE_*` secrets are absent, so forks/PRs don't fail. Replaces the disabled GitHub Pages stub.

## Why

The triggering need: view an agent's memory (`../red-skills`, a file-backed reddb) "like sqlite", and more generally serve one red-ui across local/standalone/web without a master-password wall where there's no secret. See PRD #19.

## Follow-up

PRD #19 is sliced into #20–#27. This PR is docs + CI only — no app code. The `ui.reddb.io` DNS binding and `CLOUDFLARE_*` secrets are tracked in #24 (and `../rio-infra`).

Refs #19

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782689773&installation_id=129708444&pr_number=28&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F28&signature=f73dc980a2854c93207ed3859008d2afb083ec818689030ced5eb7daa9c697a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->