### PR TITLE
feat(protocol): Open Contract — ?cs= opens red-ui at a target (#20)

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -1,24 +1,19 @@
+# .red/config.yaml — per-project plugin settings (consumed by /afk and friends)
+# Uncomment any line to override the default.
+
 afk:
-  runner: claude
   hooks:
-    # red-ui is a pnpm workspace; a fresh git worktree has no node_modules
-    # (pnpm keeps them at the workspace root with symlinks the worktree can't
-    # inherit). Without deps the worktree can't run vitest/vite, the inner
-    # agent flees to the primary checkout, and feedback gates false-fail.
-    # Installing into the worktree before the runner boots keeps the agent
-    # working in isolation and makes the feedback loop valid.
+    # red-ui is a pnpm workspace; node_modules live at the workspace root and a
+    # fresh git worktree can't inherit the symlinks. Without deps the AFK inner
+    # agent can't run vitest/vite in its worktree, so it migrates to the primary
+    # checkout (committing to main) and the feedback loop false-fails with
+    # "vitest: not found". Installing into the worktree before the runner boots
+    # keeps the agent isolated and makes the feedback gates valid.
     pre_worker: "cd \"$RED_AFK_WORKSPACE\" && pnpm install --frozen-lockfile"
-
-reddb:
-  url: http://localhost:5055
-  token: ${RED_DB_TOKEN}
-
-editor:
-  cdn: true
-
-memory:
-  enabled: false
-
-reddb_DISABLED_BENCH:
-  url: http://localhost:5055
-  token: ${RED_DB_TOKEN}
+#   default_runner: claude        # fallback runner when no explicit signal
+#   fleet:
+#     target: 2                   # default supervisor worker target
+#   hooks:
+#     defaults:
+#       cargo: true               # ship cargo isolation on Rust projects
+#       gradle: true              # ship gradle isolation when GRADLE_USER_HOME_BASE is set

--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -1,11 +1,24 @@
-# .red/config.yaml — per-project plugin settings (consumed by /afk and friends)
-# Uncomment any line to override the default.
+afk:
+  runner: claude
+  hooks:
+    # red-ui is a pnpm workspace; a fresh git worktree has no node_modules
+    # (pnpm keeps them at the workspace root with symlinks the worktree can't
+    # inherit). Without deps the worktree can't run vitest/vite, the inner
+    # agent flees to the primary checkout, and feedback gates false-fail.
+    # Installing into the worktree before the runner boots keeps the agent
+    # working in isolation and makes the feedback loop valid.
+    pre_worker: "cd \"$RED_AFK_WORKSPACE\" && pnpm install --frozen-lockfile"
 
-# afk:
-#   default_runner: claude        # fallback runner when no explicit signal
-#   fleet:
-#     target: 2                   # default supervisor worker target
-#   hooks:
-#     defaults:
-#       cargo: true               # ship cargo isolation on Rust projects
-#       gradle: true              # ship gradle isolation when GRADLE_USER_HOME_BASE is set
+reddb:
+  url: http://localhost:5055
+  token: ${RED_DB_TOKEN}
+
+editor:
+  cdn: true
+
+memory:
+  enabled: false
+
+reddb_DISABLED_BENCH:
+  url: http://localhost:5055
+  token: ${RED_DB_TOKEN}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,4 +1,5 @@
 export * from './uri'
+export * from './open-contract'
 export * from './types'
 export * from './client'
 export * from './connection-provider'

--- a/packages/protocol/src/open-contract.test.ts
+++ b/packages/protocol/src/open-contract.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest'
+import {
+  encodeOpenContract,
+  isBrowserReachableUrl,
+  isSafeRoute,
+  parseOpenContract,
+  type OpenContract,
+} from './open-contract'
+
+describe('isBrowserReachableUrl', () => {
+  it('accepts http and https URLs', () => {
+    expect(isBrowserReachableUrl('http://localhost:5055')).toBe(true)
+    expect(isBrowserReachableUrl('https://db.example.com')).toBe(true)
+  })
+
+  it('rejects filesystem paths and non-http schemes', () => {
+    expect(isBrowserReachableUrl('/var/run/reddb.sock')).toBe(false)
+    expect(isBrowserReachableUrl('./mydb.rdb')).toBe(false)
+    expect(isBrowserReachableUrl('../db.rdb')).toBe(false)
+    expect(isBrowserReachableUrl('~/db.rdb')).toBe(false)
+    expect(isBrowserReachableUrl('file:///Users/foo/db.rdb')).toBe(false)
+    expect(isBrowserReachableUrl('red://localhost')).toBe(false)
+    expect(isBrowserReachableUrl('not a url at all')).toBe(false)
+    expect(isBrowserReachableUrl('')).toBe(false)
+  })
+})
+
+describe('isSafeRoute', () => {
+  it('accepts absolute same-origin paths', () => {
+    expect(isSafeRoute('/')).toBe(true)
+    expect(isSafeRoute('/c/users')).toBe(true)
+    expect(isSafeRoute('/query?tab=2')).toBe(true)
+  })
+
+  it('rejects protocol-relative and external routes', () => {
+    expect(isSafeRoute('//evil.com')).toBe(false)
+    expect(isSafeRoute('/\\evil.com')).toBe(false)
+    expect(isSafeRoute('https://evil.com')).toBe(false)
+    expect(isSafeRoute('c/users')).toBe(false)
+    expect(isSafeRoute('')).toBe(false)
+  })
+})
+
+describe('encode/parse round-trips', () => {
+  const cases: OpenContract[] = [
+    {},
+    { cs: 'http://localhost:5055' },
+    { to: '/c/users' },
+    { token: 'eyJhbGciOi.payload.sig' },
+    { cs: 'https://db.example.com:8443', to: '/query', token: 'short-lived-123' },
+    { cs: 'http://localhost:5055', to: '/c/my%20coll' },
+  ]
+
+  for (const contract of cases) {
+    it(`round-trips ${JSON.stringify(contract)}`, () => {
+      const parts = encodeOpenContract(contract)
+      const { contract: parsed, warnings } = parseOpenContract(parts)
+      expect(warnings).toEqual([])
+      expect(parsed).toEqual(contract)
+    })
+  }
+
+  it('round-trips through a full URL string', () => {
+    const parts = encodeOpenContract({ cs: 'http://localhost:5055', to: '/cluster', token: 'abc' })
+    const full = `https://ui.reddb.io/${parts.search}${parts.hash}`
+    const { contract } = parseOpenContract(full)
+    expect(contract).toEqual({ cs: 'http://localhost:5055', to: '/cluster', token: 'abc' })
+  })
+})
+
+describe('parseOpenContract — sources', () => {
+  it('reads from a window.location-like object', () => {
+    const { contract } = parseOpenContract({
+      search: '?cs=http%3A%2F%2Flocalhost%3A5055&to=%2Fquery',
+      hash: '#token=abc',
+    })
+    expect(contract).toEqual({ cs: 'http://localhost:5055', to: '/query', token: 'abc' })
+  })
+
+  it('reads from a URL instance', () => {
+    const url = new URL('https://ui.reddb.io/?cs=http://localhost:5055#token=xyz')
+    const { contract } = parseOpenContract(url)
+    expect(contract.cs).toBe('http://localhost:5055')
+    expect(contract.token).toBe('xyz')
+  })
+
+  it('tolerates a bare search#hash tail string', () => {
+    const { contract } = parseOpenContract('?cs=http://localhost:5055#token=t')
+    expect(contract).toEqual({ cs: 'http://localhost:5055', token: 't' })
+  })
+})
+
+describe('token invariant — only the #hash carries it', () => {
+  it('encode never emits the token into the query string', () => {
+    const parts = encodeOpenContract({ cs: 'http://localhost:5055', token: 'secret' })
+    expect(parts.search).not.toContain('token')
+    expect(parts.search).not.toContain('secret')
+    expect(parts.hash).toContain('token=secret')
+  })
+
+  it('parse ignores a token supplied in the query string', () => {
+    const { contract, warnings } = parseOpenContract({
+      search: '?cs=http://localhost:5055&token=leaked',
+      hash: '',
+    })
+    expect(contract.token).toBeUndefined()
+    expect(warnings.some((w) => w.includes('token present in query string'))).toBe(true)
+  })
+
+  it('parse honours a token only when it is in the hash', () => {
+    const { contract } = parseOpenContract({ search: '', hash: '#token=good' })
+    expect(contract.token).toBe('good')
+  })
+
+  it('a query token does not override or mix with the hash token', () => {
+    const { contract } = parseOpenContract({
+      search: '?token=leaked',
+      hash: '#token=real',
+    })
+    expect(contract.token).toBe('real')
+  })
+})
+
+describe('no-path invariant — cs must be a browser-reachable URL', () => {
+  it('rejects a filesystem-path cs and warns', () => {
+    const { contract, warnings } = parseOpenContract({
+      search: '?cs=' + encodeURIComponent('/Users/me/mydb.rdb'),
+      hash: '',
+    })
+    expect(contract.cs).toBeUndefined()
+    expect(warnings.some((w) => w.includes('cs is not a browser-reachable'))).toBe(true)
+  })
+
+  it('rejects a relative-path cs', () => {
+    const { contract } = parseOpenContract({
+      search: '?cs=' + encodeURIComponent('./mydb.rdb'),
+      hash: '',
+    })
+    expect(contract.cs).toBeUndefined()
+  })
+
+  it('rejects a file:// cs', () => {
+    const { contract } = parseOpenContract({
+      search: '?cs=' + encodeURIComponent('file:///var/db.rdb'),
+      hash: '',
+    })
+    expect(contract.cs).toBeUndefined()
+  })
+
+  it('encode throws on a non-reachable cs', () => {
+    expect(() => encodeOpenContract({ cs: '/var/db.rdb' })).toThrow()
+    expect(() => encodeOpenContract({ cs: 'file:///db.rdb' })).toThrow()
+  })
+})
+
+describe('malformed / partial input is tolerated', () => {
+  it('empty location yields an empty contract and no warnings', () => {
+    const { contract, warnings } = parseOpenContract({ search: '', hash: '' })
+    expect(contract).toEqual({})
+    expect(warnings).toEqual([])
+  })
+
+  it('garbage query string yields an empty contract', () => {
+    const { contract } = parseOpenContract({ search: '?=&=&&%%%', hash: '' })
+    expect(contract).toEqual({})
+  })
+
+  it('drops an unsafe to but keeps a valid cs', () => {
+    const { contract, warnings } = parseOpenContract({
+      search: '?cs=http://localhost:5055&to=' + encodeURIComponent('//evil.com'),
+      hash: '',
+    })
+    expect(contract.cs).toBe('http://localhost:5055')
+    expect(contract.to).toBeUndefined()
+    expect(warnings.some((w) => w.includes('to must be a same-origin path'))).toBe(true)
+  })
+
+  it('an empty hash token is treated as absent', () => {
+    const { contract } = parseOpenContract({ search: '', hash: '#token=' })
+    expect(contract.token).toBeUndefined()
+  })
+})

--- a/packages/protocol/src/open-contract.ts
+++ b/packages/protocol/src/open-contract.ts
@@ -1,0 +1,186 @@
+// The Open Contract — the URL shape that lets one red-ui bundle be opened
+// against a specific target from outside (the reddb.io "open" button, a
+// `red://open?…` deep-link, a hand-built `ui.reddb.io/?cs=…` link).
+//
+// Three fields, three different transports, chosen for security:
+//   - `cs`  (query)  the target server URL. ALWAYS a browser-reachable
+//                    http(s) URL, NEVER a filesystem path — a hosted page
+//                    cannot open a file, and `?cs=/etc/passwd`-style input
+//                    is rejected rather than silently mishandled.
+//   - `to`  (query)  the initial route to land on (e.g. `/c/users`). A
+//                    same-origin path only, so it can never become an open
+//                    redirect to another origin.
+//   - `token` (#hash) the short-lived session-handoff token. Carried ONLY
+//                    in the URL fragment so it never reaches a server log,
+//                    a `Referer` header, or the query string. The fragment
+//                    stays client-side; the caller consumes the token and
+//                    must never persist it.
+//
+// This module is the single encode/parse seam shared by every producer and
+// consumer of those links. It is pure (no DOM, no network) so it round-trips
+// under test and runs the same in the browser, Tauri, and Node.
+
+export interface OpenContract {
+  /** Target server URL — a browser-reachable http(s) URL, never a file path. */
+  cs?: string
+  /** Short-lived handoff token. Lives only in the #hash; never persist it. */
+  token?: string
+  /** Initial route to land on, e.g. `/c/users`. Same-origin path only. */
+  to?: string
+}
+
+/** The two URL pieces the contract is split across. */
+export interface OpenContractUrlParts {
+  /** Query string, including a leading `?` (empty when there is no query). */
+  search: string
+  /** Fragment, including a leading `#` (empty when there is no fragment). */
+  hash: string
+}
+
+export interface OpenContractParse {
+  contract: OpenContract
+  /** Non-fatal issues: fields that were present but dropped, with the reason. */
+  warnings: string[]
+}
+
+/** Anything we can pull a `search` + `hash` out of. */
+export type OpenContractSource =
+  | OpenContractUrlParts
+  | URL
+  | Location
+  | string
+
+/**
+ * True when `value` is a URL the browser can actually fetch — an absolute
+ * http: or https: URL. This is the gate that rejects filesystem paths
+ * (`/var/db.rdb`, `./mydb.rdb`, `C:\db`), `file://` URLs, and any other
+ * non-reachable scheme: they either fail to parse as an absolute URL or
+ * carry a non-http(s) protocol.
+ */
+export function isBrowserReachableUrl(value: string): boolean {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    return false
+  }
+  return url.protocol === 'http:' || url.protocol === 'https:'
+}
+
+/**
+ * True when `to` is a safe same-origin route: an absolute path beginning
+ * with a single `/`. Rejects protocol-relative (`//evil.com`) and
+ * backslash-smuggled (`/\evil.com`) forms that browsers can treat as a
+ * cross-origin redirect.
+ */
+export function isSafeRoute(to: string): boolean {
+  if (!to.startsWith('/')) return false
+  // Second char `/` or `\` turns it into a protocol-relative / external URL.
+  if (to.length >= 2 && (to[1] === '/' || to[1] === '\\')) return false
+  return true
+}
+
+function stripLeading(s: string, ch: string): string {
+  return s.startsWith(ch) ? s.slice(1) : s
+}
+
+function toParts(source: OpenContractSource): OpenContractUrlParts {
+  if (typeof source === 'string') {
+    // A full URL parses cleanly; otherwise treat the string as a raw
+    // `search#hash` (or `?search#hash`) tail.
+    try {
+      const u = new URL(source)
+      return { search: u.search, hash: u.hash }
+    } catch {
+      const hashIdx = source.indexOf('#')
+      if (hashIdx >= 0) {
+        return { search: source.slice(0, hashIdx), hash: source.slice(hashIdx) }
+      }
+      return { search: source, hash: '' }
+    }
+  }
+  // URL, Location, or an OpenContractUrlParts literal all expose search/hash.
+  return { search: source.search ?? '', hash: source.hash ?? '' }
+}
+
+/**
+ * Parse an Open Contract out of a location's query + fragment.
+ *
+ * Tolerant by design: a malformed or disallowed field is dropped (never
+ * throws) and the reason is recorded in `warnings`, so a bad link still
+ * boots the app instead of crashing it. The two security invariants are
+ * enforced here:
+ *   - a `token` in the QUERY string is ignored (tokens travel only in #hash);
+ *   - a `cs` that is not a browser-reachable http(s) URL is rejected.
+ */
+export function parseOpenContract(source: OpenContractSource): OpenContractParse {
+  const { search, hash } = toParts(source)
+  const warnings: string[] = []
+  const query = new URLSearchParams(stripLeading(search, '?'))
+  const fragment = new URLSearchParams(stripLeading(hash, '#'))
+  const contract: OpenContract = {}
+
+  const cs = query.get('cs')
+  if (cs !== null) {
+    if (isBrowserReachableUrl(cs)) {
+      contract.cs = cs
+    } else {
+      warnings.push(`cs is not a browser-reachable http(s) URL; rejected: ${cs}`)
+    }
+  }
+
+  const to = query.get('to')
+  if (to !== null) {
+    if (isSafeRoute(to)) {
+      contract.to = to
+    } else {
+      warnings.push(`to must be a same-origin path beginning with '/'; rejected: ${to}`)
+    }
+  }
+
+  // The token invariant: never honour it from the query string.
+  if (query.has('token')) {
+    warnings.push('token present in query string; ignored (tokens travel only in the #hash)')
+  }
+  const token = fragment.get('token')
+  if (token) contract.token = token
+
+  return { contract, warnings }
+}
+
+/**
+ * Encode an Open Contract into URL parts. The inverse of {@link parseOpenContract}
+ * for any valid contract.
+ *
+ * Unlike parsing, encoding is STRICT: a producer passing an invalid `cs` or
+ * `to` is a programming error, so it throws rather than silently dropping the
+ * field. The token is emitted ONLY into the fragment — it is structurally
+ * impossible for `encodeOpenContract` to leak a token into the query string.
+ */
+export function encodeOpenContract(contract: OpenContract): OpenContractUrlParts {
+  const query = new URLSearchParams()
+
+  if (contract.cs != null) {
+    if (!isBrowserReachableUrl(contract.cs)) {
+      throw new Error(`cs must be a browser-reachable http(s) URL: ${contract.cs}`)
+    }
+    query.set('cs', contract.cs)
+  }
+
+  if (contract.to != null) {
+    if (!isSafeRoute(contract.to)) {
+      throw new Error(`to must be a same-origin path beginning with '/': ${contract.to}`)
+    }
+    query.set('to', contract.to)
+  }
+
+  const fragment = new URLSearchParams()
+  if (contract.token) fragment.set('token', contract.token)
+
+  const q = query.toString()
+  const f = fragment.toString()
+  return {
+    search: q ? `?${q}` : '',
+    hash: f ? `#${f}` : '',
+  }
+}

