### PR TITLE
feat(ui): Surface-aware boot gate (#21)

### DIFF
--- a/packages/ui/src/lib/Workspace.svelte
+++ b/packages/ui/src/lib/Workspace.svelte
@@ -104,12 +104,14 @@
   // start from the persisted value rather than the in-memory default.
   theme.init()
 
-  // Hard lock gate: while the secure store is locked, no automatic
-  // network traffic should fire. The user hasn't yet authenticated this
-  // session, so probing the configured URL would leak its existence and
-  // shape to anyone watching the network panel.
+  // Hard lock gate: while the secure store is locked, no automatic network
+  // traffic should fire — probing the configured URL would leak its existence
+  // and shape. Additionally (#21, acceptance #4) no traffic fires until a real
+  // target is resolved (URL/boot params, a stored pin, or an explicit connect),
+  // so a credential-less Surface that boots straight to data never probes a
+  // default it was never pointed at.
   $effect(() => {
-    if (secureStore.locked) return
+    if (secureStore.locked || !connection.targetResolved) return
     connection.refresh()
     const id = setInterval(() => connection.refresh(), REFRESH_MS)
     return () => clearInterval(id)

--- a/packages/ui/src/lib/connections.svelte.ts
+++ b/packages/ui/src/lib/connections.svelte.ts
@@ -345,9 +345,23 @@ class ConnectionStore {
    */
   #capabilities = $state<ServerCapabilities>({ ...EMPTY_SERVER_CAPABILITIES })
 
+  /**
+   * Whether a real connection target has been resolved (#21, acceptance #4):
+   * true when one came from the URL/boot params, a stored pin, or an explicit
+   * connect — false when `active` is only the default-preset fallback. Gates
+   * automatic network so nothing probes before the user (or a Surface) has
+   * actually chosen a target.
+   */
+  #targetResolved = $state<boolean>(!!(loadLocationConnection() ?? loadStored()))
+
   constructor() {
     this.history = historyStore.uiEntries()
     historyStore.setOnChange(() => { this.history = historyStore.uiEntries() })
+  }
+
+  /** See {@link ConnectionStore.#targetResolved}. */
+  get targetResolved(): boolean {
+    return this.#targetResolved
   }
 
   get client(): RedClient | null {
@@ -419,6 +433,9 @@ class ConnectionStore {
   }
 
   async tryConnect(preset: ConnectionPreset): Promise<boolean> {
+    // An explicit connect attempt means a target has been chosen — unblocks
+    // automatic refresh from here on (#21).
+    this.#targetResolved = true
     try {
       const active = await activity.track(
         `connect · ${preset.label}`,
@@ -507,6 +524,9 @@ class ConnectionStore {
     this.probe = { reachable: false }
     this.#client = null
     this.#capabilities = { ...EMPTY_SERVER_CAPABILITIES }
+    // Back to "no active target" — auto-network stays off until the user (or a
+    // Surface) resolves a target again (#21).
+    this.#targetResolved = false
   }
 }
 

--- a/packages/ui/src/lib/connections.test.ts
+++ b/packages/ui/src/lib/connections.test.ts
@@ -185,3 +185,14 @@ describe('boot-params pre-configuration (#36)', () => {
     expect(Object.keys(p.bootParams() ?? {})).toEqual(['endpoint'])
   })
 })
+
+describe('target resolution gate (#21)', () => {
+  it('an explicit connect marks the target resolved (gates auto-network)', async () => {
+    // In the node test env there is no URL/stored pin, so nothing is resolved
+    // until a connect happens — exactly the credential-less boot case.
+    expect(connection.targetResolved).toBe(false)
+    setConnectionProvider(new InjectedClientProvider({ client: fakeClient() }))
+    await connection.adoptInjected()
+    expect(connection.targetResolved).toBe(true)
+  })
+})

--- a/packages/ui/src/lib/secureStore.svelte.ts
+++ b/packages/ui/src/lib/secureStore.svelte.ts
@@ -13,6 +13,7 @@ import {
   SecureStoreError,
   type EncryptedStore,
 } from '#reddb'
+import { bootGateLocked, detectSurface, type Surface } from './surface'
 
 const NAMESPACE = 'red-ui:secure'
 const PROBE_KEY = '__probe__'
@@ -27,11 +28,6 @@ function envelopesExist(): boolean {
   return false
 }
 
-function isTauri(): boolean {
-  if (typeof window === 'undefined') return false
-  return '__TAURI_INTERNALS__' in window || '__TAURI__' in window
-}
-
 class SecureStoreSvc {
   /** The active backend, or null when locked. */
   store = $state<EncryptedStore | null>(null)
@@ -41,6 +37,8 @@ class SecureStoreSvc {
   needsSetup = $state<boolean>(false)
   /** Backend kind, for the UI to skip the password prompt entirely on desktop. */
   backend = $state<'tauri' | 'web' | 'unknown'>('unknown')
+  /** The detected Surface (#21) — drives the Surface-aware boot gate. */
+  surface = $state<Surface>('web')
   /** Last unlock attempt error, surface-able to the dialog. */
   error = $state<string | null>(null)
 
@@ -49,14 +47,20 @@ class SecureStoreSvc {
       this.backend = 'unknown'
       return
     }
-    if (isTauri()) {
+    this.surface = detectSurface()
+    if (this.surface === 'standalone') {
+      // Tauri desktop — defer to the OS keychain, which unlocks the vault.
       this.backend = 'tauri'
       this.bindTauri()
-    } else {
-      this.backend = 'web'
-      this.needsSetup = !envelopesExist()
-      this.locked = true
+      return
     }
+    // embedded or web. A credential-less embedded Surface boots straight to
+    // data; web gates on the master password ONLY when there is a secret to
+    // decrypt (#21) — a fresh web user with nothing saved is not blocked.
+    this.backend = 'web'
+    const hasSecret = envelopesExist()
+    this.needsSetup = !hasSecret
+    this.locked = bootGateLocked(this.surface, hasSecret)
   }
 
   private async bindTauri() {

--- a/packages/ui/src/lib/surface.test.ts
+++ b/packages/ui/src/lib/surface.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { bootGateLocked, surfaceFrom } from './surface'
+
+describe('surfaceFrom', () => {
+  it('Tauri is the standalone Surface', () => {
+    expect(surfaceFrom({ tauri: true, inFrame: false, mcp: false })).toBe('standalone')
+    // Tauri wins even when also framed/mcp.
+    expect(surfaceFrom({ tauri: true, inFrame: true, mcp: true })).toBe('standalone')
+  })
+
+  it('a framed or MCP context is the embedded Surface', () => {
+    expect(surfaceFrom({ tauri: false, inFrame: true, mcp: false })).toBe('embedded')
+    expect(surfaceFrom({ tauri: false, inFrame: false, mcp: true })).toBe('embedded')
+  })
+
+  it('a top-level browser page is the web Surface', () => {
+    expect(surfaceFrom({ tauri: false, inFrame: false, mcp: false })).toBe('web')
+  })
+})
+
+describe('bootGateLocked', () => {
+  it('a credential-less embedded Surface is never locked', () => {
+    expect(bootGateLocked('embedded', false)).toBe(false)
+    expect(bootGateLocked('embedded', true)).toBe(false)
+  })
+
+  it('the standalone Surface keeps its vault gate (keychain unlocks it)', () => {
+    expect(bootGateLocked('standalone', false)).toBe(true)
+    expect(bootGateLocked('standalone', true)).toBe(true)
+  })
+
+  it('web gates only when there is a secret to decrypt', () => {
+    expect(bootGateLocked('web', false)).toBe(false) // nothing to protect → boot to data
+    expect(bootGateLocked('web', true)).toBe(true) // saved credentials → unlock first
+  })
+})

--- a/packages/ui/src/lib/surface.ts
+++ b/packages/ui/src/lib/surface.ts
@@ -1,0 +1,66 @@
+// Surface detection + boot gate (#21, ADR-0001). red-ui is one Core delivered
+// by three Surfaces; the boot gate must be Surface-aware so a credential-less
+// Surface is never blocked behind the master-password vault.
+//
+//   - embedded   — the Embeddable Lib / MCP App, running inside a host that
+//                  owns auth (or a local, no-secret connection). Credential-less:
+//                  boots straight to data, no vault.
+//   - standalone — the Tauri desktop app. Keeps its vault (the OS keychain,
+//                  which unlocks automatically — "vault unlock as before").
+//   - web        — the hosted PWA. Gates on the master password ONLY when there
+//                  is a secret to protect (saved encrypted credentials); a fresh
+//                  web user with nothing to decrypt boots straight to data.
+
+export type Surface = 'embedded' | 'standalone' | 'web'
+
+/** Runtime signals the Surface is derived from (pure — injectable for tests). */
+export interface SurfaceSignals {
+  /** Running inside the Tauri shell. */
+  tauri: boolean
+  /** Rendered inside a cross-document frame (embedded in a host page). */
+  inFrame: boolean
+  /** The MCP App boot flag (`?mcp=1`) is present. */
+  mcp: boolean
+}
+
+/** Pure Surface decision from runtime signals. */
+export function surfaceFrom({ tauri, inFrame, mcp }: SurfaceSignals): Surface {
+  if (tauri) return 'standalone'
+  if (inFrame || mcp) return 'embedded'
+  return 'web'
+}
+
+/** Detect the Surface from the live browser globals. Defaults to `web` in SSR. */
+export function detectSurface(): Surface {
+  if (typeof window === 'undefined') return 'web'
+  const tauri = '__TAURI_INTERNALS__' in window || '__TAURI__' in window
+  let inFrame = false
+  try {
+    inFrame = window.self !== window.top
+  } catch {
+    // Cross-origin parent access throws — that itself means we're framed.
+    inFrame = true
+  }
+  const mcp =
+    typeof location !== 'undefined' && new URLSearchParams(location.search).has('mcp')
+  return surfaceFrom({ tauri, inFrame, mcp })
+}
+
+/**
+ * The initial lock state for a Surface (#21). `hasSecret` is whether encrypted
+ * credentials already exist for the web vault.
+ *
+ * - embedded → never locked (credential-less; the host owns auth).
+ * - standalone → locked initially; the Tauri keychain unlocks it (as before).
+ * - web → locked only when there is a secret to decrypt; otherwise boots to data.
+ */
+export function bootGateLocked(surface: Surface, hasSecret: boolean): boolean {
+  switch (surface) {
+    case 'embedded':
+      return false
+    case 'standalone':
+      return true
+    case 'web':
+      return hasSecret
+  }
+}


### PR DESCRIPTION
Closes #21. Per ADR-0001.

The boot gate is Surface-aware: detectSurface() classifies the runtime as embedded | standalone | web. A credential-less embedded Surface boots straight to data (host owns auth); web gates on the master password ONLY when a secret exists to decrypt; Tauri (standalone) keeps its keychain vault. connection.targetResolved gates auto-network so nothing probes before a real target is resolved (URL/boot-params/stored/explicit connect) — the default preset fallback does not count.

Verified: svelte-check 0 errors, 246/246 tests pass (7 new: Surface classification + per-Surface boot-gate + target-resolution gate), static build green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782881239&installation_id=129708444&pr_number=45&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F45&signature=6dabdee3aef3f8d8f3b14d7463baf8d86f4f963ae7992f00223b62ab14b55f73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic connection refresh to prevent network attempts until a connection target is properly established.

* **New Features**
  * Enhanced application initialization with better environment detection for different deployment modes.

* **Tests**
  * Added test coverage for connection target resolution and environment detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->