### PR TITLE
feat(mcp): open local .rdb --read-only when held by a writer (#50)

### DIFF
--- a/.changeset/mcp-local-file-read-only-when-locked.md
+++ b/.changeset/mcp-local-file-read-only-when-locked.md
@@ -1,0 +1,13 @@
+---
+"@reddb-io/ui-mcp": minor
+---
+
+The MCP App now opens a local `.rdb` `--read-only` when it is already held by
+another writer instead of failing on reddb's single-writer `flock` (ADR-0006,
+#50). When the caller does not pin a mode, `spawnLocalServer` opens read-write
+first and, if the `red server` child dies acquiring the lock, transparently
+retries with `--read-only`; reddb then reports `read_only` in `/stats` and the
+UI renders the existing read-only badge (#23). The trigger case is inspecting an
+agent's live memory `.rdb` while the agent is writing it. A file with no active
+writer still opens read-write, and an explicit `readOnly` is honoured verbatim
+with no fallback.

--- a/.red/adr/0006-mcp-local-file-spawns-red-server.md
+++ b/.red/adr/0006-mcp-local-file-spawns-red-server.md
@@ -10,10 +10,12 @@ so the MCP process **spawns `red server --http-bind 127.0.0.1:<ephemeral> --path
 ## Status
 
 accepted — local-file path implemented by #48 (`packages/mcp/src/local-server.ts`,
-`target-mode.ts`), merged via PR #54 on 2026-06-02. Remaining PRD #19 slices:
-#49 (server-side data tools), #50 (lock-aware `--read-only`), #51 (same-origin
-embeddable bundle). The "Today `packages/mcp` is a pure display proxy" framing in
-Context below is the historical state at authoring time, kept as the decision's _why_.
+`target-mode.ts`), merged via PR #54 on 2026-06-02; lock-aware `--read-only`
+fallback implemented by #50 (`spawnLocalServer` opens read-write, then retries
+`--read-only` when reddb dies on the single-writer `flock`). Remaining PRD #19
+slices: #49 (server-side data tools), #51 (same-origin embeddable bundle). The
+"Today `packages/mcp` is a pure display proxy" framing in Context below is the
+historical state at authoring time, kept as the decision's _why_.
 
 ## Context
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -477,11 +477,14 @@ function createServer(config: ServerConfig): McpServer {
         const target = connectionUrl ?? "";
         try {
           const local = await openLocalServer(target);
+          const readOnlyNote = local.readOnly
+            ? " (read-only: the file is already held by another writer)"
+            : "";
           return {
             content: [
               {
                 type: "text",
-                text: `Serving local file ${local.filePath} via a red server at ${local.baseUrl}; opening red-ui ${selectedView} view.`,
+                text: `Serving local file ${local.filePath} via a red server at ${local.baseUrl}${readOnlyNote}; opening red-ui ${selectedView} view.`,
               },
             ],
             structuredContent: {

--- a/packages/mcp/src/local-server.ts
+++ b/packages/mcp/src/local-server.ts
@@ -1,4 +1,4 @@
-// Local-file mode for the MCP App (#48, ADR-0006).
+// Local-file mode for the MCP App (#48, #50, ADR-0006).
 //
 // A browser Surface cannot reach a filesystem `.rdb`, and the MCP process (Node)
 // cannot open it either — reddb's embedded mode is Rust-only. So for a local
@@ -7,6 +7,13 @@
 // and hand the UI `?cs=http://127.0.0.1:<port>`. The child is torn down on MCP
 // exit/disconnect — no orphan servers. We never reimplement the reddb HTTP API;
 // we shell out to the `red` binary.
+//
+// Lock-aware open (#50): reddb takes a single-writer `flock` on the file. The
+// trigger case is inspecting an agent's live memory `.rdb` while the agent is
+// writing it — a read-write open would fail on the lock. So when the caller does
+// not pin `readOnly`, we open read-write first and, if reddb dies on the lock,
+// transparently retry with `--read-only`. reddb then reports `read_only` in
+// `/stats` and the UI renders the existing read-only badge (#23).
 
 import { spawn, type ChildProcess } from "node:child_process";
 import { accessSync, constants as fsConstants } from "node:fs";
@@ -199,22 +206,60 @@ async function waitForHealthy(
 }
 
 /**
- * Spawn one `red server` that owns `target`, wait for `/stats` to report
- * healthy, and return a handle whose `stop()` tears the child down.
+ * Raised when `red server` dies trying to acquire the single-writer `flock` on
+ * the target — the signal to retry the open with `--read-only` (#50).
  */
-export async function spawnLocalServer(
-  options: SpawnLocalServerOptions
-): Promise<LocalServerHandle> {
-  const {
-    target,
-    readOnly = false,
-    healthTimeoutMs = 10_000,
-    signal,
-  } = options;
-  const filePath = resolveLocalFilePath(target);
-  const binaryPath =
-    options.binaryPath ?? (await resolveRedBinary()).binaryPath;
-  const port = options.port ?? (await pickEphemeralPort());
+export class LockContentionError extends Error {
+  constructor(public readonly detail: string) {
+    super(
+      "The .rdb is already held by another writer (reddb single-writer flock)." +
+        (detail ? `\n${detail}` : "")
+    );
+    this.name = "LockContentionError";
+  }
+}
+
+// Signatures of reddb failing to take the single-writer `flock` on the file,
+// across platforms and wordings. Deliberately broad: a false positive only costs
+// one extra `--read-only` retry, while a miss leaves the trigger case (a live
+// agent memory `.rdb`) unopenable. We cannot import reddb's exact message —
+// it is a separate Rust binary — so we match the family of lock-contention text.
+const LOCK_CONTENTION_PATTERNS = [
+  /flock/i,
+  /\block(ed|ing)?\b/i,
+  /would.?block/i,
+  /resource temporarily unavailable/i,
+  /\bE?WOULDBLOCK\b|\bEAGAIN\b/i,
+  /another (process|writer|instance)/i,
+  /already (open|held|locked|running)/i,
+  /single.?writer/i,
+  /in use by/i,
+  /read[-_ ]?only/i,
+];
+
+/** True when `text` (a `red server` stderr) looks like single-writer lock
+ *  contention — used to decide whether to retry the open as `--read-only`. */
+export function looksLikeLockContention(text: string): boolean {
+  return Boolean(text) && LOCK_CONTENTION_PATTERNS.some((re) => re.test(text));
+}
+
+interface AttemptOptions {
+  binaryPath: string;
+  filePath: string;
+  readOnly: boolean;
+  port?: number;
+  healthTimeoutMs: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Spawn one `red server` for a single open mode and wait for `/stats` healthy.
+ * Resolves to a tracked-elsewhere handle, or rejects: with `LockContentionError`
+ * when the child died on the flock (caller may retry `--read-only`), otherwise
+ * with the raw startup error.
+ */
+async function attemptSpawn(opts: AttemptOptions): Promise<LocalServerHandle> {
+  const port = opts.port ?? (await pickEphemeralPort());
   const baseUrl = `http://127.0.0.1:${port}`;
 
   const args = [
@@ -223,11 +268,11 @@ export async function spawnLocalServer(
     "--http-bind",
     `127.0.0.1:${port}`,
     "--path",
-    filePath,
+    opts.filePath,
   ];
-  if (readOnly) args.push("--read-only");
+  if (opts.readOnly) args.push("--read-only");
 
-  const child = spawn(binaryPath, args, {
+  const child = spawn(opts.binaryPath, args, {
     stdio: ["ignore", "ignore", "pipe"],
   });
 
@@ -240,8 +285,8 @@ export async function spawnLocalServer(
   const handle: LocalServerHandle = {
     baseUrl,
     port,
-    filePath,
-    readOnly,
+    filePath: opts.filePath,
+    readOnly: opts.readOnly,
     child,
     stop: makeStop(child),
   };
@@ -250,13 +295,62 @@ export async function spawnLocalServer(
     await waitForHealthy(
       baseUrl,
       child,
-      healthTimeoutMs,
+      opts.healthTimeoutMs,
       () => stderr.trim(),
-      signal
+      opts.signal
     );
   } catch (error) {
     await handle.stop();
+    // Did the child die on the single-writer flock? If so, let the caller decide
+    // to retry --read-only rather than surfacing a raw "exited" error.
+    const exited = child.exitCode !== null || child.signalCode !== null;
+    if (!opts.readOnly && exited && looksLikeLockContention(stderr)) {
+      throw new LockContentionError(stderr.trim());
+    }
     throw error;
+  }
+
+  return handle;
+}
+
+/**
+ * Spawn one `red server` that owns `target`, wait for `/stats` to report
+ * healthy, and return a handle whose `stop()` tears the child down.
+ *
+ * Open mode (#50): an explicit `readOnly` is honoured verbatim. When it is
+ * unspecified, the file opens read-write but transparently falls back to
+ * `--read-only` if reddb dies acquiring the single-writer `flock` — the trigger
+ * case being a second viewer of a live agent memory `.rdb` (ADR-0006).
+ */
+export async function spawnLocalServer(
+  options: SpawnLocalServerOptions
+): Promise<LocalServerHandle> {
+  const { target, healthTimeoutMs = 10_000, signal } = options;
+  const filePath = resolveLocalFilePath(target);
+  const binaryPath =
+    options.binaryPath ?? (await resolveRedBinary()).binaryPath;
+
+  const attempt = (readOnly: boolean): Promise<LocalServerHandle> =>
+    attemptSpawn({
+      binaryPath,
+      filePath,
+      readOnly,
+      port: options.port,
+      healthTimeoutMs,
+      signal,
+    });
+
+  let handle: LocalServerHandle;
+  if (options.readOnly !== undefined) {
+    handle = await attempt(options.readOnly);
+  } else {
+    try {
+      handle = await attempt(false);
+    } catch (error) {
+      if (!(error instanceof LockContentionError)) throw error;
+      // The file is flock-held by another writer — reopen read-only (#50).
+      handle = await attempt(true);
+    }
   }
 
   trackServer(handle);

--- a/packages/mcp/test/fake-red.mjs
+++ b/packages/mcp/test/fake-red.mjs
@@ -6,6 +6,8 @@
 //
 //   FAKE_RED_FAIL=exit       exit immediately (simulate a bad binary / bad file)
 //   FAKE_RED_DELAY_MS=<n>    delay before `/stats` starts answering (default 150)
+//   FAKE_RED_LOCKED=1        simulate the single-writer flock being held: a
+//                            read-write open dies on the lock; --read-only starts
 
 import http from "node:http";
 
@@ -13,10 +15,21 @@ const args = process.argv.slice(2);
 const bindIdx = args.indexOf("--http-bind");
 const bind = bindIdx >= 0 ? args[bindIdx + 1] : "127.0.0.1:0";
 const [host, portStr] = bind.split(":");
+const readOnly = args.includes("--read-only");
 
 if (process.env.FAKE_RED_FAIL === "exit") {
   process.stderr.write("fake red: refusing to start (FAKE_RED_FAIL)\n");
   process.exit(3);
+}
+
+// Single-writer flock contention: only a read-write open contends for the lock;
+// a --read-only open does not and starts cleanly.
+if (process.env.FAKE_RED_LOCKED === "1" && !readOnly) {
+  process.stderr.write(
+    "fake red: failed to acquire exclusive lock on database file: " +
+      "resource temporarily unavailable (another writer holds the flock)\n"
+  );
+  process.exit(1);
 }
 
 const delayMs = Number(process.env.FAKE_RED_DELAY_MS ?? 150);
@@ -25,7 +38,9 @@ setTimeout(() => {
   const server = http.createServer((req, res) => {
     if (req.url === "/stats") {
       res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ store: { collection_count: 0 } }));
+      res.end(
+        JSON.stringify({ store: { collection_count: 0 }, read_only: readOnly })
+      );
       return;
     }
     res.writeHead(404);

--- a/packages/mcp/test/local-server.test.mjs
+++ b/packages/mcp/test/local-server.test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 const here = dirname(fileURLToPath(import.meta.url));
 const packageDir = dirname(here);
 const {
+  looksLikeLockContention,
   resolveLocalFilePath,
   resolveRedBinary,
   spawnLocalServer,
@@ -101,6 +102,10 @@ assert(
     handle.filePath === "/tmp/red-ui-mcp-test.rdb",
     "filePath is resolved"
   );
+  assert(
+    handle.readOnly === false,
+    "a file with no active writer opens read-write"
+  );
   assert(await isUp(handle.baseUrl), "server must be healthy after spawn");
 
   await handle.stop();
@@ -155,6 +160,87 @@ assert(
   await stopAllLocalServers();
   assert(!(await isUp(a.baseUrl)), "server a down after stopAll");
   assert(!(await isUp(b.baseUrl)), "server b down after stopAll");
+}
+
+// --- lock detection predicate: lock-contention text vs unrelated failures ----
+for (const text of [
+  "failed to acquire exclusive lock: resource temporarily unavailable",
+  "another writer holds the flock",
+  "database is already locked",
+  "EWOULDBLOCK while opening db",
+  "opened read-only because the file is in use",
+]) {
+  assert(
+    looksLikeLockContention(text),
+    `lock-contention text must be detected: ${text}`
+  );
+}
+for (const text of [
+  "",
+  "no such file or directory",
+  "permission denied",
+  "failed to bind to 127.0.0.1: address already in use",
+]) {
+  assert(
+    !looksLikeLockContention(text),
+    `unrelated failure must NOT be read as a lock: ${text}`
+  );
+}
+
+// --- locked file (#50): a flock-held writer → transparent --read-only open ----
+{
+  const saved = process.env.FAKE_RED_LOCKED;
+  process.env.FAKE_RED_LOCKED = "1";
+  let handle = null;
+  try {
+    handle = await spawnLocalServer({
+      target: "/tmp/red-ui-mcp-locked.rdb",
+      binaryPath: FAKE_RED,
+      healthTimeoutMs: 5000,
+    });
+    assert(
+      handle.readOnly === true,
+      "a file held by another writer must open --read-only"
+    );
+    assert(await isUp(handle.baseUrl), "read-only server must be healthy");
+    const stats = await (
+      await fetch(`${handle.baseUrl}/stats`, {
+        signal: AbortSignal.timeout(1000),
+      })
+    ).json();
+    assert(
+      stats.read_only === true,
+      "/stats.read_only must be true for the locked file (drives the #23 badge)"
+    );
+  } finally {
+    if (handle) await handle.stop();
+    if (saved === undefined) delete process.env.FAKE_RED_LOCKED;
+    else process.env.FAKE_RED_LOCKED = saved;
+  }
+}
+
+// --- explicit readOnly:false is honoured — no fallback even if it can't lock --
+{
+  const saved = process.env.FAKE_RED_LOCKED;
+  process.env.FAKE_RED_LOCKED = "1";
+  let threw = null;
+  let handle = null;
+  try {
+    handle = await spawnLocalServer({
+      target: "/tmp/red-ui-mcp-rw-forced.rdb",
+      binaryPath: FAKE_RED,
+      readOnly: false,
+      healthTimeoutMs: 5000,
+    });
+  } catch (error) {
+    threw = error;
+  } finally {
+    if (handle) await handle.stop();
+    if (saved === undefined) delete process.env.FAKE_RED_LOCKED;
+    else process.env.FAKE_RED_LOCKED = saved;
+  }
+  assert(!handle, "explicit readOnly:false must not silently fall back");
+  assert(threw, "explicit readOnly:false against a locked file must reject");
 }
 
 console.log("local-server lifecycle test passed");


### PR DESCRIPTION
Lands completed work for #50 (PRD #19, ADR-0006). AFK worker wF5TE implemented + verified (commit a7c6393) but exited no-sentinel. Re-verified locally: `pnpm --filter @reddb-io/ui-mcp test` green (build + 4 suites).

Closes #50

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783007566&installation_id=129708444&pr_number=56&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F56&signature=41d3288198433c6fdef7d30c4dbbe55142816ff631d47001e4e14b8c87921cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic read-only fallback when a local database file is locked by another writer, preventing connection failures.
  * UI now displays read-only status in stats and trigger badge when operating in fallback mode.

* **Documentation**
  * Updated architecture documentation to reflect read-only fallback implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->