### PR TITLE
feat(ui): universal graph.json loader (#16)

### DIFF
--- a/packages/ui/src/lib/graph-loader/contract.test.ts
+++ b/packages/ui/src/lib/graph-loader/contract.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseGraphExport,
+  parseGraphExportJson,
+  loadGraphExport,
+  GraphContractError,
+  SUPPORTED_GRAPH_VERSION_MAJOR,
+} from './contract'
+import { extractGraph, hasGraphShape } from '$lib/renderers/graph-render'
+
+/** A minimal, contract-conformant export (nested envelope). */
+function validExport() {
+  return {
+    version: '1.0',
+    graph: {
+      nodes: [
+        {
+          id: 'a',
+          label: 'Alpha',
+          type: 'concept',
+          community: 0,
+          centrality: 0.75,
+          properties: { note: 'root' },
+        },
+        { id: 'b', label: 'Beta', community: 1 },
+        { id: 'c', label: 'Gamma', community: 1 },
+      ],
+      edges: [
+        { source: 'a', target: 'b', type: 'rel' },
+        { source: 'b', target: 'c' },
+      ],
+    },
+    communities: [
+      { id: 0, label: 'Roots', color: '#ff2056', size: 1 },
+      { id: 1, label: 'Leaves', size: 2 },
+    ],
+    meta: { source: 'unit-test' },
+  }
+}
+
+describe('parseGraphExport — model', () => {
+  it('yields the expected node/edge/community model', () => {
+    const loaded = parseGraphExport(validExport())
+
+    expect(loaded.version).toBe('1.0')
+    expect(loaded.model.nodes).toHaveLength(3)
+    expect(loaded.model.edges).toHaveLength(2)
+
+    expect(loaded.model.nodes[0]).toMatchObject({
+      id: 'a',
+      label: 'Alpha',
+      type: 'concept',
+      community: 0,
+    })
+    expect(loaded.model.nodes[0].data).toMatchObject({ centrality: 0.75 })
+
+    expect(loaded.model.edges[0]).toMatchObject({
+      source: 'a',
+      target: 'b',
+      type: 'rel',
+    })
+
+    expect(loaded.model.communities).toEqual([
+      { id: 0, label: 'Roots', color: '#ff2056', size: 1 },
+      { id: 1, label: 'Leaves', color: expect.any(String), size: 2 },
+    ])
+
+    expect(loaded.meta).toEqual({ source: 'unit-test' })
+  })
+
+  it('accepts the flat envelope (nodes/edges at top level)', () => {
+    const loaded = parseGraphExport({
+      version: '1.0',
+      nodes: [{ id: 'x' }, { id: 'y' }],
+      edges: [{ source: 'x', target: 'y' }],
+    })
+    expect(loaded.model.nodes.map((n) => n.id)).toEqual(['x', 'y'])
+    expect(loaded.model.edges).toHaveLength(1)
+  })
+
+  it('coerces numeric ids to strings and defaults label to the id', () => {
+    const loaded = parseGraphExport({
+      version: '1.2',
+      graph: { nodes: [{ id: 42 }], edges: [{ source: 42, target: 42 }] },
+    })
+    expect(loaded.model.nodes[0].id).toBe('42')
+    expect(loaded.model.nodes[0].label).toBe('42')
+    expect(loaded.model.edges[0]).toMatchObject({ source: '42', target: '42' })
+  })
+
+  it('defaults communities to an empty array when omitted', () => {
+    const loaded = parseGraphExport({
+      version: '1.0',
+      graph: { nodes: [{ id: 'x' }], edges: [] },
+    })
+    expect(loaded.model.communities).toEqual([])
+    expect(SUPPORTED_GRAPH_VERSION_MAJOR).toBe(1)
+  })
+})
+
+describe('parseGraphExport — renderer reuse', () => {
+  it('produces a graph-shaped QueryResult the existing renderer accepts', () => {
+    const loaded = parseGraphExport(validExport())
+
+    // The exact contract the GraphRenderer relies on.
+    expect(hasGraphShape(loaded.result)).toBe(true)
+
+    // extractGraph is what GraphRenderer calls internally — proving reuse.
+    const graph = extractGraph(loaded.result)
+    expect(graph.nodes.map((n) => n.id).sort()).toEqual(['a', 'b', 'c'])
+    expect(graph.nodes.find((n) => n.id === 'a')?.label).toBe('Alpha')
+    expect(graph.edges).toHaveLength(2)
+    expect(graph.edges[0]).toMatchObject({ source: 'a', target: 'b', label: 'rel' })
+  })
+})
+
+describe('parseGraphExport — malformed / wrong version', () => {
+  it('rejects a non-object payload', () => {
+    expect(() => parseGraphExport(null)).toThrow(GraphContractError)
+    expect(() => parseGraphExport('nope')).toThrow(/must be a JSON object/)
+  })
+
+  it('rejects a missing version', () => {
+    expect(() => parseGraphExport({ graph: { nodes: [], edges: [] } })).toThrow(
+      /missing a "version"/,
+    )
+  })
+
+  it('rejects an unsupported major version with a clear message', () => {
+    expect(() =>
+      parseGraphExport({ version: '2.0', graph: { nodes: [], edges: [] } }),
+    ).toThrow(/Unsupported graph export version "2.0"[\s\S]*supports version 1\.x/)
+  })
+
+  it('rejects non-array nodes/edges', () => {
+    expect(() =>
+      parseGraphExport({ version: '1.0', graph: { nodes: {}, edges: [] } }),
+    ).toThrow(/"nodes" must be an array/)
+    expect(() =>
+      parseGraphExport({ version: '1.0', graph: { nodes: [], edges: 7 } }),
+    ).toThrow(/"edges" must be an array/)
+  })
+
+  it('rejects a node missing an id, naming the offending index', () => {
+    expect(() =>
+      parseGraphExport({
+        version: '1.0',
+        graph: { nodes: [{ id: 'a' }, { label: 'no id' }], edges: [] },
+      }),
+    ).toThrow(/node at index 1 is missing the required "id"/)
+  })
+
+  it('rejects an edge missing source/target, naming the offending index', () => {
+    expect(() =>
+      parseGraphExport({
+        version: '1.0',
+        graph: { nodes: [{ id: 'a' }], edges: [{ source: 'a' }] },
+      }),
+    ).toThrow(/edge at index 0 is missing the required "target"/)
+  })
+})
+
+describe('parseGraphExportJson', () => {
+  it('parses a valid JSON string', () => {
+    const loaded = parseGraphExportJson(JSON.stringify(validExport()))
+    expect(loaded.model.nodes).toHaveLength(3)
+  })
+
+  it('wraps JSON syntax errors as GraphContractError', () => {
+    expect(() => parseGraphExportJson('{ not json ')).toThrow(GraphContractError)
+    expect(() => parseGraphExportJson('{ not json ')).toThrow(/not valid JSON/)
+  })
+})
+
+describe('loadGraphExport', () => {
+  it('fetches and parses a graph from a URL', async () => {
+    const fetchFn = (async () =>
+      new Response(JSON.stringify(validExport()), { status: 200 })) as typeof fetch
+    const loaded = await loadGraphExport('https://example.test/graph.json', { fetch: fetchFn })
+    expect(loaded.model.nodes).toHaveLength(3)
+    expect(hasGraphShape(loaded.result)).toBe(true)
+  })
+
+  it('reports a clear error on a non-OK HTTP response', async () => {
+    const fetchFn = (async () =>
+      new Response('not found', { status: 404, statusText: 'Not Found' })) as typeof fetch
+    await expect(
+      loadGraphExport('https://example.test/missing.json', { fetch: fetchFn }),
+    ).rejects.toThrow(/HTTP 404/)
+  })
+
+  it('reports a clear error when the fetch itself fails', async () => {
+    const fetchFn = (async () => {
+      throw new Error('network down')
+    }) as typeof fetch
+    await expect(
+      loadGraphExport('https://example.test/graph.json', { fetch: fetchFn }),
+    ).rejects.toThrow(/Failed to fetch graph[\s\S]*network down/)
+  })
+
+  it('surfaces contract errors from fetched-but-wrong-version payloads', async () => {
+    const fetchFn = (async () =>
+      new Response(JSON.stringify({ version: '9.9', graph: { nodes: [], edges: [] } }), {
+        status: 200,
+      })) as typeof fetch
+    await expect(
+      loadGraphExport('https://example.test/old.json', { fetch: fetchFn }),
+    ).rejects.toThrow(/Unsupported graph export version/)
+  })
+})

