### PR TITLE
Streaming, honest transports, artifact versioning, CI harvest + MCP ADR

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,7 @@
 {
   "statusLine": {
     "type": "command",
-    "command": "bash ${CLAUDE_PLUGIN_ROOT}/skills/engineering/afk/scripts/statusline.sh",
+    "command": "sh -c 'b=$(ls -t \"$HOME\"/.claude/plugins/cache/red-skills/dev/*/skills/engineering/afk/bin/afk.mjs 2>/dev/null | head -1); [ -n \"$b\" ] && exec node \"$b\" statusline'",
     "refreshInterval": 5
   }
 }

--- a/.github/actions/tauri-linux-deps/action.yml
+++ b/.github/actions/tauri-linux-deps/action.yml
@@ -1,0 +1,20 @@
+name: Tauri Linux deps
+description: >
+  Install the system libraries the Tauri Linux build needs (webkit2gtk,
+  appindicator, rsvg, patchelf, openssl) plus clang, which the mold linker is
+  driven through (see apps/desktop/src-tauri/.cargo/config.toml). Single source
+  of truth so ci.yml and release.yml can't drift. Mirrors reddb's
+  .github/actions/install-protoc composite pattern.
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libwebkit2gtk-4.1-dev \
+          libappindicator3-dev \
+          librsvg2-dev \
+          patchelf \
+          libssl-dev \
+          clang

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,27 @@ name: ci
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - ".changeset/**"
+      - "LICENSE**"
   pull_request:
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - ".changeset/**"
+      - "LICENSE**"
 
 # Blacksmith-hosted runners (matching reddb-io/reddb's pattern) — same
 # GitHub Actions semantics, dramatically faster boots and SSDs.
+
+# Cost guard: a new push cancels older in-flight CI on the same ref. Release
+# validation lives in release.yml; CI runs should stay quick (harvested from
+# reddb-io/reddb).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check:
@@ -28,15 +45,29 @@ jobs:
     # Verify the Rust shell still compiles on every PR; doesn't bundle
     # installers (that's the release workflow's job) — just runs
     # `cargo check` against the same workspace tauri-action will later use.
+    # Skipped on draft PRs (the slowest job; don't burn it on WIP).
+    if: github.event.pull_request.draft != true
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      # sccache object-cache; CARGO_INCREMENTAL must be 0 (incremental and
+      # sccache are mutually exclusive). Harvested from reddb-io/reddb.
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: rui314/setup-mold@v1
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: Swatinem/rust-cache@v2
         with:
           workspaces: apps/desktop/src-tauri
-      - name: linux deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libssl-dev
+          # Shared with release.yml's tauri job so the release build
+          # warm-starts from CI's cache.
+          shared-key: tauri-${{ runner.os }}-rust-1.95.0
+          cache-on-failure: "true"
+      - uses: ./.github/actions/tauri-linux-deps
       - run: cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: release
 
 on:
   push:
-    tags: ['v*']
+    tags: ["v*"]
   workflow_dispatch:
 
 # Runners: Blacksmith-hosted, matching reddb-io/reddb's setup.
@@ -28,6 +28,11 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      # Stamp the bundle/embed version from the git tag (v1.2.3 → 1.2.3);
+      # empty on non-tag dispatch so the build falls back to package.json.
+      RED_BUILD_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
+      RED_BUILD_GIT_SHA: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -58,13 +63,16 @@ jobs:
         # the Linux pipeline is green end-to-end. Uncomment to restore.
         include:
           - platform: blacksmith-8vcpu-ubuntu-2404
-            args: ''
+            args: ""
           # - platform: blacksmith-6vcpu-macos-15
           #   args: '--target universal-apple-darwin'
           # - platform: blacksmith-8vcpu-windows-2025
           #   args: ''
 
     runs-on: ${{ matrix.platform }}
+    env:
+      RED_BUILD_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
+      RED_BUILD_GIT_SHA: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
 
@@ -129,7 +137,7 @@ jobs:
         with:
           projectPath: apps/desktop
           tagName: ${{ github.ref_name }}
-          releaseName: 'red-ui ${{ github.ref_name }}'
+          releaseName: "red-ui ${{ github.ref_name }}"
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}
@@ -139,6 +147,9 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: write
+    env:
+      RED_BUILD_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
+      RED_BUILD_GIT_SHA: ${{ github.sha }}
     outputs:
       zip-name: ${{ steps.pack.outputs.zip-name }}
     steps:
@@ -154,7 +165,7 @@ jobs:
       # Pages always reflects the latest tag.
       - name: build pwa (root, for embedding)
         env:
-          BASE_PATH: ''
+          BASE_PATH: ""
         run: pnpm --filter @reddb-io/ui build
 
       - name: pack zip
@@ -173,7 +184,7 @@ jobs:
           files: ${{ steps.pack.outputs.zip-name }}
           tag_name: ${{ github.ref_name }}
           draft: true
-          name: 'red-ui ${{ github.ref_name }}'
+          name: "red-ui ${{ github.ref_name }}"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,16 @@ on:
 #   WINDOWS_CERTIFICATE           — base64-encoded .pfx
 #   WINDOWS_CERTIFICATE_PASSWORD
 
+# Never interrupt an in-flight release (a half-published tag is worse than a
+# queued one), but don't run two releases for the same ref at once.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   npm:
     name: npm · publish packages
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
       id-token: write
@@ -73,6 +79,11 @@ jobs:
     env:
       RED_BUILD_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
       RED_BUILD_GIT_SHA: ${{ github.sha }}
+      # sccache object-cache (CARGO_INCREMENTAL must be 0 — incremental and
+      # sccache are mutually exclusive). Harvested from reddb-io/reddb.
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v4
 
