### PR TITLE
feat(mcp): serve embeddable bundle same-origin on localhost in local mode (#51)

### DIFF
--- a/.changeset/mcp-local-same-origin-ui.md
+++ b/.changeset/mcp-local-same-origin-ui.md
@@ -1,0 +1,18 @@
+---
+"@reddb-io/ui-mcp": minor
+"@reddb-io/ui": minor
+---
+
+MCP local-file mode now serves the Embeddable Lib bundle (#37) itself over
+`http://127.0.0.1:<port>` and points the embedded iframe there instead of the
+hosted HTTPS origin (ADR-0006, #51). The visual UI and the spawned `red server`
+then share an `http://` scheme, so there is no HTTPS→`http://localhost`
+mixed-content block (Chrome exempts localhost, but Firefox/Safari are
+unreliable) and a local session works fully offline. The host page imports the
+same-origin bundle and mounts red-ui through an `InjectedClientProvider` seeded
+from the `?cs=` endpoint. One embed server per MCP process, torn down with the
+local `red server` on disconnect/exit. The bundle directory is resolved from the
+installed `@reddb-io/ui` (overridable via `RED_UI_EMBED_DIR`); the `red-ui mcp`
+launcher passes it through. Remote mode is unchanged — it still loads the hosted
+UI and spawns nothing. The app resource's CSP now also allows loopback origins
+(`http://localhost:*`, `http://127.0.0.1:*`) for framing, scripts, and fetches.

--- a/.red/adr/0006-mcp-local-file-spawns-red-server.md
+++ b/.red/adr/0006-mcp-local-file-spawns-red-server.md
@@ -10,12 +10,15 @@ so the MCP process **spawns `red server --http-bind 127.0.0.1:<ephemeral> --path
 ## Status
 
 accepted — local-file path implemented by #48 (`packages/mcp/src/local-server.ts`,
-`target-mode.ts`), merged via PR #54 on 2026-06-02; lock-aware `--read-only`
-fallback implemented by #50 (`spawnLocalServer` opens read-write, then retries
-`--read-only` when reddb dies on the single-writer `flock`). Remaining PRD #19
-slices: #49 (server-side data tools), #51 (same-origin embeddable bundle). The
-"Today `packages/mcp` is a pure display proxy" framing in Context below is the
-historical state at authoring time, kept as the decision's _why_.
+`target-mode.ts`), merged via PR #54 on 2026-06-02. **PRD #19 fully implemented:**
+#49 (server-side data tools), #50 (lock-aware `--read-only`: `spawnLocalServer`
+opens read-write, then retries `--read-only` when reddb dies on the single-writer
+`flock`), and #51 (same-origin embeddable bundle, `packages/mcp/src/embed-server.ts`:
+in local mode the MCP serves the Embeddable Lib over `http://127.0.0.1:<port>` and
+points the iframe there, so the UI and the spawned red server share an http scheme —
+no mixed-content block, works offline). The "Today `packages/mcp` is a pure display
+proxy" framing in Context below is the historical state at authoring time, kept as
+the decision's _why_.
 
 ## Context
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -20,7 +20,7 @@
     "prepack": "pnpm build",
     "build": "tsc -p tsconfig.json",
     "check": "tsc -p tsconfig.json --noEmit",
-    "test": "pnpm build && node test/mcp-app-smoke.mjs && node test/target-mode.test.mjs && node test/local-server.test.mjs && node test/data-tools.test.mjs",
+    "test": "pnpm build && node test/mcp-app-smoke.mjs && node test/target-mode.test.mjs && node test/local-server.test.mjs && node test/embed-server.test.mjs && node test/data-tools.test.mjs",
     "start": "tsx src/index.ts --stdio"
   },
   "dependencies": {

--- a/packages/mcp/src/embed-server.ts
+++ b/packages/mcp/src/embed-server.ts
@@ -1,0 +1,355 @@
+// Same-origin local UI for the MCP App (#51, ADR-0006).
+//
+// In local-file mode the API is a spawned `red server` on `http://127.0.0.1:<port>`
+// (see local-server.ts). If the visual UI is still loaded from the hosted HTTPS
+// origin (https://ui.reddb.io), the browser sees an HTTPS page fetching an
+// `http://localhost` API — mixed content. Chrome exempts localhost, but Firefox
+// and Safari are unreliable, and it requires the network anyway.
+//
+// So for local mode we serve the Embeddable Lib bundle (#37, shipped in
+// `@reddb-io/ui/dist/embed`) ourselves over `http://127.0.0.1:<port>`. The iframe
+// then loads from `http://localhost` and fetches the `http://localhost` API:
+// same scheme, no mixed content, fully offline. The embed bundle owns auth via
+// an InjectedClientProvider seeded from the `?cs=` connection string.
+//
+// One embed server per MCP process (the bundle is identical regardless of which
+// file is open); torn down on MCP exit/disconnect — no orphan servers.
+
+import {
+  type IncomingMessage,
+  type ServerResponse,
+  createServer,
+} from "node:http";
+import type { Server } from "node:http";
+import {
+  accessSync,
+  constants as fsConstants,
+  createReadStream,
+} from "node:fs";
+import { createServer as createNetServer } from "node:net";
+import { createRequire } from "node:module";
+import {
+  dirname,
+  extname,
+  isAbsolute,
+  join,
+  normalize,
+  relative,
+  resolve,
+} from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const here = dirname(fileURLToPath(import.meta.url));
+
+export interface EmbedServerHandle {
+  baseUrl: string;
+  port: number;
+  /** Absolute path of the served embed bundle directory. */
+  embedDir: string;
+  server: Server;
+  /** Idempotent teardown; resolves once the HTTP server has closed. */
+  stop(): Promise<void>;
+}
+
+export interface StartEmbedServerOptions {
+  /** Override the embed bundle directory (tests, explicit config). */
+  embedDir?: string;
+  /** Override the ephemeral port (tests). */
+  port?: number;
+}
+
+function isFile(file: string): boolean {
+  try {
+    accessSync(file, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Locate the built Embeddable Lib bundle directory (`@reddb-io/ui/dist/embed`),
+ * the one containing `index.js`. Resolution order: explicit `RED_UI_EMBED_DIR`
+ * → the published `@reddb-io/ui/embed` export → the monorepo sibling
+ * (`packages/ui/dist/embed`) → the published dependency layout (the MCP lives in
+ * `<ui>/node_modules/@reddb-io/ui-mcp`). Throws an actionable error when none of
+ * these holds the bundle.
+ */
+export function resolveEmbedDir(override?: string): string {
+  const candidates: string[] = [];
+
+  const fromArg = override?.trim() || process.env.RED_UI_EMBED_DIR?.trim();
+  if (fromArg) candidates.push(resolve(fromArg));
+
+  // `@reddb-io/ui` exports `./embed` → `<ui>/dist/embed/index.js`.
+  try {
+    candidates.push(dirname(require.resolve("@reddb-io/ui/embed")));
+  } catch {
+    // Not resolvable from here (e.g. the monorepo, where ui depends on the MCP
+    // and not the reverse). Fall through to path-based strategies.
+  }
+
+  // Monorepo dev/test: packages/mcp/dist/embed-server.js → packages/ui/dist/embed.
+  candidates.push(resolve(here, "..", "..", "ui", "dist", "embed"));
+  // Published layout: <ui>/node_modules/@reddb-io/ui-mcp/dist → <ui>/dist/embed.
+  candidates.push(resolve(here, "..", "..", "..", "..", "dist", "embed"));
+
+  for (const dir of candidates) {
+    if (isFile(join(dir, "index.js"))) return dir;
+  }
+
+  throw new Error(
+    "Cannot serve the local UI: the red-ui embeddable bundle was not found. " +
+      "Build it with `pnpm --filter @reddb-io/ui build`, install a published " +
+      "@reddb-io/ui, or set RED_UI_EMBED_DIR to the directory holding the " +
+      "embed `index.js`. See ADR-0006 / issue #51."
+  );
+}
+
+/** Reserve a free TCP port on the loopback interface, then release it. */
+function pickEphemeralPort(): Promise<number> {
+  return new Promise((resolvePort, reject) => {
+    const srv = createNetServer();
+    srv.unref();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const port = addr && typeof addr === "object" ? addr.port : 0;
+      srv.close(() => {
+        if (port) resolvePort(port);
+        else reject(new Error("Could not reserve an ephemeral port."));
+      });
+    });
+  });
+}
+
+const CONTENT_TYPES: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".map": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
+};
+
+function contentType(filePath: string): string {
+  return CONTENT_TYPES[extname(filePath)] ?? "application/octet-stream";
+}
+
+/**
+ * The host page. It imports the embed bundle from the same origin, builds a
+ * single-connection InjectedClientProvider from the `?cs=` endpoint the MCP
+ * seeded (the spawned `red server`), and mounts red-ui into a full-document
+ * host element. `?to=` selects the initial route. No secret rides the URL
+ * (ADR-0005); the local server is loopback-only and unauthenticated.
+ */
+export function renderHostHtml(): string {
+  return `<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>red-ui (local)</title>
+    <style>
+      html, body { margin: 0; height: 100%; background: #050607; color: #f7f8fa; }
+      #red-ui-host { display: block; min-height: 100vh; }
+      .boot-error {
+        padding: 24px;
+        font: 13px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+        color: #ff5470;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="red-ui-host"></div>
+    <script type="module">
+      import {
+        RedClient,
+        InjectedClientProvider,
+        mountRedUi,
+      } from "./embed/index.js";
+
+      const host = document.getElementById("red-ui-host");
+      const params = new URLSearchParams(location.search);
+      const cs = (params.get("cs") || "").trim();
+      const to = (params.get("to") || "/query").trim();
+
+      if (!cs) {
+        host.className = "boot-error";
+        host.textContent =
+          "No connection string (cs) was provided to the local red-ui host.";
+      } else {
+        const client = new RedClient(cs);
+        const provider = new InjectedClientProvider({
+          client,
+          connection: {
+            id: "host",
+            url: cs,
+            label: "Local file",
+            role: "primary",
+            description: "Served by a local red server (ADR-0006).",
+          },
+        });
+        mountRedUi(host, {
+          connectionProvider: provider,
+          initialRoute: to,
+          theme: "dark",
+        }).catch((error) => {
+          host.className = "boot-error";
+          host.textContent =
+            "Failed to mount red-ui: " +
+            (error && error.message ? error.message : String(error));
+        });
+      }
+    </script>
+  </body>
+</html>`;
+}
+
+function sendText(
+  res: ServerResponse,
+  status: number,
+  type: string,
+  body: string
+): void {
+  res.writeHead(status, { "content-type": type });
+  res.end(body);
+}
+
+function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  embedDir: string,
+  host: string,
+  port: number
+): void {
+  let pathname: string;
+  try {
+    pathname = decodeURIComponent(
+      new URL(req.url ?? "/", `http://${host}:${port}`).pathname
+    );
+  } catch {
+    sendText(res, 400, "text/plain; charset=utf-8", "Bad request");
+    return;
+  }
+
+  if (pathname === "/" || pathname === "/index.html") {
+    sendText(res, 200, "text/html; charset=utf-8", renderHostHtml());
+    return;
+  }
+
+  // Everything else must resolve to a file under `<embedDir>` and be reached via
+  // the `/embed/` prefix (matching the host page's `./embed/index.js` imports).
+  const EMBED_PREFIX = "/embed/";
+  if (!pathname.startsWith(EMBED_PREFIX)) {
+    sendText(res, 404, "text/plain; charset=utf-8", "Not found");
+    return;
+  }
+
+  const requestedRel = pathname.slice(EMBED_PREFIX.length);
+  const candidate = resolve(
+    embedDir,
+    normalize(requestedRel).replace(/^(\.\.(\/|\\|$))+/, "")
+  );
+  const rel = relative(embedDir, candidate);
+  const insideEmbed = rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+  if (!insideEmbed || !isFile(candidate)) {
+    sendText(res, 404, "text/plain; charset=utf-8", "Not found");
+    return;
+  }
+
+  res.writeHead(200, { "content-type": contentType(candidate) });
+  const stream = createReadStream(candidate);
+  stream.on("error", () => {
+    if (!res.headersSent) res.writeHead(500);
+    res.end();
+  });
+  stream.pipe(res);
+}
+
+/**
+ * Start one loopback HTTP server that serves the host page at `/` and the embed
+ * bundle under `/embed/`. The returned handle's `stop()` closes it.
+ */
+export async function startEmbedServer(
+  options: StartEmbedServerOptions = {}
+): Promise<EmbedServerHandle> {
+  const embedDir = resolveEmbedDir(options.embedDir);
+  const host = "127.0.0.1";
+  const port = options.port ?? (await pickEphemeralPort());
+  const baseUrl = `http://${host}:${port}`;
+
+  const server = createServer((req, res) =>
+    handleRequest(req, res, embedDir, host, port)
+  );
+
+  await new Promise<void>((resolveListen, reject) => {
+    server.once("error", reject);
+    server.listen(port, host, () => {
+      server.removeListener("error", reject);
+      resolveListen();
+    });
+  });
+
+  const handle: EmbedServerHandle = {
+    baseUrl,
+    port,
+    embedDir,
+    server,
+    stop: makeStop(server),
+  };
+
+  trackServer(handle);
+  return handle;
+}
+
+function makeStop(server: Server): () => Promise<void> {
+  let stopping: Promise<void> | null = null;
+  return () => {
+    if (stopping) return stopping;
+    stopping = new Promise<void>((resolveStop) => {
+      server.close(() => resolveStop());
+      // Drop keep-alive sockets so close() can complete promptly.
+      server.closeAllConnections?.();
+    });
+    return stopping;
+  };
+}
+
+// --- lifecycle registry: no orphan UI servers on MCP exit/disconnect ---------
+
+const liveServers = new Set<EmbedServerHandle>();
+let exitHooksInstalled = false;
+
+function installExitHooks(): void {
+  if (exitHooksInstalled) return;
+  exitHooksInstalled = true;
+
+  process.on("exit", () => {
+    for (const handle of liveServers) {
+      try {
+        handle.server.close();
+      } catch {
+        // already gone
+      }
+    }
+  });
+}
+
+function trackServer(handle: EmbedServerHandle): void {
+  installExitHooks();
+  liveServers.add(handle);
+  handle.server.once("close", () => liveServers.delete(handle));
+}
+
+/** Stop every tracked embed server (MCP transport close / shutdown). */
+export async function stopAllEmbedServers(): Promise<void> {
+  const handles = [...liveServers];
+  await Promise.all(handles.map((h) => h.stop()));
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -18,6 +18,11 @@ import {
   spawnLocalServer,
   stopAllLocalServers,
 } from "./local-server.js";
+import {
+  type EmbedServerHandle,
+  startEmbedServer,
+  stopAllEmbedServers,
+} from "./embed-server.js";
 import { registerDataTools } from "./data-tools.js";
 
 // Single source of truth for "what version am I": the package.json version
@@ -80,6 +85,22 @@ function normalizeHttpUrl(value: string | undefined, fallback: string): string {
 
 function getOrigin(url: string): string {
   return new URL(url).origin;
+}
+
+// Local mode (#51, ADR-0006) serves the embeddable bundle from an ephemeral
+// `http://127.0.0.1:<port>` the MCP picks at runtime, so the CSP cannot name the
+// exact origin ahead of time. Allow loopback on any port for framing, scripts,
+// and connections; the hosted origin stays explicit. Port-wildcard host-sources
+// are valid CSP (`http://127.0.0.1:*`).
+const LOCALHOST_CSP = ["http://localhost:*", "http://127.0.0.1:*"] as const;
+
+function appCsp(config: ServerConfig) {
+  const appOrigin = getOrigin(config.appUrl);
+  return {
+    connectDomains: [...config.connectDomains, ...LOCALHOST_CSP],
+    frameDomains: [appOrigin, ...LOCALHOST_CSP],
+    resourceDomains: [appOrigin, "https://esm.sh", ...LOCALHOST_CSP],
+  };
 }
 
 function loadConfig(): ServerConfig {
@@ -399,6 +420,30 @@ function createServer(config: ServerConfig): McpServer {
     }
   }
 
+  // One embed server per MCP process serves the Embeddable Lib bundle (#37) over
+  // `http://127.0.0.1:<port>` for local mode (#51, ADR-0006). The bundle is the
+  // same regardless of which file is open, so it is a singleton; it is torn down
+  // with the local servers on disconnect/exit.
+  let embedServer: Promise<EmbedServerHandle> | null = null;
+  async function openEmbedServer(): Promise<EmbedServerHandle> {
+    if (embedServer) {
+      try {
+        const handle = await embedServer;
+        if (handle.server.listening) return handle;
+      } catch {
+        // Previous attempt failed; fall through and respawn.
+      }
+    }
+    const pending = startEmbedServer();
+    embedServer = pending;
+    try {
+      return await pending;
+    } catch (error) {
+      embedServer = null;
+      throw error;
+    }
+  }
+
   registerAppResource(
     server,
     "red-ui app",
@@ -408,11 +453,7 @@ function createServer(config: ServerConfig): McpServer {
         "Interactive red-ui database workspace embedded as an MCP App.",
       _meta: {
         ui: {
-          csp: {
-            connectDomains: config.connectDomains,
-            frameDomains: [getOrigin(config.appUrl)],
-            resourceDomains: [getOrigin(config.appUrl), "https://esm.sh"],
-          },
+          csp: appCsp(config),
           prefersBorder: false,
         },
       },
@@ -425,11 +466,7 @@ function createServer(config: ServerConfig): McpServer {
           text: renderRedUiAppHtml(config),
           _meta: {
             ui: {
-              csp: {
-                connectDomains: config.connectDomains,
-                frameDomains: [getOrigin(config.appUrl)],
-                resourceDomains: [getOrigin(config.appUrl), "https://esm.sh"],
-              },
+              csp: appCsp(config),
               prefersBorder: false,
             },
           },
@@ -480,15 +517,33 @@ function createServer(config: ServerConfig): McpServer {
           const readOnlyNote = local.readOnly
             ? " (read-only: the file is already held by another writer)"
             : "";
+
+          // Serve the UI same-origin over http://localhost so the iframe and
+          // the spawned red server share an http:// scheme — no HTTPS→localhost
+          // mixed-content block (Firefox/Safari), fully offline (#51, ADR-0006).
+          // If the embeddable bundle can't be found we still hand back a working
+          // local API, falling back to the hosted UI with a note.
+          let uiUrl = config.appUrl;
+          let uiNote = "";
+          try {
+            const embed = await openEmbedServer();
+            uiUrl = embed.baseUrl;
+          } catch (embedError) {
+            const detail =
+              embedError instanceof Error
+                ? embedError.message
+                : String(embedError);
+            uiNote = ` (local UI bundle unavailable, falling back to ${config.appUrl}: ${detail})`;
+          }
           return {
             content: [
               {
                 type: "text",
-                text: `Serving local file ${local.filePath} via a red server at ${local.baseUrl}${readOnlyNote}; opening red-ui ${selectedView} view.`,
+                text: `Serving local file ${local.filePath} via a red server at ${local.baseUrl}${readOnlyNote}; opening red-ui ${selectedView} view from ${uiUrl}.${uiNote}`,
               },
             ],
             structuredContent: {
-              appUrl: config.appUrl,
+              appUrl: uiUrl,
               connectionUrl: local.baseUrl,
               view: selectedView,
               mode,
@@ -561,6 +616,8 @@ Environment:
   RED_UI_CONNECT_DOMAINS     Comma-separated extra connect-src domains for the embedded app.
   RED_BINARY                 Path to the reddb \`red\` binary used to serve local .rdb files.
                              Defaults to the @reddb-io/sdk binary, else \`red\` on PATH.
+  RED_UI_EMBED_DIR           Directory holding the embeddable bundle (\`index.js\`) served over
+                             http://localhost in local mode. Defaults to the installed @reddb-io/ui.
   RED_UI_CONNECTION_URL      Default reddb endpoint for the data tools (query/list/get), e.g. http://localhost:5055.
   RED_UI_CONNECTION_TOKEN    Bearer token for the data tools' RedClient (sent as Authorization: Bearer …; never logged).
   RED_UI_CONNECTION_AUTH     Raw Authorization header for the data tools (overrides RED_UI_CONNECTION_TOKEN).
@@ -599,6 +656,7 @@ async function main() {
   transport.onclose = () => {
     previousOnClose?.();
     void stopAllLocalServers();
+    void stopAllEmbedServers();
   };
 
   await server.connect(transport);

--- a/packages/mcp/test/embed-server.test.mjs
+++ b/packages/mcp/test/embed-server.test.mjs
@@ -1,0 +1,154 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packageDir = dirname(here);
+const {
+  resolveEmbedDir,
+  startEmbedServer,
+  renderHostHtml,
+  stopAllEmbedServers,
+} = await import(join(packageDir, "dist/embed-server.js"));
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+// A stand-in embed bundle dir — just enough files to exercise serving without
+// building the full @reddb-io/ui bundle.
+const embedDir = mkdtempSync(join(tmpdir(), "red-ui-embed-"));
+writeFileSync(
+  join(embedDir, "index.js"),
+  'export { mountRedUi, RedClient, InjectedClientProvider } from "./chunk.js";\n'
+);
+writeFileSync(
+  join(embedDir, "chunk.js"),
+  "export const mountRedUi = () => {};\n"
+);
+writeFileSync(join(embedDir, "ui.css"), ".x{color:red}\n");
+
+// --- renderHostHtml: imports the bundle same-origin and wires `cs`/`to` ------
+{
+  const html = renderHostHtml();
+  assert(html.includes("./embed/index.js"), "host page must import the bundle");
+  assert(html.includes("mountRedUi"), "host page must mount red-ui");
+  assert(
+    html.includes("InjectedClientProvider"),
+    "host page must build an injected provider"
+  );
+  assert(
+    html.includes('params.get("cs")') && html.includes('params.get("to")'),
+    "host page must read cs/to from the query string"
+  );
+}
+
+// --- resolveEmbedDir: explicit override that holds index.js wins -------------
+{
+  const resolved = resolveEmbedDir(embedDir);
+  assert(
+    resolved === embedDir,
+    `explicit embedDir should win, got ${resolved}`
+  );
+}
+
+// --- resolveEmbedDir: an override without index.js falls through -------------
+{
+  const empty = mkdtempSync(join(tmpdir(), "red-ui-embed-empty-"));
+  try {
+    // No index.js here → it must fall through to a later candidate (the
+    // monorepo sibling packages/ui/dist/embed) rather than returning `empty`.
+    let resolved = null;
+    try {
+      resolved = resolveEmbedDir(empty);
+    } catch {
+      // No real bundle built in this environment — acceptable; the point is it
+      // did NOT return the empty override.
+    }
+    assert(
+      resolved !== empty,
+      "an override without index.js must not be returned"
+    );
+  } finally {
+    rmSync(empty, { recursive: true, force: true });
+  }
+}
+
+// --- startEmbedServer: serves the host page and the bundle, guards traversal -
+let handle = null;
+try {
+  handle = await startEmbedServer({ embedDir });
+  assert(
+    /^http:\/\/127\.0\.0\.1:\d+$/.test(handle.baseUrl),
+    `embed server must bind loopback, got ${handle.baseUrl}`
+  );
+
+  const root = await fetch(`${handle.baseUrl}/`);
+  assert(root.ok, "GET / must be 200");
+  assert(
+    (root.headers.get("content-type") || "").includes("text/html"),
+    "GET / must be served as HTML"
+  );
+  const rootBody = await root.text();
+  assert(rootBody.includes("./embed/index.js"), "host page imports the bundle");
+
+  const bundle = await fetch(`${handle.baseUrl}/embed/index.js`);
+  assert(bundle.ok, "GET /embed/index.js must be 200");
+  assert(
+    (bundle.headers.get("content-type") || "").includes("text/javascript"),
+    "bundle must be served as javascript"
+  );
+  assert(
+    (await bundle.text()).includes("mountRedUi"),
+    "bundle body must be the served file"
+  );
+
+  const chunk = await fetch(`${handle.baseUrl}/embed/chunk.js`);
+  assert(chunk.ok, "GET /embed/chunk.js (a relative import) must be 200");
+
+  // Path traversal must not escape the embed dir. `fetch` normalizes a literal
+  // `..`, so probe with an encoded sequence that reaches the server intact.
+  const rawEscape = await fetch(
+    `${handle.baseUrl}/embed/%2e%2e%2f%2e%2e%2fpackage.json`
+  );
+  assert(rawEscape.status === 404, "encoded traversal must 404");
+
+  const missing = await fetch(`${handle.baseUrl}/embed/nope.js`);
+  assert(missing.status === 404, "missing bundle file must 404");
+
+  const offRoute = await fetch(`${handle.baseUrl}/whatever`);
+  assert(offRoute.status === 404, "non-embed, non-root path must 404");
+} finally {
+  if (handle) await handle.stop();
+}
+
+// --- stop(): server is down afterwards ---------------------------------------
+{
+  let reachable = true;
+  try {
+    await fetch(`${handle.baseUrl}/`, { signal: AbortSignal.timeout(500) });
+  } catch {
+    reachable = false;
+  }
+  assert(!reachable, "embed server must be down after stop()");
+}
+
+// --- stopAllEmbedServers tears down a tracked server -------------------------
+{
+  const a = await startEmbedServer({ embedDir });
+  const ok = await fetch(`${a.baseUrl}/`);
+  assert(ok.ok, "server up before stopAll");
+  await stopAllEmbedServers();
+  let down = false;
+  try {
+    await fetch(`${a.baseUrl}/`, { signal: AbortSignal.timeout(500) });
+  } catch {
+    down = true;
+  }
+  assert(down, "server down after stopAllEmbedServers");
+}
+
+rmSync(embedDir, { recursive: true, force: true });
+
+console.log("embed-server test passed");

--- a/packages/mcp/test/mcp-app-smoke.mjs
+++ b/packages/mcp/test/mcp-app-smoke.mjs
@@ -1,4 +1,5 @@
-import { chmodSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -12,6 +13,14 @@ const packageDir = dirname(here);
 const fakeRed = join(here, "fake-red.mjs");
 chmodSync(fakeRed, 0o755);
 
+// Stand-in embeddable bundle so local mode can serve the UI over http://localhost
+// (#51) without building the full @reddb-io/ui bundle in this test.
+const embedDir = mkdtempSync(join(tmpdir(), "red-ui-embed-smoke-"));
+writeFileSync(
+  join(embedDir, "index.js"),
+  "export const mountRedUi = () => {};\nexport class RedClient {}\nexport class InjectedClientProvider {}\n"
+);
+
 const client = new Client({ name: "red-ui-mcp-app-smoke", version: "0.0.0" });
 const transport = new StdioClientTransport({
   command: process.execPath,
@@ -20,6 +29,7 @@ const transport = new StdioClientTransport({
     ...process.env,
     RED_UI_APP_URL: "https://ui.reddb.io",
     RED_BINARY: fakeRed,
+    RED_UI_EMBED_DIR: embedDir,
   },
 });
 
@@ -41,6 +51,7 @@ async function statsUp(baseUrl) {
 await client.connect(transport);
 
 let localBaseUrl = null;
+let uiBaseUrl = null;
 
 try {
   const tools = await client.listTools();
@@ -137,8 +148,33 @@ try {
     "spawned local server must be healthy before the UI is pointed at it"
   );
   localBaseUrl = localCs;
+
+  // #51, ADR-0006: in local mode the UI must load from http://localhost — not
+  // the hosted HTTPS origin — so the iframe and the local API share an http
+  // scheme (no Firefox/Safari mixed-content block) and work offline.
+  const uiUrl = local.structuredContent?.appUrl;
+  assert(
+    typeof uiUrl === "string" && /^http:\/\/127\.0\.0\.1:\d+$/.test(uiUrl),
+    `local mode must serve the UI from http://localhost, got ${uiUrl}`
+  );
+  assert(
+    uiUrl !== "https://ui.reddb.io",
+    "local mode must not load the UI from the hosted HTTPS origin"
+  );
+  uiBaseUrl = uiUrl;
+
+  const hostPage = await fetch(`${uiUrl}/`);
+  assert(hostPage.ok, "local UI host page must be reachable");
+  const hostHtml = await hostPage.text();
+  assert(
+    hostHtml.includes("./embed/index.js"),
+    "host page must import the embeddable bundle same-origin"
+  );
+  const bundle = await fetch(`${uiUrl}/embed/index.js`);
+  assert(bundle.ok, "embeddable bundle must be served under /embed/");
 } finally {
   await client.close();
+  rmSync(embedDir, { recursive: true, force: true });
 }
 
 // On disconnect the spawned child must be gone — no orphan servers.
@@ -152,6 +188,21 @@ if (localBaseUrl) {
     await new Promise((r) => setTimeout(r, 100));
   }
   assert(down, "spawned local server must be torn down after MCP disconnect");
+}
+
+// The local UI server must also be torn down — no orphan static servers.
+if (uiBaseUrl) {
+  let down = false;
+  for (let i = 0; i < 40; i++) {
+    try {
+      await fetch(`${uiBaseUrl}/`, { signal: AbortSignal.timeout(500) });
+    } catch {
+      down = true;
+      break;
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  assert(down, "local UI server must be torn down after MCP disconnect");
 }
 
 console.log("red-ui MCP App smoke test passed");

--- a/packages/ui/bin/red-ui.js
+++ b/packages/ui/bin/red-ui.js
@@ -1,21 +1,29 @@
 #!/usr/bin/env node
 
-import { createServer } from 'node:http'
-import { createReadStream, existsSync, readFileSync, statSync } from 'node:fs'
-import { access } from 'node:fs/promises'
-import { createRequire } from 'node:module'
-import { dirname, extname, isAbsolute, join, normalize, relative, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
-import { spawn } from 'node:child_process'
+import { createServer } from "node:http";
+import { createReadStream, existsSync, readFileSync, statSync } from "node:fs";
+import { access } from "node:fs/promises";
+import { createRequire } from "node:module";
+import {
+  dirname,
+  extname,
+  isAbsolute,
+  join,
+  normalize,
+  relative,
+  resolve,
+} from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
 
-const DEFAULT_APP_URL = 'https://ui.reddb.io'
-const DEFAULT_HOST = '127.0.0.1'
-const DEFAULT_PORT = 1420
+const DEFAULT_APP_URL = "https://ui.reddb.io";
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_PORT = 1420;
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const packageRoot = resolve(__dirname, '..')
-const buildDir = resolve(packageRoot, 'build')
-const require = createRequire(import.meta.url)
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(__dirname, "..");
+const buildDir = resolve(packageRoot, "build");
+const require = createRequire(import.meta.url);
 
 function printHelp() {
   process.stdout.write(`red-ui
@@ -29,196 +37,223 @@ Examples:
   npx @reddb-io/ui serve --open red://localhost
   npx @reddb-io/ui open red://localhost
   npx @reddb-io/ui mcp --stdio
-`)
+`);
 }
 
 function readOption(args, name, fallback) {
-  const prefix = `${name}=`
+  const prefix = `${name}=`;
   for (let i = 0; i < args.length; i += 1) {
-    const arg = args[i]
-    if (arg === name) return args[i + 1] ?? fallback
-    if (arg.startsWith(prefix)) return arg.slice(prefix.length)
+    const arg = args[i];
+    if (arg === name) return args[i + 1] ?? fallback;
+    if (arg.startsWith(prefix)) return arg.slice(prefix.length);
   }
-  return fallback
+  return fallback;
 }
 
 function hasFlag(args, name) {
-  return args.includes(name)
+  return args.includes(name);
 }
 
 function positional(args) {
-  const values = []
+  const values = [];
   for (let i = 0; i < args.length; i += 1) {
-    const arg = args[i]
-    if (arg.startsWith('--')) {
-      if (!arg.includes('=') && args[i + 1] && !args[i + 1].startsWith('--')) i += 1
-      continue
+    const arg = args[i];
+    if (arg.startsWith("--")) {
+      if (!arg.includes("=") && args[i + 1] && !args[i + 1].startsWith("--"))
+        i += 1;
+      continue;
     }
-    values.push(arg)
+    values.push(arg);
   }
-  return values
+  return values;
 }
 
 function buildAppUrl(base, { connectionUrl }) {
-  const url = new URL(base)
-  if (connectionUrl) url.searchParams.set('connection', connectionUrl)
-  return url.toString()
+  const url = new URL(base);
+  if (connectionUrl) url.searchParams.set("connection", connectionUrl);
+  return url.toString();
 }
 
 function openBrowser(url) {
-  const platform = process.platform
+  const platform = process.platform;
   const command =
-    platform === 'darwin'
-      ? 'open'
-      : platform === 'win32'
-        ? 'cmd'
-        : 'xdg-open'
-  const args = platform === 'win32' ? ['/c', 'start', '', url] : [url]
+    platform === "darwin" ? "open" : platform === "win32" ? "cmd" : "xdg-open";
+  const args = platform === "win32" ? ["/c", "start", "", url] : [url];
   const child = spawn(command, args, {
     detached: true,
-    stdio: 'ignore',
-  })
-  child.unref()
+    stdio: "ignore",
+  });
+  child.unref();
 }
 
 function contentType(filePath) {
   switch (extname(filePath)) {
-    case '.html':
-      return 'text/html; charset=utf-8'
-    case '.js':
-      return 'text/javascript; charset=utf-8'
-    case '.css':
-      return 'text/css; charset=utf-8'
-    case '.json':
-      return 'application/json; charset=utf-8'
-    case '.png':
-      return 'image/png'
-    case '.svg':
-      return 'image/svg+xml'
-    case '.woff2':
-      return 'font/woff2'
+    case ".html":
+      return "text/html; charset=utf-8";
+    case ".js":
+      return "text/javascript; charset=utf-8";
+    case ".css":
+      return "text/css; charset=utf-8";
+    case ".json":
+      return "application/json; charset=utf-8";
+    case ".png":
+      return "image/png";
+    case ".svg":
+      return "image/svg+xml";
+    case ".woff2":
+      return "font/woff2";
     default:
-      return 'application/octet-stream'
+      return "application/octet-stream";
   }
 }
 
 async function ensureBuild() {
-  const indexPath = join(buildDir, 'index.html')
+  const indexPath = join(buildDir, "index.html");
   try {
-    await access(indexPath)
+    await access(indexPath);
   } catch {
-    throw new Error(`red-ui build not found at ${indexPath}. Install a published package or run "pnpm --filter @reddb-io/ui build".`)
+    throw new Error(
+      `red-ui build not found at ${indexPath}. Install a published package or run "pnpm --filter @reddb-io/ui build".`
+    );
   }
 }
 
 async function serve(args) {
-  await ensureBuild()
+  await ensureBuild();
 
-  const host = readOption(args, '--host', DEFAULT_HOST)
-  const port = Number(readOption(args, '--port', String(DEFAULT_PORT)))
-  const connectionUrl = readOption(args, '--connection', positional(args)[0] ?? '')
+  const host = readOption(args, "--host", DEFAULT_HOST);
+  const port = Number(readOption(args, "--port", String(DEFAULT_PORT)));
+  const connectionUrl = readOption(
+    args,
+    "--connection",
+    positional(args)[0] ?? ""
+  );
 
   const server = createServer(async (req, res) => {
-    const requested = new URL(req.url ?? '/', `http://${host}:${port}`)
-    const pathname = decodeURIComponent(requested.pathname)
-    const candidate = resolve(buildDir, normalize(pathname).replace(/^\/+/, ''))
-    const rel = relative(buildDir, candidate)
-    const insideBuild = rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))
+    const requested = new URL(req.url ?? "/", `http://${host}:${port}`);
+    const pathname = decodeURIComponent(requested.pathname);
+    const candidate = resolve(
+      buildDir,
+      normalize(pathname).replace(/^\/+/, "")
+    );
+    const rel = relative(buildDir, candidate);
+    const insideBuild =
+      rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
 
-    let filePath = insideBuild ? candidate : join(buildDir, 'index.html')
+    let filePath = insideBuild ? candidate : join(buildDir, "index.html");
     if (!existsSync(filePath) || statSync(filePath).isDirectory()) {
-      filePath = join(buildDir, 'index.html')
+      filePath = join(buildDir, "index.html");
     }
 
     try {
-      res.setHeader('Content-Type', contentType(filePath))
-      createReadStream(filePath).pipe(res)
+      res.setHeader("Content-Type", contentType(filePath));
+      createReadStream(filePath).pipe(res);
     } catch (error) {
-      res.statusCode = 500
-      res.setHeader('Content-Type', 'text/plain; charset=utf-8')
-      res.end(error instanceof Error ? error.message : String(error))
+      res.statusCode = 500;
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.end(error instanceof Error ? error.message : String(error));
     }
-  })
+  });
 
   await new Promise((resolveListen, rejectListen) => {
-    server.once('error', rejectListen)
-    server.listen(port, host, resolveListen)
-  })
+    server.once("error", rejectListen);
+    server.listen(port, host, resolveListen);
+  });
 
-  const url = buildAppUrl(`http://${host}:${port}`, { connectionUrl })
-  process.stdout.write(`red-ui serving ${buildDir}\n${url}\n`)
-  if (hasFlag(args, '--open')) openBrowser(url)
+  const url = buildAppUrl(`http://${host}:${port}`, { connectionUrl });
+  process.stdout.write(`red-ui serving ${buildDir}\n${url}\n`);
+  if (hasFlag(args, "--open")) openBrowser(url);
 }
 
 function open(args) {
-  const appUrl = readOption(args, '--app-url', process.env.RED_UI_APP_URL || DEFAULT_APP_URL)
-  const connectionUrl = readOption(args, '--connection', positional(args)[0] ?? '')
-  const url = buildAppUrl(appUrl, { connectionUrl })
-  process.stdout.write(`${url}\n`)
-  openBrowser(url)
+  const appUrl = readOption(
+    args,
+    "--app-url",
+    process.env.RED_UI_APP_URL || DEFAULT_APP_URL
+  );
+  const connectionUrl = readOption(
+    args,
+    "--connection",
+    positional(args)[0] ?? ""
+  );
+  const url = buildAppUrl(appUrl, { connectionUrl });
+  process.stdout.write(`${url}\n`);
+  openBrowser(url);
 }
 
 function resolveUiMcpBin() {
-  const pkgPath = require.resolve('@reddb-io/ui-mcp/package.json')
-  const pkg = JSON.parse(readFileSyncText(pkgPath))
-  const bin = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin?.['ui-mcp']
-  if (!bin) throw new Error('@reddb-io/ui-mcp does not declare a ui-mcp bin')
-  return resolve(dirname(pkgPath), bin)
+  const pkgPath = require.resolve("@reddb-io/ui-mcp/package.json");
+  const pkg = JSON.parse(readFileSyncText(pkgPath));
+  const bin = typeof pkg.bin === "string" ? pkg.bin : pkg.bin?.["ui-mcp"];
+  if (!bin) throw new Error("@reddb-io/ui-mcp does not declare a ui-mcp bin");
+  return resolve(dirname(pkgPath), bin);
 }
 
 function readFileSyncText(path) {
-  return statSync(path) && readFileSync(path, 'utf8')
+  return statSync(path) && readFileSync(path, "utf8");
 }
 
 async function mcp(args) {
-  const appUrl = readOption(args, '--app-url', process.env.RED_UI_APP_URL || DEFAULT_APP_URL)
-  const forwarded = []
+  const appUrl = readOption(
+    args,
+    "--app-url",
+    process.env.RED_UI_APP_URL || DEFAULT_APP_URL
+  );
+  const forwarded = [];
   for (let i = 0; i < args.length; i += 1) {
-    const arg = args[i]
-    if (arg === '--app-url') {
-      i += 1
-      continue
+    const arg = args[i];
+    if (arg === "--app-url") {
+      i += 1;
+      continue;
     }
-    if (arg.startsWith('--app-url=')) continue
-    forwarded.push(arg)
+    if (arg.startsWith("--app-url=")) continue;
+    forwarded.push(arg);
   }
-  if (!forwarded.includes('--stdio')) forwarded.push('--stdio')
+  if (!forwarded.includes("--stdio")) forwarded.push("--stdio");
 
-  const bin = resolveUiMcpBin()
+  const bin = resolveUiMcpBin();
+  // The MCP serves the embeddable bundle over http://localhost for local-file
+  // mode (#51). We ship it next to this bin at <packageRoot>/dist/embed, so
+  // point the child straight at it — saves the MCP from re-resolving @reddb-io/ui
+  // and keeps local mode working in odd install layouts. An explicit env wins.
+  const embedDir = resolve(packageRoot, "dist", "embed");
+  const env = { ...process.env, RED_UI_APP_URL: appUrl };
+  if (!env.RED_UI_EMBED_DIR && existsSync(join(embedDir, "index.js"))) {
+    env.RED_UI_EMBED_DIR = embedDir;
+  }
   const child = spawn(process.execPath, [bin, ...forwarded], {
-    stdio: 'inherit',
-    env: {
-      ...process.env,
-      RED_UI_APP_URL: appUrl,
-    },
-  })
-  await new Promise((resolveExit) => child.on('exit', resolveExit))
-  process.exitCode = child.exitCode ?? 0
+    stdio: "inherit",
+    env,
+  });
+  await new Promise((resolveExit) => child.on("exit", resolveExit));
+  process.exitCode = child.exitCode ?? 0;
 }
 
 async function main() {
-  const [command = 'help', ...args] = process.argv.slice(2)
-  if (command === 'help' || command === '--help' || command === '-h') {
-    printHelp()
-    return
+  const [command = "help", ...args] = process.argv.slice(2);
+  if (command === "help" || command === "--help" || command === "-h") {
+    printHelp();
+    return;
   }
-  if (command === 'serve') {
-    await serve(args)
-    return
+  if (command === "serve") {
+    await serve(args);
+    return;
   }
-  if (command === 'open') {
-    open(args)
-    return
+  if (command === "open") {
+    open(args);
+    return;
   }
-  if (command === 'mcp') {
-    await mcp(args)
-    return
+  if (command === "mcp") {
+    await mcp(args);
+    return;
   }
 
-  throw new Error(`Unknown red-ui command: ${command}`)
+  throw new Error(`Unknown red-ui command: ${command}`);
 }
 
 main().catch((error) => {
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
-  process.exit(1)
-})
+  process.stderr.write(
+    `${error instanceof Error ? error.message : String(error)}\n`
+  );
+  process.exit(1);
+});


### PR DESCRIPTION
Lands completed work for #51 (PRD #19 final slice, ADR-0006). AFK worker wF5TE implemented + verified (commit f3cf953) but exited no-sentinel; rebased onto current main (resolved index.ts + ADR-0006 against #48/#49/#50). Re-verified locally: `pnpm --filter @reddb-io/ui-mcp test` green (build + 5 suites incl. embed-server).

Closes #51

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783007690&installation_id=129708444&pr_number=57&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F57&signature=1e354dbb8258ae96d54f1c85aae160f5894eb15f21d0b6f8cb3dd8850d2d3f05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Local mode now serves the embeddable UI bundle directly from a loopback HTTP server, enabling same-origin embedding and offline functionality while avoiding mixed-content security issues.

* **Improvements**
  * Updated Content Security Policy to allow local loopback origins for framing and resource loading.

* **Documentation**
  * Documented completion of PRD `#19` implementation including same-origin embed serving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->