--- a/packages/ui/src/routes/+layout.svelte
+++ b/packages/ui/src/routes/+layout.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import '../app.css'
   import { onMount } from 'svelte'
+  import { goto } from '$app/navigation'
+  import { base } from '$app/paths'
+  import { parseOpenContract } from '@red-ui/protocol'
   import Splash from '$lib/Splash.svelte'
   import Topbar from '$lib/Topbar.svelte'
   import StatusBar from '$lib/StatusBar.svelte'
@@ -8,7 +11,7 @@
   import ShortcutOverlay from '$lib/ShortcutOverlay.svelte'
   import MasterPasswordDialog from '$lib/MasterPasswordDialog.svelte'
   import PendingChangesPanel from '$lib/PendingChangesPanel.svelte'
-  import { connection } from '$lib/connections.svelte'
+  import { connection, makeCustomConnection } from '$lib/connections.svelte'
   import { theme } from '$lib/theme.svelte'
   import { secureStore } from '$lib/secureStore.svelte'
   import { pendingChanges, buildUpdateSql, type CommitOutcome } from '$lib/pending-changes.svelte'
@@ -22,6 +25,34 @@
     const handler = () => (pendingOpen = true)
     window.addEventListener('red:open-pending-changes', handler as EventListener)
     return () => window.removeEventListener('red:open-pending-changes', handler as EventListener)
