### PR TITLE
feat(mcp): open a local .rdb by spawning a red server (#48)

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -20,7 +20,7 @@
     "prepack": "pnpm build",
     "build": "tsc -p tsconfig.json",
     "check": "tsc -p tsconfig.json --noEmit",
-    "test": "pnpm build && node test/mcp-app-smoke.mjs && node test/target-mode.test.mjs",
+    "test": "pnpm build && node test/mcp-app-smoke.mjs && node test/target-mode.test.mjs && node test/local-server.test.mjs",
     "start": "tsx src/index.ts --stdio"
   },
   "dependencies": {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -12,6 +12,12 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { z } from "zod/v4";
 import { classifyTarget } from "./target-mode.js";
+import {
+  type LocalServerHandle,
+  resolveLocalFilePath,
+  spawnLocalServer,
+  stopAllLocalServers,
+} from "./local-server.js";
 
 // Single source of truth for "what version am I": the package.json version
 // (changeset-managed, version-locked with @reddb-io/ui + ui-kit), overridable by
@@ -347,6 +353,36 @@ function createServer(config: ServerConfig): McpServer {
     version: RED_UI_MCP_VERSION,
   });
 
+  // One `red server` per local file (its flock is single-writer — ADR-0006).
+  // Keyed by the resolved absolute path so a repeated open reuses the child.
+  const localServers = new Map<string, Promise<LocalServerHandle>>();
+
+  async function openLocalServer(target: string): Promise<LocalServerHandle> {
+    const key = resolveLocalFilePath(target);
+    const existing = localServers.get(key);
+    if (existing) {
+      try {
+        const handle = await existing;
+        if (
+          handle.child.exitCode === null &&
+          handle.child.signalCode === null
+        ) {
+          return handle;
+        }
+      } catch {
+        // Previous attempt failed; fall through and respawn.
+      }
+    }
+    const pending = spawnLocalServer({ target });
+    localServers.set(key, pending);
+    try {
+      return await pending;
+    } catch (error) {
+      localServers.delete(key);
+      throw error;
+    }
+  }
+
   registerAppResource(
     server,
     "red-ui app",
@@ -416,26 +452,53 @@ function createServer(config: ServerConfig): McpServer {
       const selectedView: RedUiView = view ?? "query";
       const mode = classifyTarget(connectionUrl);
 
-      // Local-file targets (#47, ADR-0006): the browser Surface cannot reach a
-      // filesystem path, so it is routed to the local handler seam rather than
-      // seeded as `?cs=`. Serving a local `.rdb` requires spawning a local
-      // `red server` (issue #48), which is not implemented yet — return a clear
-      // message and seed no connection.
+      // Local-file targets (#48, ADR-0006): the browser Surface cannot reach a
+      // filesystem path, so the MCP process spawns one `red server` that owns
+      // the file, health-checks it via `/stats`, and points the UI at the
+      // ephemeral `http://127.0.0.1:<port>` it exposes. The child is torn down
+      // on MCP exit/disconnect.
       if (mode === "local") {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `red-ui cannot open the local file "${connectionUrl}" yet: local-file mode (a local red server in front of the file, ADR-0006 / #48) is not implemented. Point at an http(s):// or red:// server, or wait for #48.`,
+        const target = connectionUrl ?? "";
+        try {
+          const local = await openLocalServer(target);
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Serving local file ${local.filePath} via a red server at ${local.baseUrl}; opening red-ui ${selectedView} view.`,
+              },
+            ],
+            structuredContent: {
+              appUrl: config.appUrl,
+              connectionUrl: local.baseUrl,
+              view: selectedView,
+              mode,
+              localServer: {
+                filePath: local.filePath,
+                port: local.port,
+                readOnly: local.readOnly,
+              },
             },
-          ],
-          structuredContent: {
-            appUrl: config.appUrl,
-            connectionUrl: "",
-            view: selectedView,
-            mode,
-          },
-        };
+          };
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Could not open the local file "${target}": ${message}`,
+              },
+            ],
+            isError: true,
+            structuredContent: {
+              appUrl: config.appUrl,
+              connectionUrl: "",
+              view: selectedView,
+              mode,
+            },
+          };
+        }
       }
 
       // Remote target: hand the URL to the browser via the Open Contract; no