@@ -86,20 +97,29 @@ jobs:
           cache: pnpm
 
       - name: install rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: ${{ contains(matrix.platform, 'macos') && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
+      - name: install mold (linux link speedup)
+        if: contains(matrix.platform, 'ubuntu')
+        uses: rui314/setup-mold@v1
+
+      - name: sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
       - name: rust cache
-        uses: swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v2
         with:
           workspaces: apps/desktop/src-tauri
+          # Same key as ci.yml's tauri job so the release build warm-starts
+          # from CI's cache.
+          shared-key: tauri-${{ runner.os }}-rust-1.95.0
+          cache-on-failure: "true"
 
       - name: linux deps
         if: contains(matrix.platform, 'ubuntu')
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libssl-dev
+        uses: ./.github/actions/tauri-linux-deps
 
       - run: pnpm install --frozen-lockfile
 

--- a/.red/adr/0003-transport-reachability-is-a-surface-capability.md
+++ b/.red/adr/0003-transport-reachability-is-a-surface-capability.md
@@ -13,3 +13,48 @@ The Core stays transport-agnostic (it asks a `ConnectionProvider` for a client),
 
 - The `ConnectionProvider` contract should let a Surface declare which transports it offers, so the Core's Connect UI can hide unreachable options instead of letting the client reject them (`BROWSER_TRANSPORT_UNSUPPORTED`).
 - This is a deliberate **no**: browser Surfaces will not open local files until the WASM path exists — recorded so it isn't "fixed" as if it were an oversight.
+- **`red://` is not a distinct browser transport.** `normalizeUrl` rewrites `red://host` → `http://host:5055` and `reds://host` → `https://host:5055` (the documented `red://localhost` production tunnel), so a typed `red(s)://` URL classifies as its coerced `http(s)` transport. The browser therefore reaches it (the tunnel keeps working) but advertises only `http(s)://` per the decision above — `red(s)://` is accepted-as-alias, not offered-as-transport. Native tcp/tls over the wire would be a future Desktop capability and is **not materialized today**; the only Surface-specific transport currently is the Desktop `unix` socket / embedded file.
+
+---
+
+## Transport reference matrix (verified against `../reddb` docs + source, 2026-06-01)
+
+reddb exposes **many** wire transports; the red-ui _client_ deliberately speaks a
+subset, bounded by what each Surface's runtime can reach **and** by what the
+client implements. The Connect UI never offers a transport the active client
+cannot materialize. Sources: `../reddb/docs/api/{http,grpc,postgres-wire,ingest,query-streaming,embedded,mcp}.md`, `../reddb/docs/clients/drivers/rust.md`, `../reddb/crates/reddb-server/src/server/routing.rs`.
+
+### What reddb actually offers
+
+| Transport                     | Scheme / endpoint                                     | Default port               | Wire                                      | Browser-reachable?                                           | Best for                                                                                        |
+| ----------------------------- | ----------------------------------------------------- | -------------------------- | ----------------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| **HTTP REST**                 | `http(s)://` `POST /query`, `GET /changes`, …         | 8080 (red-ui tunnel: 5055) | HTTP/1.1+2, JSON                          | ✅ `fetch`                                                   | Human-driven UI, the **most feature-complete** surface                                          |
+| **HTTP NDJSON select-stream** | `POST /query/stream` → `application/x-ndjson`         | (HTTP)                     | chunked, bounded-memory, resumable cursor | ✅ `fetch` + `ReadableStream` (POST → **not** `EventSource`) | Large `SELECT` scans without buffering the whole result                                         |
+| **HTTP SSE (ASK STREAM)**     | `POST /query` w/ `ASK … STREAM` → `text/event-stream` | (HTTP)                     | server→client tokens                      | ✅ `fetch`+`getReader` (POST → **not** `EventSource`)        | Progressive LLM answer tokens                                                                   |
+| **WebSocket ingest**          | `WS /ws/ingest/{collection}`                          | (HTTP)                     | full-duplex, per-batch ack, backpressure  | ✅ native `WebSocket`                                        | Browser/agent **write** streaming                                                               |
+| **CDC poll**                  | `GET /changes?since_lsn=`                             | (HTTP)                     | poll only — **no `/changes/stream`**      | ✅ `fetch`                                                   | Live-changes feed (the only CDC transport that exists)                                          |
+| **RedWire**                   | `red(s)://`                                           | **5050**                   | raw TCP, CBOR, multiplexed, ~30µs         | ❌ raw TCP — impossible in a browser                         | Latency-sensitive native/back-end clients                                                       |
+| **gRPC**                      | `grpc(s)://`                                          | 5055                       | HTTP/2 + protobuf                         | ❌ needs gRPC-web proxy (undocumented)                       | Back-end bulk ETL, replication. **Partial query surface** (MATCH/GRAPH/HLL/timeseries/ASK gaps) |
+| **Postgres-wire**             | —                                                     | 5432 (conventional)        | PG v3, raw TCP                            | ❌ raw TCP                                                   | `psql`/pgAdmin/JDBC compatibility                                                               |
+| **Embedded / stdio / MCP**    | in-process / `red mcp`                                | —                          | Rust in-process                           | ❌ (no `red ui <file>` command exists yet)                   | Desktop/CLI/agent, zero network hop                                                             |
+
+Key facts that correct earlier assumptions:
+
+- `red://` is **RedWire TCP on :5050** natively (`rust.md`), _not_ HTTP. red-ui coercing it to `http://:5055` is a **client convention** for its prod tunnel — and :5055 is reddb's _gRPC_ default, so this only works because the tunnel maps :5055→HTTP. Fragile if ports ever change.
+- There is **no `/changes/stream` SSE endpoint** (`routing.rs` only has `GET /changes`). CDC is poll-only. The client's dormant SSE plumbing targets an endpoint reddb has not shipped.
+- Both HTTP streaming reads are **POST-based**, so the browser `EventSource` API cannot drive them — `fetch` + `ReadableStream` is required.
+
+### Optimal protocol per Surface (channel), with limitations
+
+| Surface                                  | Reachable                           | Optimal today                              | Limitation                                                                                         | Available upgrade (not yet built)                                                                     |
+| ---------------------------------------- | ----------------------------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| **Web / PWA** (browser)                  | HTTP only                           | `POST /query` (REST) + `GET /changes` poll | No raw TCP/gRPC/PG-wire; no CDC push exists                                                        | NDJSON `POST /query/stream` for big results; `fetch`-SSE for `ASK STREAM`; `WS /ws/ingest` for writes |
+| **Embeddable Lib** (browser, shadow DOM) | HTTP only (host-injected client)    | same as PWA                                | same; cannot elevate (`__TAURI__` absent)                                                          | same as PWA                                                                                           |
+| **Tauri Desktop**                        | HTTP **+ native TCP/unix via Rust** | HTTP through the webview (same as browser) | **Not using its native advantage** — could speak RedWire(:5050)/gRPC from Rust for ~30µs vs ~250µs | Rust-side RedWire/gRPC client + IPC bridge; wire the dead `tcp_ping`; honour `red+unix`               |
+| **MCP App**                              | HTTP (iframe)                       | display-proxy iframe → PWA                 | No model-callable data tools; all access is visual                                                 | Server-side `RedClient` data tools (query/list) returning structured content                          |
+
+### Current red-ui state vs optimal
+
+- **Web / Embed:** already optimal **given the channel** — HTTP is both the only reachable transport and reddb's most complete surface; CDC poll is the only live-changes path. ✅
+- **Desktop:** sub-optimal but functional — runs the browser HTTP path inside the webview and ignores the Rust shell's native-socket capability. The `unix` transport is _advertised_ (`DESKTOP_TRANSPORTS`) but **not implemented end-to-end**, and `red+unix` deep links are registered but unhandled by `normalizeUrl`. Tracked as a gap, not silently shipped.
+- **MCP:** functional as a launcher; no native data path (by design today).

--- a/.red/adr/0006-mcp-local-file-spawns-red-server.md
+++ b/.red/adr/0006-mcp-local-file-spawns-red-server.md
@@ -1,0 +1,60 @@
+# MCP App: remote targets connect directly; local files are served by a spawned `red server`
+
+The MCP App resolves its target into one of two modes. A **remote** target (an
+`http(s)://` or `red://` URL) is handed to the browser Surface as-is via the
+Open Contract — the UI fetches it directly (reddb CORS). A **local file** target
+(a filesystem path / `file://` / `*.rdb`) cannot be reached by a browser at all,
+so the MCP process **spawns `red server --http-bind 127.0.0.1:<ephemeral> --path
+<file>`** as a child, health-checks it, and hands the UI `?cs=http://127.0.0.1:<port>`.
+
+## Context
+
+The browser sandbox has no usable filesystem API for an `.rdb`, and cannot speak
+reddb's native RedWire/TCP (`red://` = TCP :5050). reddb's embedded mode is
+in-process Rust (`RedDB::open`) with no stdio/HTTP bridge, and **no `red ui
+<file>` command exists** (PRD #19 assumed ../reddb would build one; it has not).
+Therefore any browser Surface that inspects a file needs an HTTP server in front
+of that file. reddb already _is_ that server: `red server --path <file>
+--http-bind …` opens the file and exposes the full HTTP API + CORS (≥1.9.1). The
+MCP process (Node) cannot open the `.rdb` itself (Rust-only embedded), so it
+spawns the `red` binary rather than reimplementing the HTTP API.
+
+Today `packages/mcp` is a pure display proxy: it renders an `<iframe>` at
+`RED_UI_APP_URL` (default `https://ui.reddb.io`) and connects to no reddb itself.
+Local-file support and any server-side data access are new capability.
+
+## Decision
+
+- **Mode detection** lives in the MCP process. URL-shaped target → remote;
+  filesystem/`file://`/`*.rdb` → local. The Core stays unchanged — it only ever
+  receives a connection string through the Open Contract (ADR-0001, ADR-0005).
+- **Remote:** pass `?cs=<url>` (+ managed-session token via the handoff channel,
+  ADR-0005 / #27). No process is spawned. Optionally the MCP process runs a
+  server-side `RedClient` to answer data tools (`query`/`list`/`get`) as
+  `structuredContent`, so the model gets data without driving the visual iframe.
+- **Local file:** spawn **one** `red server --http-bind` that **owns** the file;
+  both the visual UI and any MCP data tools talk to it over `http://localhost`.
+  One owner because reddb's `flock` is single-writer — we must not open the file
+  from two processes. Spawn requires a `red` binary (via `@reddb-io/sdk`'s
+  subprocess or a PATH `red`); resolve-or-fail explicitly, never reimplement the
+  API as a Node↔SDK HTTP proxy.
+- **Lock-aware:** if the file is already held by another writer (the trigger
+  case — viewing an agent's live memory `.rdb`), spawn with `--read-only`; reddb
+  reports `read_only` in `/stats` and the UI already renders the badge (#23).
+- **Same-origin local UI:** for the local mode, serve the Embeddable Lib bundle
+  (#37) on `http://localhost` too, so the iframe and the API share an
+  `http://localhost` origin — avoids HTTPS→`http://localhost` mixed-content
+  (Chrome exempts localhost; Firefox/Safari are unreliable) and works offline.
+- **Lifecycle:** spawn on demand, wait for `/stats` healthy, tear the child down
+  on MCP exit/disconnect; pick an ephemeral port.
+
+## Consequences
+
+- The MCP App gains a hard dependency on a `red` binary for the local-file path
+  (acceptable: it is the database we are a client of). The remote path keeps zero
+  binary dependency.
+- "Open this file in the UI" no longer waits on a `red ui <file>` subcommand in
+  ../reddb — the MCP owns the embedded-surface story for its App.
+- Two processes never write one `.rdb`: a local session is one `red server` that
+  both the UI and the model-facing tools share.
+- Secrets still never ride the URL (ADR-0005 holds for the remote token path).

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/ui-desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/.cargo/config.toml
+++ b/apps/desktop/src-tauri/.cargo/config.toml
@@ -1,0 +1,13 @@
+# Use clang + the mold linker on Linux for a much faster link of the Tauri
+# binary (harvested from reddb-io/reddb). Target-scoped to linux-gnu only, so
+# macOS / Windows builds (and the commented-out release matrix entries) are
+# untouched. Local Linux dev needs `clang` and `mold` on PATH
+# (`apt install clang mold`); CI installs clang via the tauri-linux-deps
+# composite and mold via rui314/setup-mold.
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+[target.aarch64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "red-ui"
-version = "0.1.0"
+version = "0.1.1"
 description = "reddb universal client"
 authors = ["reddb-io"]
 edition = "2021"

--- a/apps/desktop/src-tauri/rust-toolchain.toml
+++ b/apps/desktop/src-tauri/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+# Pinned (matching reddb-io/reddb) so a `stable` bump never silently changes the
+# compiler under CI/dev and so the swatinem cache key stays stable.
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "red-ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "io.reddb.ui",
   "build": {
     "beforeDevCommand": "pnpm --filter @reddb-io/ui dev",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "check": "pnpm -r check",
     "test": "pnpm -r test",
     "changeset": "changeset",
-    "release:version": "changeset version",
+    "release:version": "changeset version && node scripts/sync-desktop-version.mjs",
+    "sync:desktop-version": "node scripts/sync-desktop-version.mjs",
     "release:publish": "changeset publish",
     "prepare": "husky"
   },

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -7,7 +7,33 @@ import {
 } from "@modelcontextprotocol/ext-apps/server";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { z } from "zod/v4";
+
+// Single source of truth for "what version am I": the package.json version
+// (changeset-managed, version-locked with @reddb-io/ui + ui-kit), overridable by
+// the RED_BUILD_VERSION env the release CI sets from the git tag. From the
+// compiled dist/index.js, ../package.json is the package root manifest (shipped
+// because `files` always includes it). Mirrors the ../red-skills build-info
+// pattern; replaces the previously hardcoded "0.1.0".
+function resolveVersion(): string {
+  const fromEnv = process.env.RED_BUILD_VERSION;
+  if (fromEnv) return fromEnv.replace(/^v/, "");
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkg = JSON.parse(
+      readFileSync(join(here, "..", "package.json"), "utf8")
+    ) as { version?: string };
+    if (pkg.version) return pkg.version;
+  } catch {
+    // fall through
+  }
+  return "0.0.0-dev";
+}
+
+const RED_UI_MCP_VERSION = resolveVersion();
 
 const APP_RESOURCE_URI = "ui://red-ui/app.html";
 const MCP_APPS_CDN =
@@ -299,7 +325,7 @@ function renderRedUiAppHtml(config: ServerConfig): string {
       try {
         const { App } = await import(MCP_APPS_CDN);
         app = new App(
-          { name: 'red-ui', version: '0.1.0' },
+          { name: 'red-ui', version: ${JSON.stringify(RED_UI_MCP_VERSION)} },
           {},
           { autoResize: true }
         );
@@ -317,7 +343,7 @@ function renderRedUiAppHtml(config: ServerConfig): string {
 function createServer(config: ServerConfig): McpServer {
   const server = new McpServer({
     name: "red-ui",
-    version: "0.1.0",
+    version: RED_UI_MCP_VERSION,
   });
 
   registerAppResource(

--- a/packages/ui/src/lib/ConnectDropdown.svelte
+++ b/packages/ui/src/lib/ConnectDropdown.svelte
@@ -100,8 +100,9 @@
   const supportedHint = $derived.by(() => {
     const t = connection.supportedTransports
     const schemes: string[] = []
+    // http(s):// is the only browser transport; red(s):// works everywhere as an
+    // http(s)://host:5055 alias (normalizeUrl) so it's not advertised separately.
     if (t.includes('http') || t.includes('https')) schemes.push('http(s)://')
-    if (t.includes('tcp') || t.includes('tls')) schemes.push('red(s)://')
     if (t.includes('unix')) schemes.push('file://')
     return schemes.join(' · ')
   })

--- a/packages/ui/src/lib/LiveChanges.svelte
+++ b/packages/ui/src/lib/LiveChanges.svelte
@@ -31,8 +31,14 @@
     }
     const cdc = new CDCStreamClient({
       client,
-      // No EventSource probe wired yet; reddb's SSE endpoint is in flight, so
-      // force REST polling. When the server ships SSE this becomes:
+      // CDC is poll-only on reddb today: the server exposes `GET /changes`
+      // (handlers_backup.rs / routing.rs) and there is NO `/changes/stream` SSE
+      // route (verified against ../reddb 2026-06-01). Polling `GET /changes` is
+      // therefore the optimal — and only — live-changes transport for every
+      // Surface. The CDCStreamClient keeps full SSE plumbing dormant for a
+      // hypothetical future server push endpoint; do NOT enable it until reddb
+      // actually ships `/changes/stream`, or every subscription 404s. When it
+      // lands this becomes:
       //   sseFactory: (url) => new EventSource(url),
       //   sseProbe: async () => (await fetch(url, { method: 'HEAD' })).ok,
       sseFactory: null,

--- a/packages/ui/src/lib/QueryEditor.svelte
+++ b/packages/ui/src/lib/QueryEditor.svelte
@@ -107,6 +107,11 @@
         Run a query to see results here.
       </div>
     {:else}
+      {#if qs.result.truncated}
+        <div class="px-3 py-1.5 border-b border-line-1 bg-bg-1 text-[11px] font-mono text-fg-3">
+          Streamed first {qs.result.record_count.toLocaleString()} rows — more remain on the server. Add a <span class="text-fg-2">LIMIT</span> to narrow.
+        </div>
+      {/if}
       {@const renderer = pickRenderer()}
       {#if renderer}
         {@const Renderer = renderer.component}

--- a/packages/ui/src/lib/StatusBar.svelte
+++ b/packages/ui/src/lib/StatusBar.svelte
@@ -3,6 +3,9 @@
   import { connection } from './connections.svelte'
   import { pendingChanges } from './pending-changes.svelte'
   import { ArrowRight, FilePenLine, Lock } from 'lucide-svelte'
+  import { readBuildInfo } from './build-info'
+
+  const build = readBuildInfo()
 
   const router = useRouter()
   const pendingCount = $derived(pendingChanges.count)
@@ -150,4 +153,11 @@
       <ArrowRight class="size-3" />
     </button>
   {/if}
+
+  <span
+    class="inline-flex items-center px-3 shrink-0 font-mono text-fg-3 border-l border-line-1 select-none"
+    title={`red-ui ${build.version} · ${build.gitSha} · built ${build.buildTime}`}
+  >
+    v{build.version}
+  </span>
 </div>

--- a/packages/ui/src/lib/Workspace.svelte
+++ b/packages/ui/src/lib/Workspace.svelte
@@ -16,7 +16,7 @@
   import ClusterView from './ClusterView.svelte'
   import SecurityView from './SecurityView.svelte'
   import { connection, setConnectionProvider } from './connections.svelte'
-  import type { ConnectionProvider } from '#reddb'
+  import { runQueryPreferStream, type ConnectionProvider } from '#reddb'
   import { theme, type Theme } from './theme.svelte'
   import { secureStore } from './secureStore.svelte'
   import { pendingChanges, buildUpdateSql, type CommitOutcome } from './pending-changes.svelte'
@@ -109,7 +109,7 @@
       queryTabs.setExecutor(null)
       return
     }
-    queryTabs.setExecutor((sql) => client.query(sql))
+    queryTabs.setExecutor((sql) => runQueryPreferStream(client, sql))
     pendingChanges.setExecutor(async (changes) =>
       Promise.all(
         changes.map(async (c): Promise<CommitOutcome> => {

--- a/packages/ui/src/lib/build-info.ts
+++ b/packages/ui/src/lib/build-info.ts
@@ -1,0 +1,41 @@
+// Single source of truth for "what version am I" across the Web/PWA, the
+// Embeddable Lib, and the Tauri desktop webview (which all run this same
+// bundle). Mirrors ../red-skills/src/packages/build-info: the version is
+// injected at build time by Vite `define` (see vite.config.ts /
+// vite.embed.config.ts) from `packages/ui/package.json` — overridable by the
+// `RED_BUILD_VERSION` env the release CI sets from the git tag. Falls back to
+// `0.0.0-dev` for an un-stamped local dev build.
+
+declare const __RED_UI_VERSION__: string | undefined;
+declare const __RED_UI_GIT_SHA__: string | undefined;
+declare const __RED_UI_BUILD_TIME__: string | undefined;
+
+export interface BuildInfo {
+  version: string;
+  gitSha: string;
+  buildTime: string;
+}
+
+function injected(read: () => string | undefined): string | undefined {
+  try {
+    const v = read();
+    return typeof v === "string" && v.length > 0 ? v : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function stripTagPrefix(v: string): string {
+  return v.startsWith("v") ? v.slice(1) : v;
+}
+
+export function readBuildInfo(): BuildInfo {
+  return {
+    version: stripTagPrefix(injected(() => __RED_UI_VERSION__) ?? "0.0.0-dev"),
+    gitSha: injected(() => __RED_UI_GIT_SHA__) ?? "unknown",
+    buildTime: injected(() => __RED_UI_BUILD_TIME__) ?? "unknown",
+  };
+}
+
+/** The resolved app version, e.g. `0.1.1` (or `0.0.0-dev` un-stamped). */
+export const RED_UI_VERSION: string = readBuildInfo().version;

--- a/packages/ui/src/lib/embed/index.ts
+++ b/packages/ui/src/lib/embed/index.ts
@@ -2,6 +2,10 @@ import appCss from "../../app.css?inline";
 import type { Component } from "svelte";
 import type { ConnectionProvider } from "../reddb";
 import type { Theme } from "../theme.svelte";
+import { RED_UI_VERSION, readBuildInfo } from "../build-info";
+
+/** Build version of the embeddable bundle, stamped at build time. */
+export { RED_UI_VERSION, readBuildInfo };
 
 declare global {
   interface Window {
@@ -181,6 +185,13 @@ export class RedUiElement extends HTMLElement {
   #handle: RedUiEmbedHandle | null = null;
   #mounting: Promise<void> | null = null;
 
+  /** Build version of the embedded bundle (also reflected as a `version`
+   *  attribute on connect, so a host can read `el.getAttribute('version')`). */
+  static readonly version = RED_UI_VERSION;
+  get version(): string {
+    return RED_UI_VERSION;
+  }
+
   get connectionProvider(): ConnectionProvider | null {
     return this.#connectionProvider;
   }
@@ -191,6 +202,8 @@ export class RedUiElement extends HTMLElement {
   }
 
   connectedCallback() {
+    if (!this.hasAttribute("version"))
+      this.setAttribute("version", RED_UI_VERSION);
     this.#mounting ??= this.#mount();
   }
 

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -1,3 +1,4 @@
+export { RED_UI_VERSION, readBuildInfo, type BuildInfo } from "./build-info";
 export { default as ActivityIndicator } from "./ActivityIndicator.svelte";
 export { default as ClusterNode } from "./ClusterNode.svelte";
 export { default as ClusterView } from "./ClusterView.svelte";

--- a/packages/ui/src/lib/reddb/client.ts
+++ b/packages/ui/src/lib/reddb/client.ts
@@ -33,6 +33,25 @@ export interface QueryResult {
   record_count: number;
   result: { columns: string[]; records: QueryRow[] };
   error?: string;
+  /** True when this result was assembled from the NDJSON streaming endpoint
+   *  (`POST /query/stream`) rather than the buffered `POST /query`. */
+  streamed?: boolean;
+  /** True when streaming stopped at `maxRows` and more rows remained on the
+   *  server (the cursor was cancelled). Surfaced so the UI never silently
+   *  drops rows. */
+  truncated?: boolean;
+}
+
+/** Result of collecting a read-only SELECT over the NDJSON streaming endpoint. */
+export interface StreamedQueryResult {
+  columns: string[];
+  schemaFingerprint?: string;
+  rows: Array<Record<string, unknown>>;
+  rowCount: number;
+  /** Hit the `maxRows` cap with more rows still on the server. */
+  truncated: boolean;
+  /** Opaque resume token from the `cursor` frame, if one was emitted. */
+  cursor?: string;
 }
 
 export interface CollectionMetadata {
@@ -261,6 +280,79 @@ function unsupportedCollectionMetadataError(baseUrl: string): Error {
   );
 }
 
+/** One NDJSON frame from `POST /query/stream`. Discriminated by its single key. */
+type NdjsonFrame =
+  | { descriptor: { columns: string[]; schema_fingerprint?: string } }
+  | { cursor: { token: string; snapshot_lsn?: number; resumable?: boolean } }
+  | { row: Record<string, unknown> }
+  | { end: { row_count?: number } }
+  | { cancelled: Record<string, unknown> };
+
+/**
+ * Parse a chunked `application/x-ndjson` body into one frame per line. Buffers
+ * across chunk boundaries (a JSON object split over two TCP reads is emitted
+ * exactly once, in order) and flushes a trailing newline-less line at EOF.
+ */
+async function* parseNdjsonFrames(
+  body: ReadableStream<Uint8Array>
+): AsyncGenerator<NdjsonFrame> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      let nl: number;
+      while ((nl = buf.indexOf("\n")) !== -1) {
+        const line = buf.slice(0, nl).trim();
+        buf = buf.slice(nl + 1);
+        if (line) yield JSON.parse(line) as NdjsonFrame;
+      }
+    }
+    const tail = buf.trim();
+    if (tail) yield JSON.parse(tail) as NdjsonFrame;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+const SELECT_RE = /^\s*select\b/i;
+
+/**
+ * Run a query, preferring the bounded-memory NDJSON stream for a plain SELECT
+ * and falling back to the buffered `POST /query` for everything else — and for
+ * any streaming failure (network, a non-SELECT 400, or an older server with no
+ * `/query/stream` route returning 404). The fallback makes this strictly safe:
+ * behaviour is identical to {@link RedClient.query} unless the server supports
+ * streaming AND the statement is a SELECT, in which case the server streams
+ * rows instead of buffering the whole result set.
+ */
+export async function runQueryPreferStream(
+  client: Pick<RedClient, "query" | "queryStreamCollect">,
+  sql: string,
+  opts: { maxRows?: number; signal?: AbortSignal } = {}
+): Promise<QueryResult> {
+  if (!SELECT_RE.test(sql)) return client.query(sql);
+  try {
+    const s = await client.queryStreamCollect(sql, opts);
+    return {
+      ok: true,
+      query: sql,
+      record_count: s.rowCount,
+      result: {
+        columns: s.columns,
+        records: s.rows.map((values) => ({ values })),
+      },
+      streamed: true,
+      truncated: s.truncated,
+    };
+  } catch {
+    return client.query(sql);
+  }
+}
+
 export class RedClient {
   readonly baseUrl: string;
   private readonly headers: HeadersInit | undefined;
@@ -410,6 +502,85 @@ export class RedClient {
       method: "POST",
       body: JSON.stringify({ query }),
     });
+  }
+
+  /**
+   * Stream a read-only SELECT through `POST /query/stream` (NDJSON, chunked).
+   * The server emits rows through a bounded-memory channel — it never buffers
+   * the whole result — and we collect up to `maxRows` (default 10 000) before
+   * cancelling the server cursor. The NDJSON frame order is fixed
+   * (`descriptor` → `cursor` → `row`* → `end`|`cancelled`), verified against
+   * ../reddb/docs/api/query-streaming.md.
+   *
+   * Throws for a non-SELECT (server `400 stream_unsupported_statement`) and for
+   * an absent route on an older server (`404`) — callers fall back to
+   * {@link query}. Browser-reachable: this is `fetch` + `ReadableStream`, not
+   * `EventSource` (the endpoint is POST-based).
+   */
+  async queryStreamCollect(
+    query: string,
+    opts: { maxRows?: number; signal?: AbortSignal } = {}
+  ): Promise<StreamedQueryResult> {
+    const maxRows = opts.maxRows ?? 10_000;
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "application/x-ndjson",
+    };
+    Object.assign(headers, this.headers as Record<string, string> | undefined);
+
+    const res = await this.fetcher(`${this.baseUrl}/query/stream`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ query }),
+      signal: opts.signal,
+    });
+    if (!res.ok || !res.body) {
+      const body = res.body ? await res.text().catch(() => "") : "";
+      throw new Error(
+        `POST /query/stream → ${res.status} ${body.slice(0, 200)}`
+      );
+    }
+
+    const out: StreamedQueryResult = {
+      columns: [],
+      rows: [],
+      rowCount: 0,
+      truncated: false,
+    };
+
+    for await (const frame of parseNdjsonFrames(res.body)) {
+      if ("descriptor" in frame) {
+        out.columns = frame.descriptor.columns ?? [];
+        out.schemaFingerprint = frame.descriptor.schema_fingerprint;
+      } else if ("cursor" in frame) {
+        out.cursor = frame.cursor.token;
+      } else if ("row" in frame) {
+        if (out.rows.length >= maxRows) {
+          out.truncated = true;
+          break;
+        }
+        out.rows.push(frame.row);
+        out.rowCount = out.rows.length;
+      } else if ("end" in frame || "cancelled" in frame) {
+        break;
+      }
+    }
+
+    // We stopped early with more rows on the server — release the pinned cursor.
+    if (out.truncated && out.cursor) {
+      await this.cancelQueryStream(out.cursor).catch(() => {
+        // best-effort: the cursor TTL reclaims it anyway.
+      });
+    }
+    return out;
+  }
+
+  /** Cancel a streaming-query cursor server-side (`POST /query/stream/cancel`). */
+  async cancelQueryStream(cursor: string): Promise<void> {
+    await this.json("/query/stream/cancel", {
+      method: "POST",
+      body: JSON.stringify({ cursor }),
+    }).catch(() => undefined);
   }
 
   async collectionVcs(name: string): Promise<CollectionVcsState> {

--- a/packages/ui/src/lib/reddb/query-stream.test.ts
+++ b/packages/ui/src/lib/reddb/query-stream.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from "vitest";
+import { RedClient, runQueryPreferStream } from "./client";
+
+// Build a fake Response whose body is a ReadableStream of the given chunks,
+// so we can exercise the NDJSON frame parser across arbitrary chunk splits.
+function ndjsonResponse(chunks: string[], status = 200): Response {
+  const enc = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      for (const ch of chunks) c.enqueue(enc.encode(ch));
+      c.close();
+    },
+  });
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    body: status >= 200 && status < 300 ? stream : null,
+    text: async () => "",
+  } as unknown as Response;
+}
+
+const DESCRIPTOR =
+  '{"descriptor":{"columns":["id","name"],"schema_fingerprint":"abc"}}\n';
+const CURSOR =
+  '{"cursor":{"token":"deadbeef","snapshot_lsn":42,"resumable":true}}\n';
+
+describe("queryStreamCollect", () => {
+  it("collects descriptor + rows + end into a StreamedQueryResult", async () => {
+    const fetch = vi.fn(async (_url: RequestInfo | URL) =>
+      ndjsonResponse([
+        DESCRIPTOR,
+        CURSOR,
+        '{"row":{"id":1,"name":"alice"}}\n',
+        '{"row":{"id":2,"name":"bob"}}\n',
+        '{"end":{"row_count":2}}\n',
+      ])
+    );
+    const client = new RedClient("http://h:5055", { fetch });
+    const r = await client.queryStreamCollect("SELECT * FROM users");
+
+    expect(r.columns).toEqual(["id", "name"]);
+    expect(r.schemaFingerprint).toBe("abc");
+    expect(r.rows).toEqual([
+      { id: 1, name: "alice" },
+      { id: 2, name: "bob" },
+    ]);
+    expect(r.rowCount).toBe(2);
+    expect(r.truncated).toBe(false);
+    expect(String(fetch.mock.calls[0][0])).toBe("http://h:5055/query/stream");
+  });
+
+  it("reassembles a row JSON split across chunk boundaries", async () => {
+    const fetch = vi.fn(async () =>
+      ndjsonResponse([
+        DESCRIPTOR + '{"row":{"id":1,"na',
+        'me":"split"}}\n{"end":{"row_count":1}}\n',
+      ])
+    );
+    const client = new RedClient("http://h", { fetch });
+    const r = await client.queryStreamCollect("SELECT 1");
+    expect(r.rows).toEqual([{ id: 1, name: "split" }]);
+  });
+
+  it("flushes a trailing line with no newline at EOF", async () => {
+    const fetch = vi.fn(async () =>
+      ndjsonResponse([DESCRIPTOR + '{"row":{"id":9}}\n{"end":{"row_count":1}}'])
+    );
+    const client = new RedClient("http://h", { fetch });
+    const r = await client.queryStreamCollect("SELECT 1");
+    expect(r.rows).toEqual([{ id: 9 }]);
+  });
+
+  it("caps at maxRows, marks truncated, and cancels the server cursor", async () => {
+    const calls: string[] = [];
+    const fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      calls.push(url);
+      if (url.endsWith("/query/stream/cancel")) {
+        return {
+          ok: true,
+          status: 200,
+          body: null,
+          json: async () => ({ ok: true }),
+        } as unknown as Response;
+      }
+      return ndjsonResponse([
+        DESCRIPTOR,
+        CURSOR,
+        '{"row":{"id":1}}\n',
+        '{"row":{"id":2}}\n',
+        '{"row":{"id":3}}\n',
+        '{"end":{"row_count":3}}\n',
+      ]);
+    });
+    const client = new RedClient("http://h", { fetch });
+    const r = await client.queryStreamCollect("SELECT * FROM big", {
+      maxRows: 1,
+    });
+
+    expect(r.rows).toEqual([{ id: 1 }]);
+    expect(r.truncated).toBe(true);
+    expect(calls).toContain("http://h/query/stream/cancel");
+  });
+
+  it("throws on a non-ok response (e.g. 400 unsupported / 404 missing route)", async () => {
+    const fetch = vi.fn(async () => ndjsonResponse([], 400));
+    const client = new RedClient("http://h", { fetch });
+    await expect(client.queryStreamCollect("UPDATE x SET y=1")).rejects.toThrow(
+      /\/query\/stream → 400/
+    );
+  });
+});
+
+describe("runQueryPreferStream", () => {
+  it("streams a SELECT and assembles a QueryResult (streamed flag set)", async () => {
+    const client = {
+      query: vi.fn(),
+      queryStreamCollect: vi.fn(async () => ({
+        columns: ["id"],
+        rows: [{ id: 1 }, { id: 2 }],
+        rowCount: 2,
+        truncated: false,
+      })),
+    };
+    const r = await runQueryPreferStream(client, "SELECT * FROM t");
+    expect(client.queryStreamCollect).toHaveBeenCalledOnce();
+    expect(client.query).not.toHaveBeenCalled();
+    expect(r.streamed).toBe(true);
+    expect(r.record_count).toBe(2);
+    expect(r.result.records).toEqual([
+      { values: { id: 1 } },
+      { values: { id: 2 } },
+    ]);
+  });
+
+  it("propagates truncated through to the QueryResult", async () => {
+    const client = {
+      query: vi.fn(),
+      queryStreamCollect: vi.fn(async () => ({
+        columns: ["id"],
+        rows: [{ id: 1 }],
+        rowCount: 1,
+        truncated: true,
+      })),
+    };
+    const r = await runQueryPreferStream(client, "select * from t", {
+      maxRows: 1,
+    });
+    expect(r.truncated).toBe(true);
+  });
+
+  it("does NOT stream a non-SELECT — goes straight to buffered query()", async () => {
+    const buffered = {
+      ok: true,
+      query: "x",
+      record_count: 0,
+      result: { columns: [], records: [] },
+    };
+    const client = {
+      query: vi.fn(async () => buffered),
+      queryStreamCollect: vi.fn(),
+    };
+    const r = await runQueryPreferStream(client, "INSERT INTO t VALUES (1)");
+    expect(client.queryStreamCollect).not.toHaveBeenCalled();
+    expect(client.query).toHaveBeenCalledWith("INSERT INTO t VALUES (1)");
+    expect(r).toBe(buffered);
+  });
+
+  it("falls back to buffered query() when streaming fails (older server / 404)", async () => {
+    const buffered = {
+      ok: true,
+      query: "x",
+      record_count: 0,
+      result: { columns: [], records: [] },
+    };
+    const client = {
+      query: vi.fn(async () => buffered),
+      queryStreamCollect: vi.fn(async () => {
+        throw new Error("POST /query/stream → 404");
+      }),
+    };
+    const r = await runQueryPreferStream(client, "SELECT * FROM t");
+    expect(client.queryStreamCollect).toHaveBeenCalledOnce();
+    expect(client.query).toHaveBeenCalledWith("SELECT * FROM t");
+    expect(r).toBe(buffered);
+  });
+});

--- a/packages/ui/src/lib/reddb/transports.test.ts
+++ b/packages/ui/src/lib/reddb/transports.test.ts
@@ -1,58 +1,74 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it } from "vitest";
 import {
   BROWSER_TRANSPORTS,
   DESKTOP_TRANSPORTS,
   isUrlReachable,
   transportForUrl,
-} from './transports'
-import { LocalUrlProvider } from './local-url-provider'
+} from "./transports";
+import { LocalUrlProvider } from "./local-url-provider";
 
-describe('transportForUrl', () => {
-  it('maps known schemes to wire transports', () => {
-    expect(transportForUrl('http://h:5055')).toBe('http')
-    expect(transportForUrl('https://h')).toBe('https')
-    expect(transportForUrl('red://localhost')).toBe('tcp')
-    expect(transportForUrl('reds://localhost')).toBe('tls')
-    expect(transportForUrl('red+unix:///var/run/red.sock')).toBe('unix')
-    expect(transportForUrl('file:///data/app.redb')).toBe('unix')
-  })
+describe("transportForUrl", () => {
+  it("maps known schemes to wire transports", () => {
+    expect(transportForUrl("http://h:5055")).toBe("http");
+    expect(transportForUrl("https://h")).toBe("https");
+    // red:///reds:// are sugar for http(s)://host:5055 (normalizeUrl), so they
+    // classify as their coerced http(s) transport — not a native tcp/tls one.
+    expect(transportForUrl("red://localhost")).toBe("http");
+    expect(transportForUrl("reds://localhost")).toBe("https");
+    expect(transportForUrl("red+unix:///var/run/red.sock")).toBe("unix");
+    expect(transportForUrl("file:///data/app.redb")).toBe("unix");
+  });
 
-  it('treats a bare host:port as http (normalizeUrl prepends it)', () => {
-    expect(transportForUrl('localhost:5055')).toBe('http')
-  })
+  it("treats a bare host:port as http (normalizeUrl prepends it)", () => {
+    expect(transportForUrl("localhost:5055")).toBe("http");
+  });
 
-  it('returns null for an unrecognised scheme and empty input', () => {
-    expect(transportForUrl('ftp://h')).toBeNull()
-    expect(transportForUrl('   ')).toBeNull()
-  })
-})
+  it("returns null for an unrecognised scheme and empty input", () => {
+    expect(transportForUrl("ftp://h")).toBeNull();
+    expect(transportForUrl("   ")).toBeNull();
+  });
+});
 
-describe('isUrlReachable', () => {
-  it('a browser Surface reaches http(s) and coerced red:// but not unix/file', () => {
-    expect(isUrlReachable('http://h', BROWSER_TRANSPORTS)).toBe(true)
-    expect(isUrlReachable('red://localhost', BROWSER_TRANSPORTS)).toBe(true) // coerced tunnel
-    expect(isUrlReachable('file:///data/app.redb', BROWSER_TRANSPORTS)).toBe(false)
-    expect(isUrlReachable('red+unix:///s.sock', BROWSER_TRANSPORTS)).toBe(false)
-  })
+describe("isUrlReachable", () => {
+  it("a browser Surface advertises http(s) only (ADR-0003)", () => {
+    // No distinct native red(s):// or file:// transport in a browser.
+    expect([...BROWSER_TRANSPORTS]).toEqual(["http", "https"]);
+  });
 
-  it('a desktop Surface additionally reaches unix/file', () => {
-    expect(isUrlReachable('file:///data/app.redb', DESKTOP_TRANSPORTS)).toBe(true)
-    expect(isUrlReachable('red+unix:///s.sock', DESKTOP_TRANSPORTS)).toBe(true)
-  })
+  it("a browser Surface reaches http(s) and coerced red:// but not unix/file", () => {
+    expect(isUrlReachable("http://h", BROWSER_TRANSPORTS)).toBe(true);
+    expect(isUrlReachable("red://localhost", BROWSER_TRANSPORTS)).toBe(true); // coerced tunnel → http
+    expect(isUrlReachable("reds://localhost", BROWSER_TRANSPORTS)).toBe(true); // coerced tunnel → https
+    expect(isUrlReachable("file:///data/app.redb", BROWSER_TRANSPORTS)).toBe(
+      false
+    );
+    expect(isUrlReachable("red+unix:///s.sock", BROWSER_TRANSPORTS)).toBe(
+      false
+    );
+  });
 
-  it('an unrecognised scheme is never reachable', () => {
-    expect(isUrlReachable('ftp://h', DESKTOP_TRANSPORTS)).toBe(false)
-  })
-})
+  it("a desktop Surface additionally reaches unix/file", () => {
+    expect(isUrlReachable("file:///data/app.redb", DESKTOP_TRANSPORTS)).toBe(
+      true
+    );
+    expect(isUrlReachable("red+unix:///s.sock", DESKTOP_TRANSPORTS)).toBe(true);
+  });
 
-describe('LocalUrlProvider.transports', () => {
-  it('defaults to the browser-reachable set', () => {
-    expect(new LocalUrlProvider().transports()).toEqual([...BROWSER_TRANSPORTS])
-  })
+  it("an unrecognised scheme is never reachable", () => {
+    expect(isUrlReachable("ftp://h", DESKTOP_TRANSPORTS)).toBe(false);
+  });
+});
 
-  it('honours an injected Surface transport set (Tauri)', () => {
-    const p = new LocalUrlProvider({ transports: [...DESKTOP_TRANSPORTS] })
-    expect(p.transports()).toEqual([...DESKTOP_TRANSPORTS])
-    expect(p.transports()).not.toBe(p.transports()) // returns a copy, not the internal array
-  })
-})
+describe("LocalUrlProvider.transports", () => {
+  it("defaults to the browser-reachable set", () => {
+    expect(new LocalUrlProvider().transports()).toEqual([
+      ...BROWSER_TRANSPORTS,
+    ]);
+  });
+
+  it("honours an injected Surface transport set (Tauri)", () => {
+    const p = new LocalUrlProvider({ transports: [...DESKTOP_TRANSPORTS] });
+    expect(p.transports()).toEqual([...DESKTOP_TRANSPORTS]);
+    expect(p.transports()).not.toBe(p.transports()); // returns a copy, not the internal array
+  });
+});

--- a/packages/ui/src/lib/reddb/transports.ts
+++ b/packages/ui/src/lib/reddb/transports.ts
@@ -1,29 +1,50 @@
-// Transport reachability (#34, ADR-0003). Which wire transports a connection
-// can actually use is a property of the *Surface*, not the Core: a browser can
-// only speak http(s) (and red:// coerced onto http — see normalizeUrl), while a
-// Tauri Surface can additionally open native TCP/TLS and unix-socket / embedded
-// files. The Connect UI offers only the transports the active provider declares
-// reachable, so the user never picks an option that fails with a transport
-// error. This module is the pure scheme↔transport mapping + reachability sets;
-// the provider declares its set and the UI consults it.
+// Transport reachability (#34, ADR-0003). Which transports a connection can use
+// is bounded by what the *red-ui client* speaks — NOT by the browser, and NOT by
+// what the reddb server exposes. reddb itself offers many wire transports (HTTP
+// + SSE/NDJSON, RedWire on :5050, gRPC, Postgres-wire, and a WebSocket ingest
+// endpoint `WS /ws/ingest/{collection}` — see ../reddb/docs/api/). The red-ui
+// client, however, currently speaks only HTTP: RedClient is fetch-based (REST),
+// and live changes use SSE/REST polling over the same http(s) connection. So the
+// Connect UI offers http(s) only because that is the client's surface today — a
+// `ws`/`wss` (or `grpc`) transport belongs here only once the client actually
+// consumes reddb's WebSocket/gRPC endpoint, not before (that would be a phantom
+// option that fails when picked).
+//
+// `red://`/`reds://` are not distinct client transports either: normalizeUrl
+// rewrites them to `http(s)://host:5055` (the documented `red://localhost`
+// production tunnel — red-ui's HTTP convention, distinct from reddb's native
+// RedWire on :5050), so they classify as their coerced http(s) transport and are
+// reachable wherever http(s) is. Streaming rides over the http(s) connection, so
+// it needs no separate transport member. Only unix-socket / embedded-file
+// connections are reachable solely from a Tauri Surface, so those are the ones a
+// browser Surface hides. The Connect UI offers only the transports the active
+// provider declares reachable, so the user never picks one that fails. This
+// module is the pure scheme↔transport mapping + reachability sets; the provider
+// declares its set and the UI consults it.
 
-import type { Transport } from './types'
+import type { Transport } from "./types";
 
-/** User-typed connection-string scheme → wire transport. */
+/**
+ * User-typed connection-string scheme → the wire transport it resolves to.
+ * `red`/`reds` (and their `red+tcp`/`red+wire`/`red+tls` aliases) are sugar for
+ * `http(s)://host:5055` via normalizeUrl, so they map to `http`/`https` — they
+ * carry no distinct wire transport in any Surface today. Native tcp/tls remains
+ * a possible future Desktop capability (ADR-0003) but is not materialized yet.
+ */
 const SCHEME_TRANSPORT: Record<string, Transport> = {
-  http: 'http',
-  https: 'https',
-  red: 'tcp',
-  'red+tcp': 'tcp',
-  'red+wire': 'tcp',
-  reds: 'tls',
-  'red+tls': 'tls',
-  'red+unix': 'unix',
-  file: 'unix',
-  unix: 'unix',
-  'red+http': 'http',
-  'red+https': 'https',
-}
+  http: "http",
+  https: "https",
+  red: "http",
+  "red+tcp": "http",
+  "red+wire": "http",
+  reds: "https",
+  "red+tls": "https",
+  "red+http": "http",
+  "red+https": "https",
+  "red+unix": "unix",
+  file: "unix",
+  unix: "unix",
+};
 
 /**
  * The transport a user-typed connection string would use. Defaults to `http`
@@ -31,30 +52,38 @@ const SCHEME_TRANSPORT: Record<string, Transport> = {
  * Returns `null` for a scheme this client doesn't recognise at all.
  */
 export function transportForUrl(input: string): Transport | null {
-  const raw = input.trim()
-  if (!raw) return null
-  const m = raw.match(/^([a-z+]+):\/\//i)
-  if (!m) return 'http' // bare host:port → http (normalizeUrl prepends it)
-  return SCHEME_TRANSPORT[m[1].toLowerCase()] ?? null
+  const raw = input.trim();
+  if (!raw) return null;
+  const m = raw.match(/^([a-z+]+):\/\//i);
+  if (!m) return "http"; // bare host:port → http (normalizeUrl prepends it)
+  return SCHEME_TRANSPORT[m[1].toLowerCase()] ?? null;
 }
 
 /**
- * Browser-reachable transports. http/https are native; tcp/tls are reachable
- * because the UI coerces `red://`/`reds://` onto http(s) at :5055
- * (normalizeUrl — the documented `red://localhost` production tunnel). Only
- * unix-socket / embedded-file connections are genuinely unreachable from a
- * browser, so those are the ones the browser Surface hides.
+ * Browser-reachable transports: `http`/`https` only (ADR-0003). `red://`/`reds://`
+ * are still reachable here because they coerce to `http(s)://host:5055` and so
+ * classify as `http`/`https` — the documented `red://localhost` production
+ * tunnel keeps working — but the browser advertises no distinct red(s):// or
+ * file:// transport. Unix-socket / embedded-file connections are genuinely
+ * unreachable from a browser and are hidden.
  */
-export const BROWSER_TRANSPORTS: readonly Transport[] = ['http', 'https', 'tcp', 'tls']
+export const BROWSER_TRANSPORTS: readonly Transport[] = ["http", "https"];
 
-/** A Tauri Surface adds native unix-socket / embedded-file connections. */
-export const DESKTOP_TRANSPORTS: readonly Transport[] = ['http', 'https', 'tcp', 'tls', 'unix']
+/** A Tauri Surface adds the native unix-socket / embedded-file transport. */
+export const DESKTOP_TRANSPORTS: readonly Transport[] = [
+  "http",
+  "https",
+  "unix",
+];
 
 /**
  * Whether a user-typed URL's transport is reachable from a provider that
  * declares `supported`. An unrecognised scheme is never reachable.
  */
-export function isUrlReachable(input: string, supported: readonly Transport[]): boolean {
-  const t = transportForUrl(input)
-  return t !== null && supported.includes(t)
+export function isUrlReachable(
+  input: string,
+  supported: readonly Transport[]
+): boolean {
+  const t = transportForUrl(input);
+  return t !== null && supported.includes(t);
 }

--- a/packages/ui/version.config.ts
+++ b/packages/ui/version.config.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Build-time version stamp shared by the SvelteKit (PWA/desktop) build and the
+// Embeddable Lib build. Source of truth: packages/ui/package.json `version`
+// (changeset-managed, version-locked with ui-kit/ui-mcp), overridable by the
+// `RED_BUILD_VERSION` env the release CI sets from the git tag. Mirrors the
+// ../red-skills build-info pattern. Consumed by src/lib/build-info.ts.
+export function versionDefines(): Record<string, string> {
+  const here = dirname(fileURLToPath(import.meta.url));
+  let pkgVersion = "0.0.0-dev";
+  try {
+    pkgVersion =
+      JSON.parse(readFileSync(join(here, "package.json"), "utf8")).version ??
+      pkgVersion;
+  } catch {
+    // fall through to the dev default
+  }
+  const version = (process.env.RED_BUILD_VERSION || pkgVersion).replace(
+    /^v/,
+    ""
+  );
+  return {
+    __RED_UI_VERSION__: JSON.stringify(version),
+    __RED_UI_GIT_SHA__: JSON.stringify(
+      process.env.RED_BUILD_GIT_SHA || "unknown"
+    ),
+    __RED_UI_BUILD_TIME__: JSON.stringify(
+      process.env.RED_BUILD_TIME || "unknown"
+    ),
+  };
+}

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -1,13 +1,15 @@
-import { sveltekit } from '@sveltejs/kit/vite'
-import tailwindcss from '@tailwindcss/vite'
-import { defineConfig } from 'vite'
+import { sveltekit } from "@sveltejs/kit/vite";
+import tailwindcss from "@tailwindcss/vite";
+import { defineConfig } from "vite";
+import { versionDefines } from "./version.config";
 
 export default defineConfig({
   plugins: [tailwindcss(), sveltekit()],
+  define: versionDefines(),
   clearScreen: false,
   server: {
     port: 1420,
     strictPort: true,
-    watch: { ignored: ['**/src-tauri/**'] },
+    watch: { ignored: ["**/src-tauri/**"] },
   },
-})
+});

--- a/packages/ui/vite.embed.config.ts
+++ b/packages/ui/vite.embed.config.ts
@@ -2,12 +2,14 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 import tailwindcss from "@tailwindcss/vite";
 import { resolve } from "node:path";
 import { defineConfig } from "vite";
+import { versionDefines } from "./version.config";
 
 export default defineConfig({
   plugins: [
     tailwindcss(),
     svelte({ hot: false, compilerOptions: { css: "injected" } }),
   ],
+  define: versionDefines(),
   resolve: {
     alias: {
       "#reddb": resolve(__dirname, "src/lib/reddb/index.ts"),

--- a/scripts/sync-desktop-version.mjs
+++ b/scripts/sync-desktop-version.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Propagate the changeset-managed npm version (packages/ui/package.json, the
+// version-locked source of truth for @reddb-io/ui + ui-kit + ui-mcp) into the
+// Tauri desktop app, which lives outside the npm `fixed` group and would
+// otherwise drift. Run from `release:version` after `changeset version`, and
+// safe to run anytime (idempotent). Keeps tauri.conf.json, Cargo.toml, and the
+// desktop package.json all reporting the same version as the npm artifacts, so
+// the desktop binary/installer/updater version matches the bundle it ships.
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const version = JSON.parse(
+  readFileSync(join(root, "packages/ui/package.json"), "utf8")
+).version;
+if (!version) {
+  console.error("sync-desktop-version: no version in packages/ui/package.json");
+  process.exit(1);
+}
+
+const edits = [];
+
+// tauri.conf.json — top-level "version"
+{
+  const path = join(root, "apps/desktop/src-tauri/tauri.conf.json");
+  const conf = JSON.parse(readFileSync(path, "utf8"));
+  if (conf.version !== version) {
+    conf.version = version;
+    writeFileSync(path, JSON.stringify(conf, null, 2) + "\n");
+    edits.push(`tauri.conf.json → ${version}`);
+  }
+}
+
+// apps/desktop/package.json — "version"
+{
+  const path = join(root, "apps/desktop/package.json");
+  const pkg = JSON.parse(readFileSync(path, "utf8"));
+  if (pkg.version !== version) {
+    pkg.version = version;
+    writeFileSync(path, JSON.stringify(pkg, null, 2) + "\n");
+    edits.push(`apps/desktop/package.json → ${version}`);
+  }
+}
+
+// Cargo.toml — the [package] version line only (never a dependency's version).
+{
+  const path = join(root, "apps/desktop/src-tauri/Cargo.toml");
+  const toml = readFileSync(path, "utf8");
+  const updated = toml.replace(
+    /(\[package\][\s\S]*?\nversion\s*=\s*")[^"]*(")/,
+    `$1${version}$2`
+  );
+  if (updated !== toml) {
+    writeFileSync(path, updated);
+    edits.push(`Cargo.toml → ${version}`);
+  }
+}
+
+if (edits.length === 0) {
+  console.log(`sync-desktop-version: desktop already at ${version}`);
+} else {
+  console.log(`sync-desktop-version: ${edits.join(", ")}`);
+}


### PR DESCRIPTION
Lands the branch built across this session:

- **fix(ui)** honest transport model + reddb transport matrix (#34) — `red://`=http(s) alias, browser advertises http(s) only; ADR-0003 enriched.
- **feat(ui)** stream large SELECTs via `POST /query/stream` (NDJSON) with full fallback to buffered `/query`.
- **feat** each artifact (PWA/embed, mcp.mjs, desktop) reports its own version (build-info pattern; desktop synced via script).
- **ci** harvest reddb build patterns — sccache + mold + pinned toolchain + shared cache, concurrency, path/draft filters, npm job on Blacksmith, composite for Tauri deps.
- **docs** ADR-0006 — MCP local-file spawns `red server`; remote connects direct (sliced into #47–#51).
- **chore** RedSkills statusline wired.

Gates: svelte-check 0 errors · 310 tests · mcp smoke green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782996122&installation_id=129708444&pr_number=52&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F52&signature=cc374a5e1693cc6f94f98803fd76b65bfcd404cf80235f5b0fc5ebee553bfce5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added build metadata (version, git SHA, build time) to the status bar with tooltip display
  * Implemented streaming query support with truncation detection showing row counts
  * Added inline notice for queries exceeding result limits with guidance to add `LIMIT`

* **Improvements**
  * Updated transport reachability to properly advertise HTTP(S)-only support in browsers
  * Enhanced build version stamping across desktop and server applications

* **Documentation**
  * Added architecture decisions on transport capabilities per surface and MCP local file server handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->