+  })
+
+  // Open Contract bootstrap (issue #20): when this bundle is opened with a
+  // target in the URL (`?cs=…`, optional `#token=…`, optional `?to=…`), boot
+  // straight against it instead of waiting for the user to pick a connection
+  // in the topbar. This is the URL source the broader Connection Bootstrap
+  // (#19) will later fold into its priority ladder.
+  onMount(() => {
+    const { contract } = parseOpenContract(window.location)
+    if (!contract.cs && !contract.to) return
+
+    // The token travels only in the #hash and is consume-on-read: strip it
+    // from the address bar so it never lingers in history and is never
+    // written to persistent storage. (No handoff consumer exists yet in this
+    // slice; reading + discarding satisfies the never-persist invariant.)
+    if (contract.token) {
+      const url = new URL(window.location.href)
+      url.hash = ''
+      history.replaceState(history.state, '', url.toString())
+    }
+
+    if (contract.cs) {
+      // Bypass the Connect screen by connecting directly to the target.
+      connection.tryConnect(makeCustomConnection(contract.cs))
+    }
+    if (contract.to) {
+      goto(`${base}${contract.to}`, { replaceState: true })
+    }
   })
 
   // Wire the commit executor to the active client. Re-binds whenever the


### PR DESCRIPTION
## What

