### PR TITLE
feat(ui): lock-aware read-only badge for the Embedded Surface (#23)

### DIFF
--- a/packages/ui/src/lib/PendingChangesPanel.svelte
+++ b/packages/ui/src/lib/PendingChangesPanel.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import { pendingChanges, buildUpdateSql } from './pending-changes.svelte'
-  import { X, AlertTriangle } from 'lucide-svelte'
+  import { connection } from './connections.svelte'
+  import { X, AlertTriangle, Lock } from 'lucide-svelte'
+
+  // Mutations are committed against the server; block them while it reports
+  // read-only (#23). The reason explains *why* the control is disabled.
+  const readOnly = $derived(connection.readOnly)
+  const readOnlyReason = $derived(connection.readOnlyReason)
 
   interface Props {
     open: boolean
@@ -109,6 +115,13 @@
         {/if}
       </div>
 
+      {#if readOnly}
+        <div class="flex items-center gap-1.5 px-4 py-2 text-warn text-[11px] font-mono border-t border-line-1 bg-warn/5">
+          <Lock class="size-3 shrink-0" />
+          <span>{readOnlyReason ?? 'Server is read-only (file in use) — changes can’t be applied.'}</span>
+        </div>
+      {/if}
+
       <div class="flex items-center justify-end gap-2 px-4 py-3 border-t border-line-1 bg-bg-1/60">
         <button
           type="button"
@@ -129,7 +142,8 @@
           type="button"
           class="text-[12px] font-mono px-3 py-1 bg-accent text-white rounded disabled:opacity-50"
           onclick={apply}
-          disabled={pendingChanges.count === 0 || committing}
+          disabled={pendingChanges.count === 0 || committing || readOnly}
+          title={readOnly ? (readOnlyReason ?? 'Server is read-only — mutations are disabled.') : undefined}
         >
           {committing ? 'Applying…' : 'Apply all'}
         </button>

--- a/packages/ui/src/lib/StatusBar.svelte
+++ b/packages/ui/src/lib/StatusBar.svelte
@@ -2,10 +2,14 @@
   import { useRouter } from './router.svelte'
   import { connection } from './connections.svelte'
   import { pendingChanges } from './pending-changes.svelte'
-  import { ArrowRight, FilePenLine } from 'lucide-svelte'
+  import { ArrowRight, FilePenLine, Lock } from 'lucide-svelte'
 
   const router = useRouter()
   const pendingCount = $derived(pendingChanges.count)
+
+  // Read-only badge (#23) — driven solely by the server's reported status.
+  const readOnly = $derived(connection.readOnly)
+  const readOnlyReason = $derived(connection.readOnlyReason)
 
   function openPending() {
     window.dispatchEvent(new CustomEvent('red:open-pending-changes'))
@@ -101,6 +105,17 @@
         <span class="text-fg-2">
           <span class="text-fg-3">lsn</span>
           <span class="text-fg-1 tabular-nums">{wal}</span>
+        </span>
+      {/if}
+
+      {#if readOnly}
+        <span class="text-fg-3">·</span>
+        <span
+          class="inline-flex items-center gap-1 shrink-0 text-warn"
+          title={readOnlyReason ?? 'The server is open read-only — mutations are disabled.'}
+        >
+          <Lock class="size-3" />
+          <span class="uppercase tracking-wider text-[10px]">read-only — file in use</span>
         </span>
       {/if}
     {:else}

--- a/packages/ui/src/lib/connections.svelte.ts
+++ b/packages/ui/src/lib/connections.svelte.ts
@@ -324,6 +324,21 @@ class ConnectionStore {
     return this.#client
   }
 
+  /**
+   * Read-only state derived from the server's reported `/stats` (#23). True
+   * only when the connected server reports `read_only` — never hardcoded. When
+   * the server reports no signal (the common case) this stays false and the UI
+   * behaves normally.
+   */
+  get readOnly(): boolean {
+    return this.connected && this.probe.stats?.read_only === true
+  }
+
+  /** Optional human-facing reason for the read-only badge tooltip. */
+  get readOnlyReason(): string | undefined {
+    return this.probe.stats?.read_only_reason
+  }
+
   async forget(url: string) {
     await historyStore.forgetByUrl(url)
   }

--- a/packages/ui/src/lib/connections.test.ts
+++ b/packages/ui/src/lib/connections.test.ts
@@ -9,11 +9,12 @@ import { InjectedClientProvider, LocalUrlProvider } from '#reddb'
 import type { RedClient } from '#reddb'
 
 // Fake client covering every method tryConnect touches (ping/stats/replication
-// on connect, whoami on demand). The host would inject a real one.
-function fakeClient(): RedClient {
+// on connect, whoami on demand). The host would inject a real one. `stats`
+// overrides let a test simulate the server's reported read-only flag (#23).
+function fakeClient(stats: Record<string, unknown> = {}): RedClient {
   return {
     ping: vi.fn(async () => ({ ok: true, rtt_ms: 3 })),
-    stats: vi.fn(async () => ({ collections: 0, records: 0 })),
+    stats: vi.fn(async () => ({ collections: 0, records: 0, ...stats })),
     replication: vi.fn(async () => undefined),
     whoami: vi.fn(async () => ({ authenticated: true, username: 'host', role: 'admin' })),
   } as unknown as RedClient
@@ -53,5 +54,33 @@ describe('connection seam (ADR-0001)', () => {
 
     connection.disconnect()
     expect(connection.client).toBeNull() // no URL-built fallback
+  })
+})
+
+describe('read-only state (#23)', () => {
+  it('is false when the server reports no read-only signal', async () => {
+    setConnectionProvider(new InjectedClientProvider({ client: fakeClient() }))
+    await connection.adoptInjected()
+    expect(connection.connected).toBe(true)
+    expect(connection.readOnly).toBe(false)
+  })
+
+  it('is true, with the reason, when the server reports read_only', async () => {
+    setConnectionProvider(
+      new InjectedClientProvider({
+        client: fakeClient({ read_only: true, read_only_reason: 'file in use by another writer' }),
+      }),
+    )
+    await connection.adoptInjected()
+    expect(connection.readOnly).toBe(true)
+    expect(connection.readOnlyReason).toBe('file in use by another writer')
+  })
+
+  it('is false once disconnected even if the last probe was read-only', async () => {
+    setConnectionProvider(new InjectedClientProvider({ client: fakeClient({ read_only: true }) }))
+    await connection.adoptInjected()
+    expect(connection.readOnly).toBe(true)
+    connection.disconnect()
+    expect(connection.readOnly).toBe(false) // gated on `connected`, never hardcoded
   })
 })

--- a/packages/ui/src/lib/reddb/client.ts
+++ b/packages/ui/src/lib/reddb/client.ts
@@ -48,6 +48,15 @@ export interface Stats {
   store: { collection_count: number; cross_ref_count: number; total_entities: number; total_memory_bytes: number }
   system: { arch: string; cpu_cores: number; hostname: string; os: string; pid: number; total_memory_bytes: number; available_memory_bytes: number }
   kv?: { gets: number; puts: number; deletes: number; cas_success: number; cas_conflict: number }
+  /**
+   * Set by the server when the store is open read-only — e.g. an embedded file
+   * already held by an active writer (lock detection is owned by reddb). Absent
+   * when the server reports no read-only signal, in which case the UI shows no
+   * badge and behaves normally (#23). `read_only_reason` is an optional
+   * human-facing explanation for the badge tooltip.
+   */
+  read_only?: boolean
+  read_only_reason?: string
 }
 
 export interface ClusterStatus {

--- a/packages/ui/src/lib/renderers/TableRenderer.svelte
+++ b/packages/ui/src/lib/renderers/TableRenderer.svelte
@@ -134,7 +134,9 @@
   let editValue = $state('')
 
   function startEdit(row: number, col: string, value: unknown) {
-    if (editing || !collection) return
+    // Read-only server (#23): cells aren't editable — the mutation entry point
+    // is absent rather than letting a doomed edit stage and fail at commit.
+    if (editing || !collection || connection.readOnly) return
     editing = { row, col }
     const staged = pendingChanges.find(collection, row, col)
     editValue = staged ? staged.newValue : String(value ?? '')


### PR DESCRIPTION
Closes #23. Parent #19.

Renders read-only state from the server's reported `/stats` (`read_only` / `read_only_reason`) — never hardcoded; absent signal ⇒ no badge ⇒ unchanged behaviour. Adds `connection.readOnly`/`readOnlyReason` (gated on `connected`), a StatusBar badge, and suppresses mutating controls (PendingChanges 'Apply all' disabled + reason banner; TableRenderer cell-edit entry absent).

Verified: svelte-check 0 errors, **209/209 tests pass** (3 new), static build green. Lock detection itself stays owned by reddb — this slice is the UI rendering of the reported flag.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782878390&installation_id=129708444&pr_number=41&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F41&signature=cc8603b4f97c7fc9d564039b67059c32cc3f3d4f61e8af427e0331bc4898b11c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only server state indicators throughout the UI, including a badge in the status bar and warning banner in the pending changes panel
  * "Apply all" button and cell-editing are now disabled when the server is read-only, with explanatory tooltips

* **Tests**
  * Added test coverage for read-only server state behavior and state reset

<!-- end of auto-generated comment: release notes by coderabbit.ai -->