@@ -469,6 +532,8 @@ Usage:
 Environment:
   RED_UI_APP_URL             URL of the hosted or running red-ui web app. Default: ${DEFAULT_APP_URL}
   RED_UI_CONNECT_DOMAINS     Comma-separated extra connect-src domains for the embedded app.
+  RED_BINARY                 Path to the reddb \`red\` binary used to serve local .rdb files.
+                             Defaults to the @reddb-io/sdk binary, else \`red\` on PATH.
 
 Example client config:
   {
@@ -496,6 +561,16 @@ async function main() {
 
   const server = createServer(loadConfig());
   const transport = new StdioServerTransport();
+
+  // Tear down any spawned local `red server` children when the MCP client
+  // disconnects (stdin closes) — no orphan servers (ADR-0006). The process
+  // exit hooks in local-server.ts are the synchronous backstop.
+  const previousOnClose = transport.onclose?.bind(transport);
+  transport.onclose = () => {
+    previousOnClose?.();
+    void stopAllLocalServers();
+  };
+
   await server.connect(transport);
 }
 

--- a/packages/mcp/src/local-server.ts
+++ b/packages/mcp/src/local-server.ts
@@ -1,0 +1,334 @@
+// Local-file mode for the MCP App (#48, ADR-0006).
+//
+// A browser Surface cannot reach a filesystem `.rdb`, and the MCP process (Node)
+// cannot open it either — reddb's embedded mode is Rust-only. So for a local
+// target we spawn ONE `red server --http --http-bind 127.0.0.1:<ephemeral>
+// --path <file>` child that owns the file, wait for `/stats` to report healthy,
+// and hand the UI `?cs=http://127.0.0.1:<port>`. The child is torn down on MCP
+// exit/disconnect — no orphan servers. We never reimplement the reddb HTTP API;
+// we shell out to the `red` binary.
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { accessSync, constants as fsConstants } from "node:fs";
+import { createServer } from "node:net";
+import { homedir } from "node:os";
+import { delimiter, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Modules that may expose reddb's binary resolver. `@reddb-io/sdk` is the
+// canonical name in ADR-0006; `reddb-cli` is the package that currently ships
+// `resolveBinary`. Either is optional — neither is a hard dependency of this
+// package, so resolution falls through to a PATH `red` when absent.
+const SDK_CANDIDATES = ["@reddb-io/sdk", "reddb-cli"] as const;
+
+export interface RedBinary {
+  binaryPath: string;
+  /** Where we found it: an SDK package name, "path", or "env". */
+  source: string;
+}
+
+export interface LocalServerHandle {
+  baseUrl: string;
+  port: number;
+  filePath: string;
+  readOnly: boolean;
+  child: ChildProcess;
+  /** Idempotent teardown — SIGTERM then SIGKILL, resolves once the child exits. */
+  stop(): Promise<void>;
+}
+
+export interface SpawnLocalServerOptions {
+  /** Connection target as received by the tool (path / file:// / ~/… / *.rdb). */
+  target: string;
+  readOnly?: boolean;
+  /** Override binary resolution (tests, explicit config). */
+  binaryPath?: string;
+  /** Override the ephemeral port (tests). */
+  port?: number;
+  /** Max time to wait for `/stats` to report healthy. Default 10s. */
+  healthTimeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Resolve a fuzzy local target into an absolute filesystem path the `red`
+ * binary can `--path`. Handles `file://` URLs, `~`/`~/…` home expansion, and
+ * relative paths (resolved against the MCP process cwd).
+ */
+export function resolveLocalFilePath(target: string): string {
+  const t = target.trim();
+  if (/^file:\/\//i.test(t)) return fileURLToPath(t);
+  if (t === "~") return homedir();
+  if (t.startsWith("~/")) return join(homedir(), t.slice(2));
+  if (isAbsolute(t)) return t;
+  return resolve(process.cwd(), t);
+}
+
+function isExecutable(file: string): boolean {
+  try {
+    accessSync(file, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Find an executable by name on PATH (mirrors `which`). */
+function findOnPath(name: string): string | null {
+  const paths = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
+  const names = process.platform === "win32" ? [name, `${name}.exe`] : [name];
+  for (const dir of paths) {
+    for (const candidate of names) {
+      const full = join(dir, candidate);
+      if (process.platform === "win32" ? true : isExecutable(full)) {
+        // On win32 PATHEXT handling is approximate; accept the first match.
+        if (process.platform === "win32" && !isFile(full)) continue;
+        return full;
+      }
+    }
+  }
+  return null;
+}
+
+function isFile(file: string): boolean {
+  try {
+    accessSync(file, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the `red` binary: explicit `RED_BINARY` env → `@reddb-io/sdk`'s
+ * subprocess binary (or `reddb-cli`'s) → a PATH `red`. Throws an actionable
+ * error when none is found.
+ */
+export async function resolveRedBinary(): Promise<RedBinary> {
+  const envBin = process.env.RED_BINARY?.trim();
+  if (envBin) return { binaryPath: envBin, source: "env" };
+
+  for (const name of SDK_CANDIDATES) {
+    try {
+      const mod: Record<string, unknown> = await import(name);
+      const resolveBinary = (mod.resolveBinary ??
+        (mod.default as Record<string, unknown> | undefined)?.resolveBinary) as
+        | ((opts?: unknown) => Promise<string> | string)
+        | undefined;
+      if (typeof resolveBinary === "function") {
+        const binaryPath = await resolveBinary();
+        if (binaryPath && isFile(binaryPath)) {
+          return { binaryPath, source: name };
+        }
+      }
+    } catch {
+      // Not installed or resolution failed; try the next strategy.
+    }
+  }
+
+  const onPath = findOnPath("red");
+  if (onPath) return { binaryPath: onPath, source: "path" };
+
+  throw new Error(
+    "Cannot open a local .rdb file: no reddb `red` binary found. " +
+      "Install the reddb SDK (`pnpm add @reddb-io/sdk`) so its bundled binary " +
+      "can be used, put `red` on your PATH, or set RED_BINARY to its absolute path. " +
+      "See ADR-0006."
+  );
+}
+
+/** Reserve a free TCP port on the loopback interface, then release it. */
+function pickEphemeralPort(): Promise<number> {
+  return new Promise((resolvePort, reject) => {
+    const srv = createServer();
+    srv.unref();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const port = addr && typeof addr === "object" ? addr.port : 0;
+      srv.close(() => {
+        if (port) resolvePort(port);
+        else reject(new Error("Could not reserve an ephemeral port."));
+      });
+    });
+  });
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Poll `${baseUrl}/stats` until it answers 200, the child exits, the timeout
+ * elapses, or the signal aborts. `/stats` is reddb's canonical proof-of-life
+ * (CLAUDE.md: `/health` returns 503 by design).
+ */
+async function waitForHealthy(
+  baseUrl: string,
+  child: ChildProcess,
+  timeoutMs: number,
+  getStderr: () => string,
+  signal?: AbortSignal
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    if (signal?.aborted) throw new Error("Local server startup aborted.");
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(
+        `red server exited (code ${child.exitCode}, signal ${child.signalCode}) ` +
+          `before /stats became healthy.${getStderr() ? `\n${getStderr()}` : ""}`
+      );
+    }
+    try {
+      const res = await fetch(`${baseUrl}/stats`, {
+        signal: AbortSignal.timeout(1500),
+      });
+      if (res.ok) return;
+    } catch {
+      // Not accepting connections yet — keep polling.
+    }
+    if (Date.now() > deadline) {
+      throw new Error(
+        `red server did not report healthy at ${baseUrl}/stats within ` +
+          `${timeoutMs}ms.${getStderr() ? `\n${getStderr()}` : ""}`
+      );
+    }
+    await delay(150);
+  }
+}
+
+/**
+ * Spawn one `red server` that owns `target`, wait for `/stats` to report
+ * healthy, and return a handle whose `stop()` tears the child down.
+ */
+export async function spawnLocalServer(
+  options: SpawnLocalServerOptions
+): Promise<LocalServerHandle> {
+  const {
+    target,
+    readOnly = false,
+    healthTimeoutMs = 10_000,
+    signal,
+  } = options;
+  const filePath = resolveLocalFilePath(target);
+  const binaryPath =
+    options.binaryPath ?? (await resolveRedBinary()).binaryPath;
+  const port = options.port ?? (await pickEphemeralPort());
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  const args = [
+    "server",
+    "--http",
+    "--http-bind",
+    `127.0.0.1:${port}`,
+    "--path",
+    filePath,
+  ];
+  if (readOnly) args.push("--read-only");
+
+  const child = spawn(binaryPath, args, {
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+
+  let stderr = "";
+  child.stderr?.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString();
+    if (stderr.length > 4000) stderr = stderr.slice(-4000);
+  });
+
+  const handle: LocalServerHandle = {
+    baseUrl,
+    port,
+    filePath,
+    readOnly,
+    child,
+    stop: makeStop(child),
+  };
+
+  try {
+    await waitForHealthy(
+      baseUrl,
+      child,
+      healthTimeoutMs,
+      () => stderr.trim(),
+      signal
+    );
+  } catch (error) {
+    await handle.stop();
+    throw error;
+  }
+
+  trackServer(handle);
+  return handle;
+}
+
+function makeStop(child: ChildProcess): () => Promise<void> {
+  let stopping: Promise<void> | null = null;
+  return () => {
+    if (stopping) return stopping;
+    stopping = new Promise<void>((resolveStop) => {
+      if (child.exitCode !== null || child.signalCode !== null) {
+        resolveStop();
+        return;
+      }
+      const onExit = () => {
+        clearTimeout(killTimer);
+        resolveStop();
+      };
+      child.once("exit", onExit);
+      const killTimer = setTimeout(() => {
+        child.kill("SIGKILL");
+      }, 3000);
+      killTimer.unref?.();
+      child.kill("SIGTERM");
+    });
+    return stopping;
+  };
+}
+
+// --- lifecycle registry: guarantee no orphan servers on MCP exit/disconnect ---
+
+const liveServers = new Set<LocalServerHandle>();
+let exitHooksInstalled = false;
+
+function installExitHooks(): void {
+  if (exitHooksInstalled) return;
+  exitHooksInstalled = true;
+
+  // Synchronous best-effort kill on hard exit — handlers can't await.
+  process.on("exit", () => {
+    for (const handle of liveServers) {
+      try {
+        handle.child.kill("SIGKILL");
+      } catch {
+        // already gone
+      }
+    }
+  });
+
+  for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+    process.on(sig, () => {
+      for (const handle of liveServers) {
+        try {
+          handle.child.kill("SIGKILL");
+        } catch {
+          // already gone
+        }
+      }
+      process.exit(0);
+    });
+  }
+}
+
+function trackServer(handle: LocalServerHandle): void {
+  installExitHooks();
+  liveServers.add(handle);
+  handle.child.once("exit", () => liveServers.delete(handle));
+}
+
+/** Stop every tracked local server (MCP transport close / shutdown). */
+export async function stopAllLocalServers(): Promise<void> {
+  const handles = [...liveServers];
+  await Promise.all(handles.map((h) => h.stop()));
+}

--- a/packages/mcp/test/fake-red.mjs
+++ b/packages/mcp/test/fake-red.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// Stand-in for the `red` binary used by the local-server lifecycle test.
+// It ignores the leading `server --http` args, reads `--http-bind host:port`,
+// and serves a 200 `/stats` after a short startup delay — enough to exercise
+// spawn → health-check → teardown without needing a real reddb build.
+//
+//   FAKE_RED_FAIL=exit       exit immediately (simulate a bad binary / bad file)
+//   FAKE_RED_DELAY_MS=<n>    delay before `/stats` starts answering (default 150)
+
+import http from "node:http";
+
+const args = process.argv.slice(2);
+const bindIdx = args.indexOf("--http-bind");
+const bind = bindIdx >= 0 ? args[bindIdx + 1] : "127.0.0.1:0";
+const [host, portStr] = bind.split(":");
+
+if (process.env.FAKE_RED_FAIL === "exit") {
+  process.stderr.write("fake red: refusing to start (FAKE_RED_FAIL)\n");
+  process.exit(3);
+}
+
+const delayMs = Number(process.env.FAKE_RED_DELAY_MS ?? 150);
+
+setTimeout(() => {
+  const server = http.createServer((req, res) => {
+    if (req.url === "/stats") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ store: { collection_count: 0 } }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  server.listen(Number(portStr), host, () => {
+    process.stdout.write(`fake red listening on ${bind}\n`);
+  });
+  const shutdown = () => {
+    server.close(() => process.exit(0));
+    // Backstop if connections linger.
+    setTimeout(() => process.exit(0), 200).unref();
+  };
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+}, delayMs);

--- a/packages/mcp/test/local-server.test.mjs
+++ b/packages/mcp/test/local-server.test.mjs
@@ -1,0 +1,160 @@
+import { chmodSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packageDir = dirname(here);
+const {
+  resolveLocalFilePath,
+  resolveRedBinary,
+  spawnLocalServer,
+  stopAllLocalServers,
+} = await import(join(packageDir, "dist/local-server.js"));
+
+const FAKE_RED = join(here, "fake-red.mjs");
+chmodSync(FAKE_RED, 0o755);
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function isUp(baseUrl) {
+  try {
+    const res = await fetch(`${baseUrl}/stats`, {
+      signal: AbortSignal.timeout(1000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+// --- resolveLocalFilePath: normalize fuzzy targets to an fs path -------------
+assert(
+  resolveLocalFilePath("file:///data/app.rdb") === "/data/app.rdb",
+  "file:// should map to its path"
+);
+assert(
+  resolveLocalFilePath("~/notes.rdb") === join(homedir(), "notes.rdb"),
+  "~ should expand to home"
+);
+assert(
+  resolveLocalFilePath("/var/lib/x.rdb") === "/var/lib/x.rdb",
+  "absolute path is preserved"
+);
+assert(
+  resolveLocalFilePath("./mydb.rdb") === resolve(process.cwd(), "mydb.rdb"),
+  "relative path resolves against cwd"
+);
+
+// --- binary resolution: actionable failure when no binary exists -------------
+{
+  const savedPath = process.env.PATH;
+  const savedBin = process.env.RED_BINARY;
+  process.env.PATH = ""; // no `red` on PATH
+  delete process.env.RED_BINARY; // no explicit override
+  let threw = null;
+  try {
+    await resolveRedBinary();
+  } catch (error) {
+    threw = error;
+  } finally {
+    process.env.PATH = savedPath;
+    if (savedBin !== undefined) process.env.RED_BINARY = savedBin;
+  }
+  assert(threw, "resolveRedBinary must throw when no binary is found");
+  assert(
+    /red.*binary|RED_BINARY|PATH|@reddb-io\/sdk/i.test(threw.message),
+    `failure message must be actionable, got: ${threw.message}`
+  );
+}
+
+// --- binary resolution: RED_BINARY override wins -----------------------------
+{
+  const saved = process.env.RED_BINARY;
+  process.env.RED_BINARY = FAKE_RED;
+  try {
+    const resolved = await resolveRedBinary();
+    assert(
+      resolved.binaryPath === FAKE_RED && resolved.source === "env",
+      "RED_BINARY override should resolve to that path with source=env"
+    );
+  } finally {
+    if (saved === undefined) delete process.env.RED_BINARY;
+    else process.env.RED_BINARY = saved;
+  }
+}
+
+// --- lifecycle: spawn → health-check → teardown (no orphan) ------------------
+{
+  const handle = await spawnLocalServer({
+    target: "/tmp/red-ui-mcp-test.rdb",
+    binaryPath: FAKE_RED,
+    healthTimeoutMs: 5000,
+  });
+  assert(
+    handle.baseUrl === `http://127.0.0.1:${handle.port}`,
+    "handle exposes the loopback baseUrl"
+  );
+  assert(
+    handle.filePath === "/tmp/red-ui-mcp-test.rdb",
+    "filePath is resolved"
+  );
+  assert(await isUp(handle.baseUrl), "server must be healthy after spawn");
+
+  await handle.stop();
+  assert(
+    handle.child.exitCode !== null || handle.child.signalCode !== null,
+    "child must have exited after stop()"
+  );
+  assert(!(await isUp(handle.baseUrl)), "server must be down after teardown");
+
+  // stop() is idempotent.
+  await handle.stop();
+}
+
+// --- lifecycle: a binary that exits before healthy rejects, leaves no child --
+{
+  const saved = process.env.FAKE_RED_FAIL;
+  process.env.FAKE_RED_FAIL = "exit";
+  let threw = null;
+  let handle = null;
+  try {
+    handle = await spawnLocalServer({
+      target: "/tmp/red-ui-mcp-bad.rdb",
+      binaryPath: FAKE_RED,
+      healthTimeoutMs: 5000,
+    });
+  } catch (error) {
+    threw = error;
+  } finally {
+    if (saved === undefined) delete process.env.FAKE_RED_FAIL;
+    else process.env.FAKE_RED_FAIL = saved;
+  }
+  assert(!handle, "spawnLocalServer must not resolve when the binary exits");
+  assert(threw, "spawnLocalServer must reject when the binary exits");
+  assert(
+    /exited/i.test(threw.message),
+    `error should explain the early exit, got: ${threw.message}`
+  );
+}
+
+// --- stopAllLocalServers tears down every tracked child ----------------------
+{
+  const a = await spawnLocalServer({
+    target: "/tmp/red-ui-mcp-a.rdb",
+    binaryPath: FAKE_RED,
+  });
+  const b = await spawnLocalServer({
+    target: "/tmp/red-ui-mcp-b.rdb",
+    binaryPath: FAKE_RED,
+  });
+  assert(await isUp(a.baseUrl), "server a healthy");
+  assert(await isUp(b.baseUrl), "server b healthy");
+  await stopAllLocalServers();
+  assert(!(await isUp(a.baseUrl)), "server a down after stopAll");
+  assert(!(await isUp(b.baseUrl)), "server b down after stopAll");
+}
+
+console.log("local-server lifecycle test passed");

--- a/packages/mcp/test/mcp-app-smoke.mjs
+++ b/packages/mcp/test/mcp-app-smoke.mjs
@@ -1,54 +1,138 @@
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
-import { Client } from '@modelcontextprotocol/sdk/client/index.js'
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { chmodSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
-const packageDir = dirname(dirname(fileURLToPath(import.meta.url)))
+const here = dirname(fileURLToPath(import.meta.url));
+const packageDir = dirname(here);
 
-const client = new Client({ name: 'red-ui-mcp-app-smoke', version: '0.0.0' })
+// Point the server at the fake `red` binary so the local-file path spawns a
+// stand-in HTTP server instead of needing a real reddb build.
+const fakeRed = join(here, "fake-red.mjs");
+chmodSync(fakeRed, 0o755);
+
+const client = new Client({ name: "red-ui-mcp-app-smoke", version: "0.0.0" });
 const transport = new StdioClientTransport({
   command: process.execPath,
-  args: [join(packageDir, 'dist/index.js'), '--stdio'],
+  args: [join(packageDir, "dist/index.js"), "--stdio"],
   env: {
     ...process.env,
-    RED_UI_APP_URL: 'https://ui.reddb.io',
+    RED_UI_APP_URL: "https://ui.reddb.io",
+    RED_BINARY: fakeRed,
   },
-})
+});
 
 function assert(condition, message) {
-  if (!condition) throw new Error(message)
+  if (!condition) throw new Error(message);
 }
 
-await client.connect(transport)
+async function statsUp(baseUrl) {
+  try {
+    const res = await fetch(`${baseUrl}/stats`, {
+      signal: AbortSignal.timeout(1000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+await client.connect(transport);
+
+let localBaseUrl = null;
 
 try {
-  const tools = await client.listTools()
-  const openTool = tools.tools.find((tool) => tool.name === 'open_red_ui')
+  const tools = await client.listTools();
+  const openTool = tools.tools.find((tool) => tool.name === "open_red_ui");
 
-  assert(openTool, 'open_red_ui tool was not registered')
+  assert(openTool, "open_red_ui tool was not registered");
   assert(
-    openTool._meta?.ui?.resourceUri === 'ui://red-ui/app.html',
-    `open_red_ui must point at the MCP App resource, got ${JSON.stringify(openTool._meta)}`,
-  )
+    openTool._meta?.ui?.resourceUri === "ui://red-ui/app.html",
+    `open_red_ui must point at the MCP App resource, got ${JSON.stringify(openTool._meta)}`
+  );
 
   const result = await client.callTool({
-    name: 'open_red_ui',
-    arguments: { connectionUrl: 'red://localhost', view: 'query' },
-  })
+    name: "open_red_ui",
+    arguments: { connectionUrl: "red://localhost", view: "query" },
+  });
 
-  assert(result.structuredContent?.appUrl === 'https://ui.reddb.io', 'tool result must include hosted appUrl')
-  assert(result.structuredContent?.connectionUrl === 'red://localhost', 'tool result must preserve connectionUrl')
-  assert(result.structuredContent?.view === 'query', 'tool result must preserve selected view')
+  assert(
+    result.structuredContent?.appUrl === "https://ui.reddb.io",
+    "tool result must include hosted appUrl"
+  );
+  assert(
+    result.structuredContent?.connectionUrl === "red://localhost",
+    "tool result must preserve connectionUrl"
+  );
+  assert(
+    result.structuredContent?.view === "query",
+    "tool result must preserve selected view"
+  );
 
-  const resource = await client.readResource({ uri: 'ui://red-ui/app.html' })
-  const content = resource.contents?.[0]
+  const resource = await client.readResource({ uri: "ui://red-ui/app.html" });
+  const content = resource.contents?.[0];
 
-  assert(content?.mimeType === 'text/html;profile=mcp-app', `invalid MCP App MIME type: ${content?.mimeType}`)
-  assert(typeof content.text === 'string' && content.text.includes('new App('), 'resource must load MCP Apps bridge')
-  assert(content.text.includes('https://ui.reddb.io'), 'resource must embed the configured hosted app URL')
-  assert(!content.text.includes('url.pathname'), 'resource must not rewrite the hosted app pathname')
+  assert(
+    content?.mimeType === "text/html;profile=mcp-app",
+    `invalid MCP App MIME type: ${content?.mimeType}`
+  );
+  assert(
+    typeof content.text === "string" && content.text.includes("new App("),
+    "resource must load MCP Apps bridge"
+  );
+  assert(
+    content.text.includes("https://ui.reddb.io"),
+    "resource must embed the configured hosted app URL"
+  );
+  assert(
+    !content.text.includes("url.pathname"),
+    "resource must not rewrite the hosted app pathname"
+  );
+
+  // Local-file target: the MCP must spawn a red server, health-check it, and
+  // hand the UI an http://127.0.0.1:<port> connection string (#48, ADR-0006).
+  const local = await client.callTool({
+    name: "open_red_ui",
+    arguments: {
+      connectionUrl: "/tmp/red-ui-mcp-smoke.rdb",
+      view: "collections",
+    },
+  });
+  assert(
+    local.structuredContent?.mode === "local",
+    "local target must classify as local"
+  );
+  const localCs = local.structuredContent?.connectionUrl;
+  assert(
+    typeof localCs === "string" && /^http:\/\/127\.0\.0\.1:\d+$/.test(localCs),
+    `local target must seed a loopback connection string, got ${localCs}`
+  );
+  assert(
+    local.structuredContent?.localServer?.filePath ===
+      "/tmp/red-ui-mcp-smoke.rdb",
+    "local result must report the served file path"
+  );
+  assert(
+    await statsUp(localCs),
+    "spawned local server must be healthy before the UI is pointed at it"
+  );
+  localBaseUrl = localCs;
 } finally {
-  await client.close()
+  await client.close();
 }
 
-console.log('red-ui MCP App smoke test passed')
+// On disconnect the spawned child must be gone — no orphan servers.
+if (localBaseUrl) {
+  let down = false;
+  for (let i = 0; i < 40; i++) {
+    if (!(await statsUp(localBaseUrl))) {
+      down = true;
+      break;
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  assert(down, "spawned local server must be torn down after MCP disconnect");
+}
+
+console.log("red-ui MCP App smoke test passed");


### PR DESCRIPTION
Lands the completed work for #48 (ADR-0006). The AFK worker wLLY9 implemented and verified this (commit efd30df) but exited without a DONE sentinel, so the orchestrator never merged. Re-verified locally: `pnpm --filter @reddb-io/ui-mcp test` green (tsc build + smoke + target-mode + local-server lifecycle).

Closes #48

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783001138&installation_id=129708444&pr_number=54&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F54&signature=6f68265ab7efa7bcda8bf74e40fb18d7ef2c3e5408efc7a8632c37e39bbc32c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The `open_red_ui` tool now supports local database files, automatically serving them through an ephemeral HTTP server with automatic cleanup when the connection closes.
  * Added environment variable support for specifying custom binary paths.

* **Tests**
  * Added comprehensive test coverage for local file serving functionality and server lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->