Implements the **Open Contract** — the URL shape that opens red-ui against a target. Closes the first slice of PRD #19.

New module `packages/protocol/src/open-contract.ts`:
- `parseOpenContract(source)` — tolerant parser (object/URL/string), drops bad fields with `warnings` instead of throwing.
- `encodeOpenContract(contract)` — strict inverse; structurally cannot leak a token into the query string.
- `isBrowserReachableUrl` / `isSafeRoute` — the two security gates.

Invariants enforced (per ADR-0004):
- `cs` must be a browser-reachable http(s) URL — filesystem paths, `file://`, relative paths, non-http schemes rejected.
- `token` honoured only from the `#hash`; a query-string token is ignored + warned; encode emits it only into the fragment.
- `to` must be a same-origin path (no open-redirect via `//` or `/\`).

Boot wiring (`+layout.svelte`): `?cs=` connects directly (bypassing the Connect screen), `?to=` routes the initial view, the `#hash` token is consume-on-read (stripped from the URL, never persisted).

## Verification

- `pnpm --filter @red-ui/protocol test` → 71 passed (26 new)
- `pnpm --filter @red-ui/protocol check` → clean
- `pnpm --filter @red-ui/ui check` → 0 errors / 0 warnings

## Provenance note

Implemented by an `/afk` inner agent. Due to a worktree-isolation interaction (the agent worked in the primary checkout because the pnpm worktree lacked `node_modules`), the commits initially landed on local `main`; they were rescued onto this branch, unpushed-to-origin, and verified before opening this PR. See the issue thread for the AFK config fix that prevents recurrence.

Closes #20

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782700009&installation_id=129708444&pr_number=29&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F29&signature=f7de88c4cf996eecf3d80b6f7e2c2d09d132dd4ec2cdfa2ea0c447d558198825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->