### PR TITLE
feat(mcp): remote vs local target mode detection (#47)

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -20,7 +20,7 @@
     "prepack": "pnpm build",
     "build": "tsc -p tsconfig.json",
     "check": "tsc -p tsconfig.json --noEmit",
-    "test": "pnpm build && node test/mcp-app-smoke.mjs",
+    "test": "pnpm build && node test/mcp-app-smoke.mjs && node test/target-mode.test.mjs",
     "start": "tsx src/index.ts --stdio"
   },
   "dependencies": {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -11,6 +11,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { z } from "zod/v4";
+import { classifyTarget } from "./target-mode.js";
 
 // Single source of truth for "what version am I": the package.json version
 // (changeset-managed, version-locked with @reddb-io/ui + ui-kit), overridable by
@@ -413,6 +414,32 @@ function createServer(config: ServerConfig): McpServer {
     },
     async ({ connectionUrl, view }) => {
       const selectedView: RedUiView = view ?? "query";
+      const mode = classifyTarget(connectionUrl);
+
+      // Local-file targets (#47, ADR-0006): the browser Surface cannot reach a
+      // filesystem path, so it is routed to the local handler seam rather than
+      // seeded as `?cs=`. Serving a local `.rdb` requires spawning a local
+      // `red server` (issue #48), which is not implemented yet — return a clear
+      // message and seed no connection.
+      if (mode === "local") {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `red-ui cannot open the local file "${connectionUrl}" yet: local-file mode (a local red server in front of the file, ADR-0006 / #48) is not implemented. Point at an http(s):// or red:// server, or wait for #48.`,
+            },
+          ],
+          structuredContent: {
+            appUrl: config.appUrl,
+            connectionUrl: "",
+            view: selectedView,
+            mode,
+          },
+        };
+      }
+
+      // Remote target: hand the URL to the browser via the Open Contract; no
+      // process is spawned.
       return {
         content: [
           {
@@ -424,6 +451,7 @@ function createServer(config: ServerConfig): McpServer {
           appUrl: config.appUrl,
           connectionUrl: connectionUrl ?? "",
           view: selectedView,
+          mode,
         },
       };
     }

--- a/packages/mcp/src/target-mode.ts
+++ b/packages/mcp/src/target-mode.ts
@@ -1,0 +1,38 @@
+// Target mode detection for the MCP App (#47, ADR-0006).
+//
+// The MCP can be asked to open red-ui against two kinds of target:
+//   - REMOTE: an http(s):// or red(s):// URL (or a bare host:port). The browser
+//     Surface fetches it directly via the Open Contract (`?cs=`); nothing is
+//     spawned.
+//   - LOCAL: a filesystem path / `file://` / a `*.rdb` file. A browser cannot
+//     reach a file, so this is routed to the local handler seam, which (per
+//     ADR-0006, issue #48) spawns a local `red server` in front of the file.
+//     Until #48 lands the seam returns a clear "not yet" message.
+//
+// This module is the pure classifier; the `open_red_ui` tool consults it.
+
+export type TargetMode = "remote" | "local";
+
+const SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+const RDB_RE = /\.rdb($|[?#])/i;
+const FS_PATH_RE = /^(\.\/|\.\.\/|\/|~\/?|[a-zA-Z]:[\\/])/;
+
+/**
+ * Classify a connection target. An empty/absent target is `remote` (a cold
+ * open / Connect screen — there is nothing local to serve). `file://` and
+ * filesystem paths (including a bare `*.rdb`) are `local`; every other URL
+ * scheme — `http(s)://`, `red(s)://`, `grpc://` — and a bare `host:port` are
+ * `remote`. `red://` is remote on purpose: it is browser-reachable as an
+ * http(s) alias (ADR-0003), not a local file.
+ */
+export function classifyTarget(target: string | undefined | null): TargetMode {
+  const t = (target ?? "").trim();
+  if (!t) return "remote";
+  if (/^file:\/\//i.test(t)) return "local";
+  // Any explicit URL scheme (http/https/red/reds/grpc/…) is a server endpoint.
+  if (SCHEME_RE.test(t)) return "remote";
+  // No scheme: a .rdb file or a filesystem-looking path is a local file.
+  if (RDB_RE.test(t) || FS_PATH_RE.test(t)) return "local";
+  // Bare host:port (or hostname) — normalizeUrl prepends http:// → remote.
+  return "remote";
+}

--- a/packages/mcp/test/target-mode.test.mjs
+++ b/packages/mcp/test/target-mode.test.mjs
@@ -1,0 +1,45 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const { classifyTarget } = await import(
+  join(packageDir, "dist/target-mode.js")
+);
+
+function assertEq(actual, expected, label) {
+  if (actual !== expected)
+    throw new Error(
+      `classifyTarget(${label}) = ${actual}, expected ${expected}`
+    );
+}
+
+// Remote: explicit server URLs and bare host:port.
+assertEq(classifyTarget("http://localhost:5055"), "remote", "http://");
+assertEq(classifyTarget("https://ui.example.com"), "remote", "https://");
+assertEq(classifyTarget("red://localhost"), "remote", "red:// (http(s) alias)");
+assertEq(classifyTarget("reds://host:5055"), "remote", "reds://");
+assertEq(classifyTarget("grpc://host:5055"), "remote", "grpc://");
+assertEq(classifyTarget("localhost:5055"), "remote", "bare host:port");
+assertEq(
+  classifyTarget("http://host/data.rdb"),
+  "remote",
+  "http URL serving .rdb"
+);
+
+// Remote: empty / absent → cold open, nothing local to serve.
+assertEq(classifyTarget(""), "remote", "empty");
+assertEq(classifyTarget(undefined), "remote", "undefined");
+assertEq(classifyTarget(null), "remote", "null");
+assertEq(classifyTarget("   "), "remote", "whitespace");
+
+// Local: file:// and filesystem paths / .rdb files (browser can't reach them).
+assertEq(classifyTarget("file:///data/app.rdb"), "local", "file://");
+assertEq(classifyTarget("./mydb.rdb"), "local", "./relative .rdb");
+assertEq(classifyTarget("../data/x.rdb"), "local", "../relative .rdb");
+assertEq(classifyTarget("/var/lib/reddb/data.rdb"), "local", "absolute .rdb");
+assertEq(classifyTarget("~/notes.rdb"), "local", "~ home path");
+assertEq(classifyTarget("memory.rdb"), "local", "bare .rdb filename");
+assertEq(classifyTarget("/etc/reddb/store"), "local", "absolute fs path");
+assertEq(classifyTarget("C:\\data\\app.rdb"), "local", "windows path");
+
+console.log("target-mode classifier test passed");


### PR DESCRIPTION
Implements #47 (ADR-0006). classifyTarget routes http(s)/red(s)/host:port → remote (Open Contract ?cs=, unchanged) and file://, filesystem paths, *.rdb → the local handler seam (clear 'needs #48' message, no ?cs=). No spawn for remote. Adds a classifier unit test wired into the mcp test script. Closes #47.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782997787&installation_id=129708444&pr_number=53&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F53&signature=7484dc23c8d0a444cf85bec7794675c5d13c475e93705bf4930b55370790145f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added target mode detection to classify connections as local or remote.
  * Local-file mode now indicates it's not yet implemented.
  * Remote connections continue operating with enhanced mode information included.

* **Tests**
  * Added comprehensive test coverage for target mode classification across various input formats.

* **Chores**
  * Updated test suite to run additional validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->