### PR TITLE
feat(mcp): server-side data tools returning structuredContent (#49)

### DIFF
--- a/.changeset/mcp-server-side-data-tools.md
+++ b/.changeset/mcp-server-side-data-tools.md
@@ -1,0 +1,15 @@
+---
+"@reddb-io/ui-mcp": minor
+---
+
+MCP App gains server-side data tools (`query`, `list`, `get`) that run a
+server-side `RedClient` in the MCP process against the resolved connection and
+return reddb reads to the model as `structuredContent` — the model reads data
+directly without driving the visual iframe (ADR-0006, #49). `query` is read-only
+(default-deny allowlist: SELECT/WITH/SHOW/EXPLAIN/DESCRIBE/MATCH; write/DDL is
+refused); `list` returns collection names or a collection's rows; `get` fetches a
+single record by id. Each tool resolves a remote endpoint per call (the tool's
+`connectionUrl`, else `RED_UI_CONNECTION_URL`); local-file targets are refused
+until the local-spawn slice (#48) lands. Auth comes from
+`RED_UI_CONNECTION_TOKEN`/`RED_UI_CONNECTION_AUTH` and is sent only as a request
+header — never logged, never returned in tool output (ADR-0005).

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -20,7 +20,7 @@
     "prepack": "pnpm build",
     "build": "tsc -p tsconfig.json",
     "check": "tsc -p tsconfig.json --noEmit",
-    "test": "pnpm build && node test/mcp-app-smoke.mjs && node test/target-mode.test.mjs && node test/local-server.test.mjs",
+    "test": "pnpm build && node test/mcp-app-smoke.mjs && node test/target-mode.test.mjs && node test/local-server.test.mjs && node test/data-tools.test.mjs",
     "start": "tsx src/index.ts --stdio"
   },
   "dependencies": {

--- a/packages/mcp/src/connection.ts
+++ b/packages/mcp/src/connection.ts
@@ -1,0 +1,84 @@
+// Connection resolution for the MCP data tools (#49, ADR-0006).
+//
+// A data tool receives an optional `connectionUrl`; combined with the configured
+// default it resolves to a concrete reddb endpoint the server-side RedClient can
+// reach. Two modes (ADR-0006, mirrors `open_red_ui`):
+//   - REMOTE: an http(s):// or red(s):// URL. red:// is an http(s) alias
+//     (ADR-0003); we normalise it to http(s) so `fetch` can reach it.
+//   - LOCAL: a filesystem path / file:// / *.rdb. Per ADR-0006 the MCP must spawn
+//     a local `red server` in front of the file and talk to it over
+//     http://localhost — but that spawn is issue #48 and not implemented yet, so
+//     resolving a local target throws a clear "not yet" error. This is the seam
+//     #48 plugs into: it will return the spawned server's baseUrl here.
+//
+// The resolved auth header (if any) is carried in `headers` and never surfaces in
+// tool output or logs — secrets never ride the URL (ADR-0005).
+
+import { classifyTarget, type TargetMode } from "./target-mode.js";
+
+export interface ResolvedConnection {
+  /** http(s) base URL the RedClient fetches. Non-secret (ADR-0005). */
+  baseUrl: string;
+  /** Auth headers for the client. Never logged, never returned to the model. */
+  headers?: Record<string, string>;
+  mode: TargetMode;
+}
+
+/** Translate a `red(s)://` alias to its http(s) equivalent; pass other schemes
+ *  through. red:// → http://, reds:// → https:// (ADR-0003). */
+function normalizeRemoteUrl(target: string): string {
+  const t = target.trim();
+  const lower = t.toLowerCase();
+  let url: URL;
+  if (lower.startsWith("red://")) {
+    url = new URL("http://" + t.slice("red://".length));
+  } else if (lower.startsWith("reds://")) {
+    url = new URL("https://" + t.slice("reds://".length));
+  } else if (/^https?:\/\//i.test(t)) {
+    url = new URL(t);
+  } else {
+    // Bare host:port / hostname — default to http (matches the UI's normalizer).
+    url = new URL("http://" + t);
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(`Unsupported connection scheme: ${target}`);
+  }
+  url.hash = "";
+  return url.toString().replace(/\/$/, "");
+}
+
+export interface ResolveConnectionOptions {
+  /** Default target when the tool call omits `connectionUrl`. */
+  defaultUrl?: string;
+  /** Auth header value applied to remote requests (never logged/returned). */
+  authHeader?: string;
+}
+
+/**
+ * Resolve a tool-supplied (or configured) target into a reachable endpoint.
+ * Throws for a local-file target (#48 unimplemented) and for an absent target
+ * with no configured default — the data tools need a concrete server to read.
+ */
+export function resolveConnection(
+  target: string | undefined,
+  opts: ResolveConnectionOptions = {}
+): ResolvedConnection {
+  const raw = (target ?? "").trim() || (opts.defaultUrl ?? "").trim();
+  if (!raw) {
+    throw new Error(
+      "No reddb connection: pass a connectionUrl (http(s):// or red://), or set RED_UI_CONNECTION_URL on the MCP server."
+    );
+  }
+
+  const mode = classifyTarget(raw);
+  if (mode === "local") {
+    throw new Error(
+      `Cannot run data tools against the local file "${raw}" yet: local-file mode (a local red server in front of the file, ADR-0006 / #48) is not implemented. Point at an http(s):// or red:// server.`
+    );
+  }
+
+  const headers = opts.authHeader
+    ? { Authorization: opts.authHeader }
+    : undefined;
+  return { baseUrl: normalizeRemoteUrl(raw), headers, mode };
+}

--- a/packages/mcp/src/data-tools.ts
+++ b/packages/mcp/src/data-tools.ts
@@ -1,0 +1,385 @@
+// Server-side data tools for the MCP App (#49, ADR-0006).
+//
+// `query` / `list` / `get` run a server-side RedClient against the resolved
+// connection and return reddb results to the *model* as `structuredContent` —
+// the model reads data directly without driving the visual iframe. Read-shaped
+// only: `query` rejects any statement that is not a read (default-deny), and
+// `list`/`get` build SELECTs. No secret/token is logged or returned.
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod/v4";
+import {
+  RedClient,
+  runQueryPreferStream,
+  type QueryResult,
+  type ReadClient,
+} from "./red-client.js";
+import {
+  resolveConnection,
+  type ResolveConnectionOptions,
+} from "./connection.js";
+
+/** MCP tool result shape we build (subset of the SDK's CallToolResult). The
+ *  index signature keeps it assignable to the SDK's `CallToolResult`. */
+interface ToolResult {
+  content: Array<{ type: "text"; text: string }>;
+  structuredContent: Record<string, unknown>;
+  isError?: boolean;
+  [k: string]: unknown;
+}
+
+/** Leading verbs we accept as read-shaped. Everything else is denied — a
+ *  default-deny allowlist keeps write/DDL statements out of read tools even as
+ *  reddb's query surface grows. */
+const READ_VERBS = new Set([
+  "select",
+  "with",
+  "show",
+  "explain",
+  "describe",
+  "desc",
+  "match", // graph traversal read
+]);
+
+/** Strip leading line/block comments + whitespace, then return the first token
+ *  lower-cased. Used to gate the `query` tool to read-shaped statements. */
+export function leadingVerb(sql: string): string {
+  let s = sql.trim();
+  // Drop leading -- line comments and /* */ block comments.
+  for (;;) {
+    if (s.startsWith("--")) {
+      const nl = s.indexOf("\n");
+      s = nl === -1 ? "" : s.slice(nl + 1).trim();
+    } else if (s.startsWith("/*")) {
+      const end = s.indexOf("*/");
+      s = end === -1 ? "" : s.slice(end + 2).trim();
+    } else {
+      break;
+    }
+  }
+  const m = /^[a-z]+/i.exec(s);
+  return m ? m[0].toLowerCase() : "";
+}
+
+export function isReadOnlyQuery(sql: string): boolean {
+  return READ_VERBS.has(leadingVerb(sql));
+}
+
+const IDENT_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** Reject anything that is not a bare SQL identifier (collection / column). */
+function assertIdentifier(value: string, label: string): string {
+  if (!IDENT_RE.test(value)) {
+    throw new Error(
+      `Invalid ${label} "${value}": expected a bare identifier (letters, digits, underscore).`
+    );
+  }
+  return value;
+}
+
+/** Render an id literal for a WHERE clause: numbers inline, strings single-quoted
+ *  with embedded quotes doubled. */
+function idLiteral(id: string | number): string {
+  if (typeof id === "number") {
+    if (!Number.isFinite(id)) throw new Error(`Invalid numeric id: ${id}`);
+    return String(id);
+  }
+  return `'${id.replaceAll("'", "''")}'`;
+}
+
+function ok(text: string, structured: Record<string, unknown>): ToolResult {
+  return { content: [{ type: "text", text }], structuredContent: structured };
+}
+
+function fail(message: string): ToolResult {
+  return {
+    content: [{ type: "text", text: message }],
+    structuredContent: { ok: false, error: message },
+    isError: true,
+  };
+}
+
+function shapeQueryResult(
+  r: QueryResult,
+  baseUrl: string,
+  mode: string
+): Record<string, unknown> {
+  const records = r.result?.records?.map((rec) => rec.values) ?? [];
+  return {
+    ok: r.ok !== false,
+    query: r.query,
+    columns: r.result?.columns ?? [],
+    records,
+    recordCount: r.record_count ?? records.length,
+    streamed: r.streamed ?? false,
+    truncated: r.truncated ?? false,
+    baseUrl,
+    mode,
+  };
+}
+
+// ---- Pure handlers (injectable client) — the unit-testable core. ----------
+
+export async function runQueryTool(
+  client: ReadClient,
+  args: { query: string; maxRows?: number },
+  conn: { baseUrl: string; mode: string }
+): Promise<ToolResult> {
+  if (!isReadOnlyQuery(args.query)) {
+    return fail(
+      `Refused: "${leadingVerb(args.query) || "(empty)"}" is not a read statement. The query tool runs read-shaped statements only (SELECT/WITH/SHOW/EXPLAIN/DESCRIBE/MATCH).`
+    );
+  }
+  try {
+    const r = await runQueryPreferStream(client, args.query, {
+      maxRows: args.maxRows,
+    });
+    const structured = shapeQueryResult(r, conn.baseUrl, conn.mode);
+    return ok(
+      `${structured.recordCount} row(s) from ${conn.baseUrl}${structured.truncated ? " (truncated)" : ""}.`,
+      structured
+    );
+  } catch (e) {
+    return fail(e instanceof Error ? e.message : String(e));
+  }
+}
+
+export async function runListTool(
+  client: ReadClient,
+  args: { collection?: string; maxRows?: number },
+  conn: { baseUrl: string; mode: string }
+): Promise<ToolResult> {
+  try {
+    // No collection → list collection names. With one → list its rows (a read).
+    if (!args.collection) {
+      const collections = await client.collections();
+      return ok(`${collections.length} collection(s) on ${conn.baseUrl}.`, {
+        ok: true,
+        collections,
+        count: collections.length,
+        baseUrl: conn.baseUrl,
+        mode: conn.mode,
+      });
+    }
+    const name = assertIdentifier(args.collection, "collection");
+    const limit = args.maxRows ?? 100;
+    const r = await runQueryPreferStream(
+      client,
+      `SELECT * FROM ${name} LIMIT ${limit}`,
+      { maxRows: limit }
+    );
+    const structured = shapeQueryResult(r, conn.baseUrl, conn.mode);
+    structured.collection = name;
+    return ok(
+      `${structured.recordCount} row(s) from ${name} on ${conn.baseUrl}${structured.truncated ? " (truncated)" : ""}.`,
+      structured
+    );
+  } catch (e) {
+    return fail(e instanceof Error ? e.message : String(e));
+  }
+}
+
+export async function runGetTool(
+  client: ReadClient,
+  args: { collection: string; id: string | number; idColumn?: string },
+  conn: { baseUrl: string; mode: string }
+): Promise<ToolResult> {
+  try {
+    const name = assertIdentifier(args.collection, "collection");
+    const idColumn = assertIdentifier(args.idColumn ?? "id", "idColumn");
+    const sql = `SELECT * FROM ${name} WHERE ${idColumn} = ${idLiteral(args.id)} LIMIT 1`;
+    const r = await runQueryPreferStream(client, sql, { maxRows: 1 });
+    const records = r.result?.records?.map((rec) => rec.values) ?? [];
+    const record = records[0] ?? null;
+    return ok(
+      record
+        ? `Found ${name}/${args.id} on ${conn.baseUrl}.`
+        : `No ${name} where ${idColumn} = ${args.id} on ${conn.baseUrl}.`,
+      {
+        ok: true,
+        found: record !== null,
+        collection: name,
+        id: args.id,
+        record,
+        baseUrl: conn.baseUrl,
+        mode: conn.mode,
+      }
+    );
+  } catch (e) {
+    return fail(e instanceof Error ? e.message : String(e));
+  }
+}
+
+// ---- Registration ---------------------------------------------------------
+
+export interface DataToolsConfig extends ResolveConnectionOptions {
+  /** Build a client for a resolved endpoint. Overridable in tests. */
+  createClient?: (
+    baseUrl: string,
+    headers?: Record<string, string>
+  ) => ReadClient;
+}
+
+const MODEL_ONLY_META = { ui: { visibility: ["model"] } } as const;
+
+/**
+ * Register the model-facing `query` / `list` / `get` data tools. They resolve a
+ * connection per call (tool arg `connectionUrl`, else the configured default),
+ * build a server-side RedClient, and return results as `structuredContent`.
+ */
+export function registerDataTools(
+  server: McpServer,
+  config: DataToolsConfig = {}
+): void {
+  const createClient =
+    config.createClient ??
+    ((baseUrl, headers) => new RedClient(baseUrl, { headers }));
+  const resolveOpts: ResolveConnectionOptions = {
+    defaultUrl: config.defaultUrl,
+    authHeader: config.authHeader,
+  };
+
+  function resolve(connectionUrl?: string) {
+    const conn = resolveConnection(connectionUrl, resolveOpts);
+    return { conn, client: createClient(conn.baseUrl, conn.headers) };
+  }
+
+  const connectionUrlSchema = z
+    .string()
+    .optional()
+    .describe(
+      "reddb endpoint to read from (http(s):// or red://). Defaults to the MCP server's configured connection. Local file paths are not yet supported (#48)."
+    );
+
+  server.registerTool(
+    "query",
+    {
+      title: "Query reddb",
+      description:
+        "Run a read-only reddb query (SELECT/WITH/SHOW/EXPLAIN/DESCRIBE/MATCH) and return rows as structured data. Write/DDL statements are refused.",
+      inputSchema: {
+        query: z.string().describe("A read-only reddb SQL/graph statement."),
+        connectionUrl: connectionUrlSchema,
+        maxRows: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Maximum rows to collect (default 10000)."),
+      },
+      outputSchema: {
+        ok: z.boolean(),
+        error: z.string().optional(),
+        query: z.string().optional(),
+        columns: z.array(z.string()).optional(),
+        records: z.array(z.record(z.string(), z.unknown())).optional(),
+        recordCount: z.number().optional(),
+        streamed: z.boolean().optional(),
+        truncated: z.boolean().optional(),
+        baseUrl: z.string().optional(),
+        mode: z.string().optional(),
+      },
+      _meta: MODEL_ONLY_META,
+    },
+    async ({ query, connectionUrl, maxRows }) => {
+      let resolved;
+      try {
+        resolved = resolve(connectionUrl);
+      } catch (e) {
+        return fail(e instanceof Error ? e.message : String(e));
+      }
+      return runQueryTool(resolved.client, { query, maxRows }, resolved.conn);
+    }
+  );
+
+  server.registerTool(
+    "list",
+    {
+      title: "List reddb collections or rows",
+      description:
+        "List collection names, or — when a collection is given — the first rows of that collection. Read-only.",
+      inputSchema: {
+        collection: z
+          .string()
+          .optional()
+          .describe("Collection to list rows from. Omit to list collections."),
+        connectionUrl: connectionUrlSchema,
+        maxRows: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Maximum rows when listing a collection (default 100)."),
+      },
+      outputSchema: {
+        ok: z.boolean(),
+        error: z.string().optional(),
+        collections: z.array(z.string()).optional(),
+        count: z.number().optional(),
+        collection: z.string().optional(),
+        columns: z.array(z.string()).optional(),
+        records: z.array(z.record(z.string(), z.unknown())).optional(),
+        recordCount: z.number().optional(),
+        truncated: z.boolean().optional(),
+        baseUrl: z.string().optional(),
+        mode: z.string().optional(),
+      },
+      _meta: MODEL_ONLY_META,
+    },
+    async ({ collection, connectionUrl, maxRows }) => {
+      let resolved;
+      try {
+        resolved = resolve(connectionUrl);
+      } catch (e) {
+        return fail(e instanceof Error ? e.message : String(e));
+      }
+      return runListTool(
+        resolved.client,
+        { collection, maxRows },
+        resolved.conn
+      );
+    }
+  );
+
+  server.registerTool(
+    "get",
+    {
+      title: "Get a reddb record",
+      description:
+        "Fetch a single record from a collection by id. Read-only; returns the record or null.",
+      inputSchema: {
+        collection: z.string().describe("Collection name."),
+        id: z.union([z.string(), z.number()]).describe("Record id to look up."),
+        idColumn: z
+          .string()
+          .optional()
+          .describe("Column to match the id against (default 'id')."),
+        connectionUrl: connectionUrlSchema,
+      },
+      outputSchema: {
+        ok: z.boolean(),
+        error: z.string().optional(),
+        found: z.boolean().optional(),
+        collection: z.string().optional(),
+        id: z.union([z.string(), z.number()]).optional(),
+        record: z.record(z.string(), z.unknown()).nullable().optional(),
+        baseUrl: z.string().optional(),
+        mode: z.string().optional(),
+      },
+      _meta: MODEL_ONLY_META,
+    },
+    async ({ collection, id, idColumn, connectionUrl }) => {
+      let resolved;
+      try {
+        resolved = resolve(connectionUrl);
+      } catch (e) {
+        return fail(e instanceof Error ? e.message : String(e));
+      }
+      return runGetTool(
+        resolved.client,
+        { collection, id, idColumn },
+        resolved.conn
+      );
+    }
+  );
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -18,6 +18,7 @@ import {
   spawnLocalServer,
   stopAllLocalServers,
 } from "./local-server.js";
+import { registerDataTools } from "./data-tools.js";
 
 // Single source of truth for "what version am I": the package.json version
 // (changeset-managed, version-locked with @reddb-io/ui + ui-kit), overridable by
@@ -52,6 +53,11 @@ type RedUiView = "home" | "query" | "collections" | "cluster" | "security";
 interface ServerConfig {
   appUrl: string;
   connectDomains: string[];
+  /** Default reddb endpoint the server-side data tools read from when a tool
+   *  call omits `connectionUrl`. Non-secret (ADR-0005). */
+  connectionUrl?: string;
+  /** Auth header value for the data tools' RedClient. Never logged/returned. */
+  connectionAuthHeader?: string;
 }
 
 function parseList(value: string | undefined): string[] {
@@ -88,6 +94,14 @@ function loadConfig(): ServerConfig {
     "http://127.0.0.1:25055",
   ];
 
+  // Auth for the server-side data tools: a bearer token (RED_UI_CONNECTION_TOKEN)
+  // or a raw Authorization header (RED_UI_CONNECTION_AUTH). Read from env only —
+  // never echoed into tool output or logs.
+  const token = process.env.RED_UI_CONNECTION_TOKEN?.trim();
+  const rawAuth = process.env.RED_UI_CONNECTION_AUTH?.trim();
+  const connectionAuthHeader =
+    rawAuth || (token ? `Bearer ${token}` : undefined);
+
   return {
     appUrl,
     connectDomains: [
@@ -96,6 +110,8 @@ function loadConfig(): ServerConfig {
         ...parseList(process.env.RED_UI_CONNECT_DOMAINS),
       ]),
     ],
+    connectionUrl: process.env.RED_UI_CONNECTION_URL?.trim() || undefined,
+    connectionAuthHeader,
   };
 }
 
@@ -520,6 +536,14 @@ function createServer(config: ServerConfig): McpServer {
     }
   );
 
+  // Server-side data tools (#49, ADR-0006): run a RedClient in this process and
+  // return reddb reads to the model as structuredContent, without driving the
+  // visual iframe. Honour the configured default connection + auth (env-only).
+  registerDataTools(server, {
+    defaultUrl: config.connectionUrl,
+    authHeader: config.connectionAuthHeader,
+  });
+
   return server;
 }
 
@@ -534,6 +558,9 @@ Environment:
   RED_UI_CONNECT_DOMAINS     Comma-separated extra connect-src domains for the embedded app.
   RED_BINARY                 Path to the reddb \`red\` binary used to serve local .rdb files.
                              Defaults to the @reddb-io/sdk binary, else \`red\` on PATH.
+  RED_UI_CONNECTION_URL      Default reddb endpoint for the data tools (query/list/get), e.g. http://localhost:5055.
+  RED_UI_CONNECTION_TOKEN    Bearer token for the data tools' RedClient (sent as Authorization: Bearer …; never logged).
+  RED_UI_CONNECTION_AUTH     Raw Authorization header for the data tools (overrides RED_UI_CONNECTION_TOKEN).
 
 Example client config:
   {

--- a/packages/mcp/src/red-client.ts
+++ b/packages/mcp/src/red-client.ts
@@ -1,0 +1,240 @@
+// Server-side reddb HTTP client for the MCP process (#49, ADR-0006).
+//
+// The MCP App's data tools (`query`/`list`/`get`) answer the *model* directly —
+// they run here in the Node process against the resolved connection, rather than
+// driving the visual iframe. This is a focused port of the browser client in
+// `packages/ui/src/lib/reddb/client.ts`: it covers only the read endpoints the
+// data tools need (`/query`, `/query/stream`, `/collections`) and reuses Node's
+// global `fetch` (Node >= 20). It is NOT @reddb-io/client — endpoints mirror the
+// hand-rolled UI client, verified against reddb's routing.rs.
+//
+// Auth lives entirely in the `headers` passed to the constructor; it is never
+// logged and never returned in tool output (acceptance: no secret/token leaks).
+
+export interface QueryRow {
+  values: Record<string, unknown>;
+  edges?: Record<string, unknown>;
+  nodes?: Record<string, unknown>;
+  paths?: unknown[];
+}
+
+export interface QueryResult {
+  ok: boolean;
+  query: string;
+  capability?: string;
+  engine?: string;
+  mode?: string;
+  record_count: number;
+  result: { columns: string[]; records: QueryRow[] };
+  error?: string;
+  /** True when assembled from the NDJSON stream rather than buffered `/query`. */
+  streamed?: boolean;
+  /** True when streaming stopped at `maxRows` with more rows on the server. */
+  truncated?: boolean;
+}
+
+/** Result of collecting a read-only SELECT over the NDJSON streaming endpoint. */
+export interface StreamedQueryResult {
+  columns: string[];
+  schemaFingerprint?: string;
+  rows: Array<Record<string, unknown>>;
+  rowCount: number;
+  truncated: boolean;
+  cursor?: string;
+}
+
+export interface RedClientOptions {
+  headers?: Record<string, string>;
+  fetch?: typeof fetch;
+}
+
+/** One NDJSON frame from `POST /query/stream`. Discriminated by its single key. */
+type NdjsonFrame =
+  | { descriptor: { columns: string[]; schema_fingerprint?: string } }
+  | { cursor: { token: string; snapshot_lsn?: number; resumable?: boolean } }
+  | { row: Record<string, unknown> }
+  | { end: { row_count?: number } }
+  | { cancelled: Record<string, unknown> };
+
+/**
+ * Parse a chunked `application/x-ndjson` body into one frame per line. Buffers
+ * across chunk boundaries and flushes a trailing newline-less line at EOF.
+ */
+async function* parseNdjsonFrames(
+  body: ReadableStream<Uint8Array>
+): AsyncGenerator<NdjsonFrame> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      let nl: number;
+      while ((nl = buf.indexOf("\n")) !== -1) {
+        const line = buf.slice(0, nl).trim();
+        buf = buf.slice(nl + 1);
+        if (line) yield JSON.parse(line) as NdjsonFrame;
+      }
+    }
+    const tail = buf.trim();
+    if (tail) yield JSON.parse(tail) as NdjsonFrame;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+const SELECT_RE = /^\s*select\b/i;
+
+export class RedClient {
+  readonly baseUrl: string;
+  private readonly headers: Record<string, string> | undefined;
+  private readonly fetcher: typeof fetch;
+
+  constructor(baseUrl: string, opts: RedClientOptions = {}) {
+    this.baseUrl = baseUrl.replace(/\/$/, "");
+    this.headers = opts.headers;
+    this.fetcher = opts.fetch ?? fetch;
+  }
+
+  private async json<T>(path: string, init?: RequestInit): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      ...this.headers,
+      ...(init?.headers as Record<string, string> | undefined),
+    };
+
+    const res = await this.fetcher(url, { ...init, headers });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      // The error body is the server's response, not our request — it never
+      // contains the auth header we sent. Truncated to keep tool output terse.
+      throw new Error(
+        `${init?.method ?? "GET"} ${path} → ${res.status} ${body.slice(0, 200)}`
+      );
+    }
+    return res.json() as Promise<T>;
+  }
+
+  /** Buffered query (`POST /query`). */
+  async query(query: string): Promise<QueryResult> {
+    return this.json<QueryResult>("/query", {
+      method: "POST",
+      body: JSON.stringify({ query }),
+    });
+  }
+
+  async collections(): Promise<string[]> {
+    const r = await this.json<{ collections: string[] }>("/collections");
+    return r.collections ?? [];
+  }
+
+  /**
+   * Stream a read-only SELECT through `POST /query/stream` (NDJSON, chunked),
+   * collecting up to `maxRows` before cancelling the server cursor. Throws for a
+   * non-SELECT (server `400`) and for an absent route on an older server (`404`)
+   * — callers fall back to {@link query}.
+   */
+  async queryStreamCollect(
+    query: string,
+    opts: { maxRows?: number; signal?: AbortSignal } = {}
+  ): Promise<StreamedQueryResult> {
+    const maxRows = opts.maxRows ?? 10_000;
+    const res = await this.fetcher(`${this.baseUrl}/query/stream`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/x-ndjson",
+        ...this.headers,
+      },
+      body: JSON.stringify({ query }),
+      signal: opts.signal,
+    });
+    if (!res.ok || !res.body) {
+      const body = res.body ? await res.text().catch(() => "") : "";
+      throw new Error(
+        `POST /query/stream → ${res.status} ${body.slice(0, 200)}`
+      );
+    }
+
+    const out: StreamedQueryResult = {
+      columns: [],
+      rows: [],
+      rowCount: 0,
+      truncated: false,
+    };
+
+    for await (const frame of parseNdjsonFrames(res.body)) {
+      if ("descriptor" in frame) {
+        out.columns = frame.descriptor.columns ?? [];
+        out.schemaFingerprint = frame.descriptor.schema_fingerprint;
+      } else if ("cursor" in frame) {
+        out.cursor = frame.cursor.token;
+      } else if ("row" in frame) {
+        if (out.rows.length >= maxRows) {
+          out.truncated = true;
+          break;
+        }
+        out.rows.push(frame.row);
+        out.rowCount = out.rows.length;
+      } else if ("end" in frame || "cancelled" in frame) {
+        break;
+      }
+    }
+
+    if (out.truncated && out.cursor) {
+      await this.cancelQueryStream(out.cursor).catch(() => {
+        // best-effort: the cursor TTL reclaims it anyway.
+      });
+    }
+    return out;
+  }
+
+  /** Cancel a streaming-query cursor server-side (`POST /query/stream/cancel`). */
+  async cancelQueryStream(cursor: string): Promise<void> {
+    await this.json("/query/stream/cancel", {
+      method: "POST",
+      body: JSON.stringify({ cursor }),
+    }).catch(() => undefined);
+  }
+}
+
+/** A read-only client surface — the only methods the data tools depend on. So
+ *  tests can pass a mock, and #48's local-spawn path can supply its own. */
+export type ReadClient = Pick<
+  RedClient,
+  "query" | "collections" | "queryStreamCollect"
+>;
+
+/**
+ * Run a read SELECT preferring the bounded-memory NDJSON stream, falling back to
+ * the buffered `POST /query` for everything the stream can't take — a non-SELECT
+ * statement, a network error, or an older server with no `/query/stream` route.
+ * Honest streaming negotiation (#22): identical to {@link RedClient.query}
+ * unless the server supports streaming AND the statement is a SELECT.
+ */
+export async function runQueryPreferStream(
+  client: ReadClient,
+  sql: string,
+  opts: { maxRows?: number; signal?: AbortSignal } = {}
+): Promise<QueryResult> {
+  if (!SELECT_RE.test(sql)) return client.query(sql);
+  try {
+    const s = await client.queryStreamCollect(sql, opts);
+    return {
+      ok: true,
+      query: sql,
+      record_count: s.rowCount,
+      result: {
+        columns: s.columns,
+        records: s.rows.map((values) => ({ values })),
+      },
+      streamed: true,
+      truncated: s.truncated,
+    };
+  } catch {
+    return client.query(sql);
+  }
+}

--- a/packages/mcp/test/data-tools.test.mjs
+++ b/packages/mcp/test/data-tools.test.mjs
@@ -1,0 +1,289 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const { RedClient } = await import(join(packageDir, "dist/red-client.js"));
+const { runQueryTool, runListTool, runGetTool, isReadOnlyQuery, leadingVerb } =
+  await import(join(packageDir, "dist/data-tools.js"));
+const { resolveConnection } = await import(
+  join(packageDir, "dist/connection.js")
+);
+
+let failures = 0;
+function assert(cond, msg) {
+  if (!cond) {
+    failures++;
+    console.error("FAIL:", msg);
+  }
+}
+
+// A mock reddb at the fetch boundary: a genuine round-trip exercises the real
+// RedClient parsing + the real tool handler shaping against canned responses.
+// `seenAuth` captures the Authorization header so we can prove it is sent to the
+// server but never leaks into tool output.
+function mockFetch(routes) {
+  const seenAuth = [];
+  const fetcher = async (url, init = {}) => {
+    const u = String(url);
+    const method = init.method ?? "GET";
+    const headers = new Headers(init.headers);
+    seenAuth.push(headers.get("authorization"));
+    for (const r of routes) {
+      if (r.method === method && u.endsWith(r.path)) {
+        return new Response(JSON.stringify(r.body), {
+          status: r.status ?? 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    }
+    return new Response(
+      JSON.stringify({ ok: false, error: "route not found" }),
+      {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  };
+  fetcher.seenAuth = seenAuth;
+  return fetcher;
+}
+
+const conn = { baseUrl: "http://reddb.test", mode: "remote" };
+
+function clientFor(routes, headers) {
+  const fetcher = mockFetch(routes);
+  const client = new RedClient("http://reddb.test", {
+    fetch: fetcher,
+    headers,
+  });
+  return { client, fetcher };
+}
+
+// ---- read-only guard ----------------------------------------------------
+assert(isReadOnlyQuery("SELECT * FROM t"), "SELECT is read-only");
+assert(
+  isReadOnlyQuery("  with x as (select 1) select * from x"),
+  "WITH is read-only"
+);
+assert(isReadOnlyQuery("-- a comment\nSELECT 1"), "leading comment stripped");
+assert(!isReadOnlyQuery("INSERT INTO t VALUES (1)"), "INSERT refused");
+assert(!isReadOnlyQuery("DROP TABLE t"), "DROP refused");
+assert(!isReadOnlyQuery("DELETE FROM t"), "DELETE refused");
+assert(
+  leadingVerb("/* c */ EXPLAIN SELECT 1") === "explain",
+  "block comment stripped"
+);
+
+// ---- query tool: streams a SELECT, falls back, shapes structuredContent --
+{
+  // /query/stream is absent (404) → falls back to buffered /query.
+  const { client } = clientFor([
+    {
+      method: "POST",
+      path: "/query",
+      body: {
+        ok: true,
+        query: "SELECT * FROM users",
+        record_count: 2,
+        result: {
+          columns: ["id", "name"],
+          records: [
+            { values: { id: 1, name: "ada" } },
+            { values: { id: 2, name: "alan" } },
+          ],
+        },
+      },
+    },
+  ]);
+  const res = await runQueryTool(
+    client,
+    { query: "SELECT * FROM users" },
+    conn
+  );
+  assert(!res.isError, "query tool ok");
+  assert(res.structuredContent.recordCount === 2, "query recordCount");
+  assert(
+    JSON.stringify(res.structuredContent.records) ===
+      JSON.stringify([
+        { id: 1, name: "ada" },
+        { id: 2, name: "alan" },
+      ]),
+    "query records shaped as value objects"
+  );
+  assert(
+    res.structuredContent.baseUrl === "http://reddb.test",
+    "query baseUrl present"
+  );
+}
+
+// ---- query tool: refuses a write statement (read-shaped only) -----------
+{
+  const { client, fetcher } = clientFor([]);
+  const res = await runQueryTool(client, { query: "DELETE FROM users" }, conn);
+  assert(res.isError === true, "write query is an error");
+  assert(
+    /not a read statement/.test(res.structuredContent.error),
+    "write refusal message"
+  );
+  assert(fetcher.seenAuth.length === 0, "refused query never hit the network");
+}
+
+// ---- list tool: no collection → collection names ------------------------
+{
+  const { client } = clientFor([
+    {
+      method: "GET",
+      path: "/collections",
+      body: { collections: ["users", "orders"] },
+    },
+  ]);
+  const res = await runListTool(client, {}, conn);
+  assert(!res.isError, "list collections ok");
+  assert(
+    JSON.stringify(res.structuredContent.collections) ===
+      JSON.stringify(["users", "orders"]),
+    "list returns collection names"
+  );
+  assert(res.structuredContent.count === 2, "list count");
+}
+
+// ---- list tool: with collection → rows via SELECT -----------------------
+{
+  const { client } = clientFor([
+    {
+      method: "POST",
+      path: "/query",
+      body: {
+        ok: true,
+        query: "SELECT * FROM users LIMIT 100",
+        record_count: 1,
+        result: { columns: ["id"], records: [{ values: { id: 7 } }] },
+      },
+    },
+  ]);
+  const res = await runListTool(client, { collection: "users" }, conn);
+  assert(!res.isError, "list rows ok");
+  assert(
+    res.structuredContent.collection === "users",
+    "list echoes collection"
+  );
+  assert(res.structuredContent.recordCount === 1, "list rows count");
+}
+
+// ---- list tool: rejects a non-identifier collection (injection guard) ---
+{
+  const { client, fetcher } = clientFor([]);
+  const res = await runListTool(
+    client,
+    { collection: "users; DROP TABLE x" },
+    conn
+  );
+  assert(res.isError === true, "bad collection name refused");
+  assert(fetcher.seenAuth.length === 0, "bad identifier never hit the network");
+}
+
+// ---- get tool: single record by id --------------------------------------
+{
+  const { client } = clientFor([
+    {
+      method: "POST",
+      path: "/query",
+      body: {
+        ok: true,
+        query: "SELECT * FROM users WHERE id = 7 LIMIT 1",
+        record_count: 1,
+        result: {
+          columns: ["id", "name"],
+          records: [{ values: { id: 7, name: "grace" } }],
+        },
+      },
+    },
+  ]);
+  const res = await runGetTool(client, { collection: "users", id: 7 }, conn);
+  assert(!res.isError, "get ok");
+  assert(res.structuredContent.found === true, "get found");
+  assert(res.structuredContent.record.name === "grace", "get record value");
+}
+
+// ---- get tool: not found → record null ----------------------------------
+{
+  const { client } = clientFor([
+    {
+      method: "POST",
+      path: "/query",
+      body: {
+        ok: true,
+        query: "x",
+        record_count: 0,
+        result: { columns: [], records: [] },
+      },
+    },
+  ]);
+  const res = await runGetTool(
+    client,
+    { collection: "users", id: "missing" },
+    conn
+  );
+  assert(!res.isError, "get-missing ok");
+  assert(res.structuredContent.found === false, "get-missing not found");
+  assert(res.structuredContent.record === null, "get-missing record null");
+}
+
+// ---- secret hygiene: auth header is sent to the server, never returned --
+{
+  const { client, fetcher } = clientFor(
+    [
+      {
+        method: "POST",
+        path: "/query",
+        body: {
+          ok: true,
+          query: "x",
+          record_count: 0,
+          result: { columns: [], records: [] },
+        },
+      },
+    ],
+    { Authorization: "Bearer s3cr3t-token" }
+  );
+  const res = await runQueryTool(client, { query: "SELECT 1" }, conn);
+  assert(
+    fetcher.seenAuth.includes("Bearer s3cr3t-token"),
+    "auth header reaches the server"
+  );
+  const serialized = JSON.stringify(res);
+  assert(
+    !serialized.includes("s3cr3t-token"),
+    "token never appears in tool output"
+  );
+}
+
+// ---- connection resolver: local file is refused (#48 not implemented) ---
+{
+  let threw = false;
+  try {
+    resolveConnection("/var/lib/reddb/data.rdb");
+  } catch (e) {
+    threw = true;
+    assert(/#48/.test(e.message), "local-file error references #48");
+  }
+  assert(threw, "local file target throws");
+
+  const r = resolveConnection("red://localhost:5055");
+  assert(r.baseUrl === "http://localhost:5055", "red:// normalised to http://");
+  assert(r.mode === "remote", "red:// is remote");
+
+  let threwEmpty = false;
+  try {
+    resolveConnection(undefined);
+  } catch {
+    threwEmpty = true;
+  }
+  assert(threwEmpty, "absent target with no default throws");
+}
+
+if (failures > 0) {
+  console.error(`data-tools test FAILED (${failures} assertion(s))`);
+  process.exit(1);
+}
+console.log("data-tools test passed");

--- a/packages/mcp/test/mcp-app-smoke.mjs
+++ b/packages/mcp/test/mcp-app-smoke.mjs
@@ -52,6 +52,25 @@ try {
     `open_red_ui must point at the MCP App resource, got ${JSON.stringify(openTool._meta)}`
   );
 
+  // Server-side data tools (#49) are registered as model-facing tools.
+  for (const name of ["query", "list", "get"]) {
+    const dataTool = tools.tools.find((tool) => tool.name === name);
+    assert(dataTool, `${name} data tool was not registered`);
+    assert(
+      dataTool.outputSchema,
+      `${name} must declare an outputSchema for structuredContent`
+    );
+  }
+
+  // With no configured connection, a data tool reports the missing-connection
+  // error rather than crashing — and leaks no token.
+  const noConn = await client.callTool({ name: "list", arguments: {} });
+  assert(noConn.isError === true, "list with no connection must be an error");
+  assert(
+    noConn.structuredContent?.ok === false,
+    "list error must carry structuredContent { ok: false }"
+  );
+
   const result = await client.callTool({
     name: "open_red_ui",
     arguments: { connectionUrl: "red://localhost", view: "query" },


### PR DESCRIPTION
Lands the completed work for #49 (PRD #19). AFK worker wLLY9 implemented + verified it (commit bef01e6) but exited without a DONE sentinel, so the orchestrator never merged. Re-verified locally: `pnpm --filter @reddb-io/ui-mcp test` green (tsc build + smoke + target-mode + data-tools).

Closes #49

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783003336&installation_id=129708444&pr_number=55&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F55&signature=f7785122727810beb5fad74e8fcd657d6c38b6cb915e89b116dc24eaed4f7ced"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side data tools: model-facing `query`, `list`, and `get` for reading backend data
  * Per-call connection resolution with support for red://, https://, and http:// endpoints; local-file targets are not yet supported
  * Authentication via RED_UI_CONNECTION_TOKEN / RED_UI_CONNECTION_AUTH environment variables

* **Safety & Reliability**
  * Read-only query enforcement and identifier validation to prevent unsafe operations
  * NDJSON streaming with buffered fallback for robust query results

* **Tests / Docs**
  * Added tests and a changeset entry documenting the feature and behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->