--- a/packages/ui/src/lib/graph-loader/contract.ts
+++ b/packages/ui/src/lib/graph-loader/contract.ts
@@ -1,0 +1,314 @@
+// Universal graph.json loader.
+//
+// Parses an arbitrary `graph.json` that conforms to the cross-repo export
+// contract (reddb-io/red-skills#234 — the shape emitted by the memory
+// `export` skill, graphify, and codebase-graph tooling) and adapts it into
+// the *same* `QueryResult` shape the existing `GraphRenderer` already
+// consumes. We deliberately reuse `extractGraph`/`GraphRenderer` rather than
+// building a parallel renderer: the loader is purely a data path that hands
+// the canvas a graph-shaped result, so community coloring, force layout,
+// search, and centrality all keep working unchanged and offline.
+//
+// Server-backed affordances inside the renderer (GRAPH NEIGHBORHOOD /
+// SHORTEST_PATH / CENTRALITY) issue live queries and are inert without a
+// connection — expected for a static file.
+
+import type { QueryResult } from '#reddb'
+import { colorForCommunity } from '$lib/renderers/graph-render'
+
+/** Major version of the graph.json contract this loader understands. */
+export const SUPPORTED_GRAPH_VERSION_MAJOR = 1
+
+/** A normalized node in the loaded model. */
+export interface LoadedGraphNode {
+  id: string
+  label: string
+  type?: string
+  community?: number
+  /** Full original node object, preserved for the renderer's detail panel. */
+  data: Record<string, unknown>
+}
+
+/** A normalized edge in the loaded model. */
+export interface LoadedGraphEdge {
+  id: string
+  source: string
+  target: string
+  type?: string
+  /** Full original edge object. */
+  data: Record<string, unknown>
+}
+
+/** A normalized community descriptor. */
+export interface LoadedGraphCommunity {
+  id: number
+  label: string
+  color: string
+  size: number
+}
+
+/** The result of loading a contract-conformant graph.json. */
+export interface LoadedGraph {
+  /** Declared contract version string. */
+  version: string
+  /** Normalized node/edge/community model (what the unit tests assert on). */
+  model: {
+    nodes: LoadedGraphNode[]
+    edges: LoadedGraphEdge[]
+    communities: LoadedGraphCommunity[]
+  }
+  /** A graph-shaped QueryResult ready to hand straight to `GraphRenderer`. */
+  result: QueryResult
+  /** Free-form metadata block carried by the export, if any. */
+  meta: Record<string, unknown>
+}
+
+/** Raised when an export is structurally malformed or the wrong version. */
+export class GraphContractError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'GraphContractError'
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function firstDefined(obj: Record<string, unknown>, keys: string[]): unknown {
+  for (const k of keys) {
+    const v = obj[k]
+    if (v !== undefined && v !== null && v !== '') return v
+  }
+  return undefined
+}
+
+function parseVersion(raw: Record<string, unknown>): string {
+  const v = firstDefined(raw, ['version', 'schema_version', 'schemaVersion'])
+  if (typeof v !== 'string' || v.trim() === '') {
+    throw new GraphContractError(
+      'Graph export is missing a "version" string. ' +
+        `This viewer supports the version ${SUPPORTED_GRAPH_VERSION_MAJOR}.x contract.`,
+    )
+  }
+  const major = Number.parseInt(v.split('.')[0] ?? '', 10)
+  if (!Number.isFinite(major)) {
+    throw new GraphContractError(
+      `Graph export declares an unparseable version "${v}". ` +
+        `This viewer supports version ${SUPPORTED_GRAPH_VERSION_MAJOR}.x.`,
+    )
+  }
+  if (major !== SUPPORTED_GRAPH_VERSION_MAJOR) {
+    throw new GraphContractError(
+      `Unsupported graph export version "${v}". ` +
+        `This viewer supports version ${SUPPORTED_GRAPH_VERSION_MAJOR}.x.`,
+    )
+  }
+  return v
+}
+
+function normalizeNode(raw: unknown, index: number): LoadedGraphNode {
+  if (!isObject(raw)) {
+    throw new GraphContractError(`Graph node at index ${index} is not an object.`)
+  }
+  const rawId = firstDefined(raw, ['id', 'rid', '_id', 'uid'])
+  if (rawId === undefined) {
+    throw new GraphContractError(
+      `Graph node at index ${index} is missing the required "id" field.`,
+    )
+  }
+  const id = String(rawId)
+  const label = firstDefined(raw, ['label', 'name', 'title'])
+  const type = firstDefined(raw, ['type', 'node_type', 'kind'])
+  const community = raw.community
+  return {
+    id,
+    label: label !== undefined ? String(label) : id,
+    type: type !== undefined ? String(type) : undefined,
+    community: typeof community === 'number' ? community : undefined,
+    data: raw,
+  }
+}
+
+function normalizeEdge(raw: unknown, index: number): LoadedGraphEdge {
+  if (!isObject(raw)) {
+    throw new GraphContractError(`Graph edge at index ${index} is not an object.`)
+  }
+  const source = firstDefined(raw, ['source', 'from', 'src', 'start', 'from_rid'])
+  if (source === undefined) {
+    throw new GraphContractError(
+      `Graph edge at index ${index} is missing the required "source" field.`,
+    )
+  }
+  const target = firstDefined(raw, ['target', 'to', 'dst', 'end', 'to_rid'])
+  if (target === undefined) {
+    throw new GraphContractError(
+      `Graph edge at index ${index} is missing the required "target" field.`,
+    )
+  }
+  const type = firstDefined(raw, ['type', 'label', 'rel'])
+  const s = String(source)
+  const t = String(target)
+  const rawId = firstDefined(raw, ['id', 'rid'])
+  const id =
+    rawId !== undefined ? String(rawId) : `${s}->${t}:${type ?? ''}#${index}`
+  return {
+    id,
+    source: s,
+    target: t,
+    type: type !== undefined ? String(type) : undefined,
+    data: raw,
+  }
+}
+
+function normalizeCommunities(raw: unknown): LoadedGraphCommunity[] {
+  if (raw === undefined || raw === null) return []
+  if (!Array.isArray(raw)) {
+    throw new GraphContractError('Graph export "communities" must be an array when present.')
+  }
+  return raw.map((entry, index) => {
+    if (!isObject(entry)) {
+      throw new GraphContractError(`Community at index ${index} is not an object.`)
+    }
+    if (typeof entry.id !== 'number') {
+      throw new GraphContractError(`Community at index ${index} is missing a numeric "id".`)
+    }
+    const id = entry.id
+    return {
+      id,
+      label: typeof entry.label === 'string' ? entry.label : `Community ${id}`,
+      color: typeof entry.color === 'string' ? entry.color : colorForCommunity(id),
+      size: typeof entry.size === 'number' ? entry.size : 0,
+    }
+  })
+}
+
+/**
+ * Build a graph-shaped `QueryResult` from the normalized model. All nodes and
+ * edges go into a single record's `nodes`/`edges` maps (keyed by id) — exactly
+ * the "Shape A" that `extractGraph`/`hasGraphShape` recognize, so the existing
+ * `GraphRenderer` paints it without modification.
+ */
+function toQueryResult(
+  nodes: LoadedGraphNode[],
+  edges: LoadedGraphEdge[],
+): QueryResult {
+  const nodeMap: Record<string, Record<string, unknown>> = {}
+  for (const n of nodes) {
+    nodeMap[n.id] = {
+      ...n.data,
+      id: n.id,
+      label: n.label,
+      ...(n.type !== undefined ? { node_type: n.type } : {}),
+    }
+  }
+  const edgeMap: Record<string, Record<string, unknown>> = {}
+  for (const e of edges) {
+    edgeMap[e.id] = {
+      ...e.data,
+      source: e.source,
+      target: e.target,
+      ...(e.type !== undefined ? { type: e.type } : {}),
+    }
+  }
+  return {
+    ok: true,
+    query: '',
+    capability: 'graph',
+    record_count: nodes.length + edges.length,
+    result: {
+      columns: ['nodes', 'edges'],
+      records: [{ values: {}, nodes: nodeMap, edges: edgeMap }],
+    },
+  } as QueryResult
+}
+
+/**
+ * Validate and normalize a parsed graph.json value.
+ *
+ * Accepts both the nested envelope (`{ version, graph: { nodes, edges } }`) and
+ * the flat one (`{ version, nodes, edges }`), since "universal" means liberal
+ * in what we accept. Throws a {@link GraphContractError} with an actionable
+ * message when the value is not an object, declares an unsupported version, or
+ * is missing required node/edge fields.
+ */
+export function parseGraphExport(raw: unknown): LoadedGraph {
+  if (!isObject(raw)) {
+    throw new GraphContractError(
+      'Graph export must be a JSON object with "version" and graph data.',
+    )
+  }
+
+  const version = parseVersion(raw)
+
+  const container = isObject(raw.graph) ? raw.graph : raw
+  const nodesRaw = container.nodes
+  const edgesRaw = container.edges
+  if (!Array.isArray(nodesRaw)) {
+    throw new GraphContractError('Graph export "nodes" must be an array.')
+  }
+  if (!Array.isArray(edgesRaw)) {
+    throw new GraphContractError('Graph export "edges" must be an array.')
+  }
+
+  const nodes = nodesRaw.map(normalizeNode)
+  const edges = edgesRaw.map(normalizeEdge)
+  const communities = normalizeCommunities(
+    raw.communities ?? container.communities,
+  )
+
+  return {
+    version,
+    model: { nodes, edges, communities },
+    result: toQueryResult(nodes, edges),
+    meta: isObject(raw.meta) ? raw.meta : {},
+  }
+}
+
+/**
+ * Parse a raw JSON string into a {@link LoadedGraph}. Wraps
+ * {@link parseGraphExport}, converting JSON syntax errors into a
+ * {@link GraphContractError} so callers handle a single error type.
+ */
+export function parseGraphExportJson(text: string): LoadedGraph {
+  let value: unknown
+  try {
+    value = JSON.parse(text)
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : String(e)
+    throw new GraphContractError(`Graph export is not valid JSON: ${detail}`)
+  }
+  return parseGraphExport(value)
+}
+
+/**
+ * Fetch a graph.json from a path or URL and normalize it. `src` may be an
+ * absolute URL (`https://…/graph.json`) or a same-origin path
+ * (`/exports/memory.json`). Inject `opts.fetch` for tests.
+ */
+export async function loadGraphExport(
+  src: string,
+  opts: { fetch?: typeof fetch } = {},
+): Promise<LoadedGraph> {
+  const fetchFn = opts.fetch ?? globalThis.fetch
+  if (typeof fetchFn !== 'function') {
+    throw new GraphContractError('No fetch implementation available to load the graph.')
+  }
+
+  let res: Response
+  try {
+    res = await fetchFn(src)
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : String(e)
+    throw new GraphContractError(`Failed to fetch graph from "${src}": ${detail}`)
+  }
+
+  if (!res.ok) {
+    throw new GraphContractError(
+      `Failed to load graph from "${src}": HTTP ${res.status} ${res.statusText}`.trim(),
+    )
+  }
+
+  const text = await res.text()
+  return parseGraphExportJson(text)
+}

