### PR TITLE
feat(reddb): drop /_red proxy, connect to reddb directly via server CORS (#30)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Universal client for [reddb](https://github.com/reddb-io/reddb) — connects to 
 - **lucide-svelte** — iconography
 - **pnpm workspace** — `apps/desktop` (Tauri) + `packages/{ui,ui-kit,mcp}` under the `@reddb-io/*` scope
 
-The UI HTTP adapter lives in `packages/ui/src/lib/reddb`. In browser it goes through a Vite middleware proxy at `/_red` (carries `X-Red-Target`) because reddb sends no CORS headers.
+The UI HTTP adapter lives in `packages/ui/src/lib/reddb`. The browser client fetches the connected `baseUrl` directly — reddb (>=1.9.1) emits CORS headers, so no dev proxy is needed.
 
 ## Agent skills
 
@@ -104,7 +104,7 @@ docker compose -f docker/compose.yml up -d       # primary :15055, replica :2505
 ## Known constraints
 
 - Docker compose host ports are offset (15055/25055) because `flyctl proxy 5055:5055` may be running locally to tunnel into prod reddb. `red://localhost` in the Connect screen intentionally hits :5055 — that's the production tunnel.
-- The reddb HTTP API does not send CORS headers. All browser fetches go through the Vite `/_red` proxy via `X-Red-Target`. Tauri opts out via `new RedClient(url, { proxyPath: '' })` and uses Rust-side fetch.
+- reddb (>=1.9.1) emits `Access-Control-Allow-Origin: *` and answers preflight `OPTIONS` with 204, so browser fetches go straight to the connected `baseUrl` (no proxy). Tauri uses Rust-side fetch.
 - The `tenant` field name is reserved by reddb's collection schema. Use `tenant_id` or `tenant_slug`.
 - `/health` returns 503 with rich diagnostics under normal operation. Use `/stats` as the canonical proof-of-life.
-- The 1.3.0 image requires `RED_HTTP_TLS_DEV=1` to skip TLS auto-cert refusal in plain-HTTP mode.
+- The reddb image requires `RED_HTTP_TLS_DEV=1` to skip TLS auto-cert refusal in plain-HTTP mode.

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -13,7 +13,7 @@
 
 services:
   primary:
-    image: ghcr.io/reddb-io/reddb:1.3.0
+    image: ghcr.io/reddb-io/reddb:1.9.1
     container_name: red-ui-primary
     ports:
       - "15050:5050"
@@ -36,7 +36,7 @@ services:
       RED_HTTP_TLS_DEV: "1"
 
   replica:
-    image: ghcr.io/reddb-io/reddb:1.3.0
+    image: ghcr.io/reddb-io/reddb:1.9.1
     container_name: red-ui-replica
     ports:
       - "25050:5050"

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -67,7 +67,6 @@ export type {
   NodeStats,
   QueryResult,
   QueryRow,
-  RedClientOptions,
   ReplicationStatus,
   SseFactory,
   Stats,

--- a/packages/ui/src/lib/reddb/client.test.ts
+++ b/packages/ui/src/lib/reddb/client.test.ts
@@ -18,7 +18,7 @@ describe('RedClient collection metadata probing', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const client = new RedClient('http://reddb.test', { proxyPath: '' })
+    const client = new RedClient('http://reddb.test')
     const results = await Promise.allSettled([
       client.collection('characters'),
       client.collection('grimm_graph'),
@@ -45,7 +45,7 @@ describe('RedClient collection metadata probing', () => {
     })
     vi.stubGlobal('fetch', fetchMock)
 
-    const client = new RedClient('http://reddb.test', { proxyPath: '' })
+    const client = new RedClient('http://reddb.test')
 
     await expect(client.collectionVcs('products')).resolves.toEqual({ collection: 'products', versioned: true })
     await expect(client.commitDiff('a', 'b', { collection: 'products' })).resolves.toMatchObject({ added: 1 })
@@ -60,7 +60,7 @@ describe('RedClient collection metadata probing', () => {
     }))
     vi.stubGlobal('fetch', fetchMock)
 
-    const client = new RedClient('http://reddb.test', { proxyPath: '' })
+    const client = new RedClient('http://reddb.test')
     await expect(client.changes(7, { collection: 'b', limit: 10 })).resolves.toEqual([
       { lsn: 2, timestamp: 1, operation: 'update', collection: 'b', kind: 'table' },
     ])

--- a/packages/ui/src/lib/reddb/client.ts
+++ b/packages/ui/src/lib/reddb/client.ts
@@ -194,26 +194,6 @@ export interface VcsDiff {
   entries: VcsDiffEntry[]
 }
 
-export interface RedClientOptions {
-  /**
-   * When set, requests go through a same-origin proxy at this path
-   * instead of directly to baseUrl (needed because reddb doesn't send
-   * CORS headers). The proxy receives the target via X-Red-Target.
-   * Set to '/_red' in browser dev/prod; leave undefined in Tauri/Node
-   * where direct fetch works.
-   */
-  proxyPath?: string
-}
-
-function shouldProxy(opts?: RedClientOptions): string | null {
-  if (opts?.proxyPath) return opts.proxyPath
-  // Auto-detect: in a browser, fetch is subject to CORS. Use proxy by default
-  // unless caller explicitly opts out. In Tauri the user is expected to wire
-  // up Rust-side fetch and pass proxyPath: ''.
-  if (typeof window !== 'undefined') return '/_red'
-  return null
-}
-
 const unsupportedCollectionMetadata = new Set<string>()
 const collectionMetadataSupportProbe = new Map<string, Promise<boolean>>()
 
@@ -228,17 +208,14 @@ function unsupportedCollectionMetadataError(baseUrl: string): Error {
 
 export class RedClient {
   readonly baseUrl: string
-  private readonly proxyPath: string | null
 
-  constructor(baseUrl: string, opts?: RedClientOptions) {
+  constructor(baseUrl: string) {
     this.baseUrl = baseUrl.replace(/\/$/, '')
-    this.proxyPath = shouldProxy(opts)
   }
 
   private async json<T>(path: string, init?: RequestInit): Promise<T> {
-    const url = this.proxyPath ? `${this.proxyPath}${path}` : `${this.baseUrl}${path}`
+    const url = `${this.baseUrl}${path}`
     const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-    if (this.proxyPath) headers['X-Red-Target'] = this.baseUrl
     Object.assign(headers, init?.headers as Record<string, string> | undefined)
 
     const res = await fetch(url, { ...init, headers })

--- a/packages/ui/src/lib/reddb/local-url-provider.ts
+++ b/packages/ui/src/lib/reddb/local-url-provider.ts
@@ -3,7 +3,7 @@
 // browser usage backs history with localStorage; tests inject an
 // in-memory store via the options bag.
 
-import { RedClient, type RedClientOptions } from './client'
+import { RedClient } from './client'
 import {
   NotConnectedError,
   UnknownConnectionError,
@@ -33,8 +33,6 @@ export interface LocalUrlProviderOptions {
   history?: HistoryStore
   /** Hook for tests / Tauri to swap the HTTP client implementation. */
   clientFactory?: (url: string) => RedClient
-  /** Forwarded to the default client factory. Ignored if clientFactory is set. */
-  clientOptions?: RedClientOptions
   /** Max history entries retained. */
   historyMax?: number
 }
@@ -87,7 +85,7 @@ export class LocalUrlProvider implements ConnectionProvider {
     this.history = opts.history ?? inMemoryStore()
     this.historyMax = opts.historyMax ?? HISTORY_MAX_DEFAULT
     this.clientFactory =
-      opts.clientFactory ?? ((url) => new RedClient(url, opts.clientOptions))
+      opts.clientFactory ?? ((url) => new RedClient(url))
   }
 
   async list(): Promise<Connection[]> {

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -1,62 +1,9 @@
 import { sveltekit } from '@sveltejs/kit/vite'
 import tailwindcss from '@tailwindcss/vite'
-import { defineConfig, type Plugin } from 'vite'
-
-/**
- * reddb doesn't send CORS headers, so browser fetches against
- * http://localhost:5055 from http://localhost:1420 fail.
- * This middleware accepts /_red/* requests with an X-Red-Target
- * header naming the target base URL, and proxies the request to
- * that URL with the original method/body/auth headers.
- */
-function redProxy(): Plugin {
-  return {
-    name: 'red-proxy',
-    configureServer(server) {
-      server.middlewares.use('/_red', async (req, res) => {
-        const target = (req.headers['x-red-target'] as string | undefined)?.replace(/\/$/, '')
-        if (!target) {
-          res.statusCode = 400
-          res.setHeader('Content-Type', 'application/json')
-          res.end(JSON.stringify({ ok: false, error: 'missing X-Red-Target header' }))
-          return
-        }
-        const path = req.url ?? '/'
-        const upstream = target + path
-
-        const chunks: Buffer[] = []
-        req.on('data', (c) => chunks.push(c))
-        req.on('end', async () => {
-          const body = chunks.length ? Buffer.concat(chunks) : undefined
-          try {
-            const upstreamRes = await fetch(upstream, {
-              method: req.method,
-              headers: {
-                ...(req.headers['content-type'] ? { 'content-type': String(req.headers['content-type']) } : {}),
-                ...(req.headers['authorization'] ? { authorization: String(req.headers['authorization']) } : {}),
-              },
-              body: body && body.length ? body : undefined,
-            })
-            res.statusCode = upstreamRes.status
-            upstreamRes.headers.forEach((v, k) => {
-              if (k.toLowerCase().startsWith('access-control')) return
-              res.setHeader(k, v)
-            })
-            const buf = Buffer.from(await upstreamRes.arrayBuffer())
-            res.end(buf)
-          } catch (e) {
-            res.statusCode = 502
-            res.setHeader('Content-Type', 'application/json')
-            res.end(JSON.stringify({ ok: false, error: (e as Error).message }))
-          }
-        })
-      })
-    },
-  }
-}
+import { defineConfig } from 'vite'
 
 export default defineConfig({
-  plugins: [tailwindcss(), redProxy(), sveltekit()],
+  plugins: [tailwindcss(), sveltekit()],
   clearScreen: false,
   server: {
     port: 1420,


### PR DESCRIPTION
Closes #30.

## What

Salvages the already-complete work for #30. The browser Surfaces now fetch the connected `baseUrl` directly; reddb ≥1.9.1 emits `Access-Control-Allow-Origin: *` and answers preflight `OPTIONS` with 204, so the dev-only `/_red` Vite middleware is no longer needed.

Commit `b67d7d0` (−93/+14, 7 files): transport indirection (`proxyPath`/`X-Red-Target`) removed, `client.ts` fetches `${baseUrl}${path}` directly, vite `redProxy` middleware deleted, `docker/compose.yml` bumped to reddb 1.9.1, tests + CLAUDE.md updated. Tauri (Rust fetch) untouched.

## Why a manual PR

The work was produced by an AFK attempt and committed to this branch, but AFK never landed it: the attempt ended **without the DONE sentinel**, so the loop short-circuited to `blocked:crashed` and never merged the branch that already carried the commit. Root cause + fix tracked in **reddb-io/red-skills#332**.

## Validation (per inner-agent run, re-confirm in CI)

- `svelte-check`: 0 errors / 0 warnings
- `pnpm --filter @reddb-io/ui test`: 179 passed / 21 files (incl. `client.test.ts` direct-baseUrl, `local-url-provider.test.ts`)
- No `/_red` references remain in source.

> Not exercised here: the manual browser query against a live local Docker stack. The unit test mirrors the direct-`baseUrl` path; reviewer should sanity-check the running stack before/after merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782867509&installation_id=129708444&pr_number=38&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F38&signature=0bab08023d07382e9f5d8083f1b3e2a6e4bb1b5a68d75fbc5f6ef7818f0de4ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Upgraded backend database service to version 1.9.1 with improved CORS handling.
  * Simplified HTTP adapter configuration—direct `baseUrl` fetching now eliminates proxy requirements.
  * Updated environment setup guidance for TLS in plain-HTTP mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->