--- a/packages/ui/src/lib/graph-loader/index.ts
+++ b/packages/ui/src/lib/graph-loader/index.ts
@@ -1,0 +1,13 @@
+export {
+  parseGraphExport,
+  parseGraphExportJson,
+  loadGraphExport,
+  GraphContractError,
+  SUPPORTED_GRAPH_VERSION_MAJOR,
+} from './contract'
+export type {
+  LoadedGraph,
+  LoadedGraphNode,
+  LoadedGraphEdge,
+  LoadedGraphCommunity,
+} from './contract'

--- a/packages/ui/src/routes/graph/+page.svelte
+++ b/packages/ui/src/routes/graph/+page.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { page } from '$app/state'
+  import { FileJson, Link2, Upload, RotateCw } from 'lucide-svelte'
+  import GraphRenderer from '$lib/renderers/GraphRenderer.svelte'
+  import EmptyState from '$lib/EmptyState.svelte'
+  import {
+    loadGraphExport,
+    parseGraphExportJson,
+    type LoadedGraph,
+  } from '$lib/graph-loader/contract'
+
+  let loaded = $state<LoadedGraph | null>(null)
+  let loading = $state(false)
+  let error = $state<string | null>(null)
+  let sourceLabel = $state<string | null>(null)
+
+  let srcInput = $state('')
+  let fileInput = $state<HTMLInputElement | null>(null)
+
+  async function loadFromUrl(src: string) {
+    const trimmed = src.trim()
+    if (!trimmed) return
+    loading = true
+    error = null
+    try {
+      loaded = await loadGraphExport(trimmed, { fetch })
+      sourceLabel = trimmed
+    } catch (e) {
+      loaded = null
+      error = e instanceof Error ? e.message : String(e)
+    } finally {
+      loading = false
+    }
+  }
+
+  async function loadFromFile(file: File) {
+    loading = true
+    error = null
+    try {
+      loaded = parseGraphExportJson(await file.text())
+      sourceLabel = file.name
+    } catch (e) {
+      loaded = null
+      error = e instanceof Error ? e.message : String(e)
+    } finally {
+      loading = false
+    }
+  }
+
+  function onSubmit(event: SubmitEvent) {
+    event.preventDefault()
+    void loadFromUrl(srcInput)
+  }
+
+  function onFileChange(event: Event) {
+    const file = (event.target as HTMLInputElement).files?.[0]
+    if (file) void loadFromFile(file)
+  }
+
+  function clear() {
+    loaded = null
+    error = null
+    sourceLabel = null
+    srcInput = ''
+    if (fileInput) fileInput.value = ''
+  }
+
+  onMount(() => {
+    // Deep-linkable: /graph?src=<path-or-url>
+    const src = page.url.searchParams.get('src')
+    if (src) {
+      srcInput = src
+      void loadFromUrl(src)
+    }
+  })
+</script>
+
+<svelte:head>
+  <title>Load graph · red-ui</title>
+</svelte:head>
+
+<div class="flex flex-col h-full w-full">
+  {#if loaded}
+    <div
+      class="flex items-center justify-between gap-4 px-3 py-2 border-b border-line-1 bg-bg-1 shrink-0"
+    >
+      <span class="flex items-center gap-2 min-w-0 text-fg-2 text-[13px]">
+        <FileJson size={14} />
+        <span class="font-mono text-fg-1 truncate max-w-[38vw]">{sourceLabel}</span>
+        <span class="text-fg-3 whitespace-nowrap">
+          {loaded.model.nodes.length} nodes · {loaded.model.edges.length} edges{#if loaded.model.communities.length}
+            · {loaded.model.communities.length} communities{/if}
+        </span>
+      </span>
+      <button
+        type="button"
+        class="flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-line-1 text-fg-2 text-[12px] hover:border-fg-3 hover:text-fg-1"
+        onclick={clear}
+      >
+        <RotateCw size={13} /> Load another
+      </button>
+    </div>
+    <div class="flex-1 min-h-0">
+      {#key loaded}
+        <GraphRenderer result={loaded.result} />
+      {/key}
+    </div>
+  {:else}
+    <div class="flex items-center justify-center h-full w-full p-8">
+      <EmptyState
+        title="Load a graph"
+        message="Render any contract-conformant graph.json — memory exports, codebase graphs, or graphify output — from a URL, a path, or a local file. No connection required."
+        icon={FileJson}
+      >
+        {#snippet actions()}
+          <div class="flex flex-col gap-3 w-[min(34rem,90vw)] text-left">
+            <form class="flex gap-2" onsubmit={onSubmit}>
+              <div class="relative flex-1 flex items-center">
+                <Link2 size={15} class="absolute left-2.5 text-fg-3 pointer-events-none" />
+                <input
+                  class="w-full pl-8 pr-2.5 py-2 bg-bg-2 border border-line-1 rounded-md text-fg-1 text-[13px] font-mono focus:outline-none focus:border-accent"
+                  type="text"
+                  placeholder="https://host/graph.json  or  /exports/memory.json"
+                  bind:value={srcInput}
+                  disabled={loading}
+                  spellcheck="false"
+                  autocapitalize="off"
+                  autocorrect="off"
+                />
+              </div>
+              <button
+                class="px-4 py-2 bg-accent text-white rounded-md text-[13px] font-medium whitespace-nowrap disabled:opacity-50"
+                type="submit"
+                disabled={loading || !srcInput.trim()}
+              >
+                {loading ? 'Loading…' : 'Load'}
+              </button>
+            </form>
+
+            <div class="flex items-center gap-2 text-fg-3 text-[11px] uppercase tracking-wide">
+              <span class="flex-1 h-px bg-line-1"></span>
+              or
+              <span class="flex-1 h-px bg-line-1"></span>
+            </div>
+
+            <button
+              type="button"
+              class="flex items-center justify-center gap-2 px-3 py-2 bg-bg-2 border border-line-1 rounded-md text-fg-1 text-[13px] hover:border-fg-3 disabled:opacity-50"
+              disabled={loading}
+              onclick={() => fileInput?.click()}
+            >
+              <Upload size={15} /> Choose a local graph.json
+            </button>
+            <input
+              bind:this={fileInput}
+              type="file"
+              accept="application/json,.json"
+              class="hidden"
+              onchange={onFileChange}
+            />
+
+            {#if error}
+              <p
+                class="m-0 px-3 py-2 rounded-md text-accent text-[12px] leading-relaxed border border-accent/35 bg-accent/10"
+              >
+                {error}
+              </p>
+            {/if}
+          </div>
+        {/snippet}
+      </EmptyState>
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
Closes #16. A /graph route + graph-loader that loads a contract-conformant graph.json (reddb-io/red-skills#234) from a path, URL, or file and renders it through the EXISTING GraphRenderer (not a parallel renderer) by normalizing into the same graph-shaped QueryResult. Community coloring, force layout, search, neighborhood/shortest-path and centrality keep working; malformed/wrong-version inputs fail with a clear error.

Salvaged from a prior AFK attempt that crashed before landing; re-validated on current main: svelte-check 0 errors, 263/263 tests pass (17 contract tests), static build green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782881523&installation_id=129708444&pr_number=46&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F46&signature=c4f00c4ef5ca13b81499bfe3bfe5df14d05f7882e995e6cde0f33c87afb4913d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `/graph` route for loading and rendering graphs from URLs, paths (via query parameter), or local files.
  * Graph display includes statistics showing node, edge, and community counts.
  * Implemented error handling for invalid graph data with user-friendly messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->