### PR TITLE
merge: #61 Graph Phase 2 — group-in-a-box rendering per community

### DIFF
--- a/packages/ui/src/lib/renderers/GraphRenderer.svelte
+++ b/packages/ui/src/lib/renderers/GraphRenderer.svelte
@@ -5,18 +5,22 @@
   import {
     buildSigmaGraph,
     colorForType,
+    computeCommunityBoxes,
     nodeVisualRadius,
     reduceSigmaEdge,
     reduceSigmaNode,
+    routeInterCommunityEdges,
     FOCUS_EDGE_COLOR,
     FOCUS_NODE_STROKE_COLOR,
+    type CommunityBox,
+    type RoutedEdge,
     type SigmaReducerState,
     type SigmaThemeColors,
   } from './graph-sigma'
   import { collectionPageHref } from '$lib/collection-pages'
   import { connection } from '$lib/connections.svelte'
   import { activity } from '$lib/activity.svelte'
-  import { Network, Table2, Search, X, Info, Maximize2, Play, Code2, RotateCw, Loader2, Route, AlertTriangle, ZoomIn, ZoomOut } from 'lucide-svelte'
+  import { Network, Table2, Search, X, Info, Maximize2, Play, Code2, RotateCw, Loader2, Route, AlertTriangle, ZoomIn, ZoomOut, Group } from 'lucide-svelte'
 
   interface Props {
     result: QueryResult
@@ -64,6 +68,9 @@
   let canvasError = $state<string | null>(null)
   let renderBudget = $state(350)
   let svgZoom = $state(1)
+  // Group-in-a-box: one tinted box per community, inter-community edges routed
+  // at the box borders. Off-state is the plain #59 sigma/SVG render.
+  let groupInBox = $state(false)
 
   const selectedNodeDetail = $derived(
     selectedNode
@@ -235,6 +242,63 @@
   let pulseRaf = 0
   let graphThemeVersion = $state(0)
 
+  // Canvas group-in-a-box overlay: boxes/edges projected into viewport pixels.
+  // sigma draws node/edge geometry in WebGL; the overlay is a plain SVG synced
+  // to the camera (graphToViewport) so the boxes pan/zoom with the graph.
+  interface ViewportBox extends CommunityBox {
+    vx: number
+    vy: number
+    vw: number
+    vh: number
+  }
+  interface ViewportEdge {
+    id: string
+    vx1: number
+    vy1: number
+    vx2: number
+    vy2: number
+  }
+  let overlayBoxes = $state<ViewportBox[]>([])
+  let overlayEdges = $state<ViewportEdge[]>([])
+
+  // Map a layout-space point into viewport pixels. Sigma stores nodes at y=-y
+  // (see buildSigmaGraph), so the flip is reapplied before projecting.
+  function projectPoint(x: number, y: number): { x: number; y: number } | null {
+    const instance = sigmaInstance
+    if (!instance) return null
+    return instance.graphToViewport({ x, y: -y })
+  }
+
+  function syncOverlay() {
+    if (!groupInBox || !sigmaInstance || viewMode !== 'canvas') {
+      if (overlayBoxes.length) overlayBoxes = []
+      if (overlayEdges.length) overlayEdges = []
+      return
+    }
+    const boxes: ViewportBox[] = []
+    for (const box of communityBoxes) {
+      const p1 = projectPoint(box.minX, box.minY)
+      const p2 = projectPoint(box.maxX, box.maxY)
+      if (!p1 || !p2) continue
+      boxes.push({
+        ...box,
+        vx: Math.min(p1.x, p2.x),
+        vy: Math.min(p1.y, p2.y),
+        vw: Math.abs(p2.x - p1.x),
+        vh: Math.abs(p2.y - p1.y),
+      })
+    }
+    const edges: ViewportEdge[] = []
+    for (const edge of routedEdges) {
+      const a = projectPoint(edge.x1, edge.y1)
+      const b = projectPoint(edge.x2, edge.y2)
+      if (!a || !b) continue
+      edges.push({ id: edge.id, vx1: a.x, vy1: a.y, vx2: b.x, vy2: b.y })
+    }
+    overlayBoxes = boxes
+    overlayEdges = edges
+  }
+
   function prefersReducedMotion(): boolean {
     return (
       typeof window !== 'undefined' &&
@@ -384,6 +448,26 @@
   // See packages/ui/src/lib/renderers/graph-render.ts → runGraphLayout.
   const layout = $derived(runGraphLayout(drawNodes, drawEdges))
 
+  // Dark/light is theme-aware; re-read on the data-theme mutation observer tick.
+  const isDark = $derived.by(() => {
+    void graphThemeVersion
+    return typeof document === 'undefined'
+      ? true
+      : document.documentElement.dataset.theme !== 'light'
+  })
+
+  // Group-in-a-box geometry in layout ([0,100]) space. Shared by the SVG
+  // fallback (drawn directly) and the canvas overlay (mapped through sigma's
+  // graph→viewport transform). Empty unless the toggle is on.
+  const communityBoxes = $derived<CommunityBox[]>(
+    groupInBox ? computeCommunityBoxes(drawNodes, layout, { dark: isDark }) : [],
+  )
+  const routedEdges = $derived<RoutedEdge[]>(
+    groupInBox ? routeInterCommunityEdges(drawEdges, layout, communityBoxes) : [],
+  )
+  // Edge ids the box overlay re-routes — skipped by the straight SVG renderer.
+  const routedEdgeIds = $derived(new Set(routedEdges.map((e) => e.id)))
+
   const fallbackSvgNodes = $derived.by<FallbackSvgNode[]>(() => {
     return drawNodes.map((node) => {
       const type = String(node.data.node_type ?? 'node')
@@ -502,6 +586,7 @@
       selectedNodeId: selectedNode?.id ?? null,
       pulse: pulseProgress,
       colors: sigmaThemeColors(),
+      groupInBox,
     }
   }
 
@@ -550,6 +635,9 @@
     camera.on('updated', () => {
       cameraRatio = camera.ratio
     })
+    // Every repaint (pan, zoom, resize, refresh) reprojects the group-in-a-box
+    // overlay so its boxes/edges track the camera. No-op when the mode is off.
+    instance.on('afterRender', () => syncOverlay())
   }
 
   // Create / tear down the sigma (WebGL) instance with the canvas view.
@@ -635,6 +723,19 @@
     const instance = sigmaInstance
     if (!instance || viewMode !== 'canvas') return
     instance.refresh({ skipIndexation: true })
+  })
+
+  // Group-in-a-box: toggling re-runs the edge reducer (cross-community edges
+  // hide), and any geometry/theme change re-projects the overlay onto the
+  // current camera. `afterRender` keeps it tracking subsequent repaints.
+  $effect(() => {
+    void groupInBox
+    void communityBoxes
+    void routedEdges
+    const instance = sigmaInstance
+    if (!instance || viewMode !== 'canvas') return
+    instance.refresh({ skipIndexation: true })
+    syncOverlay()
   })
 
   function onSvgNodePointerEnter(node: GraphNode) {
@@ -782,6 +883,22 @@
             <ZoomIn class="size-3.5" />
           </button>
         </div>
+      {/if}
+
+      {#if viewMode !== 'table'}
+        <button
+          type="button"
+          class={[
+            'inline-flex items-center gap-1 h-6 px-2 rounded border cursor-pointer transition-colors',
+            groupInBox ? 'border-accent/40 bg-accent/10 text-accent' : 'border-line-1 text-fg-3 hover:text-fg-1 hover:border-line-2',
+          ].join(' ')}
+          onclick={() => (groupInBox = !groupInBox)}
+          aria-pressed={groupInBox}
+          title="Group in a box — draw one tinted box per community and route inter-community edges at the borders"
+        >
+          <Group class="size-3" />
+          groups
+        </button>
       {/if}
 
       <button
@@ -944,6 +1061,36 @@
           aria-label={`${drawNodes.length} graph nodes and ${drawEdges.length} graph edges`}
           onkeydown={(event) => { if (event.key === 'Escape') { clearGraphFocus(); clearSelection() } }}
         ></div>
+        {#if groupInBox && (overlayBoxes.length > 0 || overlayEdges.length > 0)}
+          <!-- Group-in-a-box overlay, projected into viewport pixels and synced
+               to the camera. pointer-events stay off so sigma keeps the input. -->
+          <svg class="pointer-events-none absolute inset-0 h-full w-full" aria-hidden="true">
+            {#each overlayBoxes as box (box.community)}
+              <rect
+                x={box.vx}
+                y={box.vy}
+                width={box.vw}
+                height={box.vh}
+                rx="6"
+                fill={box.fill}
+                stroke={box.stroke}
+                stroke-width="1.5"
+              />
+            {/each}
+            {#each overlayEdges as e (e.id)}
+              <line
+                x1={e.vx1}
+                y1={e.vy1}
+                x2={e.vx2}
+                y2={e.vy2}
+                stroke="var(--color-line-3)"
+                stroke-width="1"
+                stroke-dasharray="4 3"
+                opacity="0.7"
+              />
+            {/each}
+          </svg>
+        {/if}
       {:else if viewMode === 'svg'}
         <div class="absolute inset-0 overflow-hidden bg-bg-0">
           <svg
@@ -959,8 +1106,42 @@
           >
             <rect x="0" y="0" width="100" height="100" fill="transparent" />
             <g transform={graphTransform}>
+              {#if groupInBox}
+                <!-- Community boxes behind everything; routed inter-community
+                     edges connect box borders rather than node centres. -->
+                <g class="pointer-events-none">
+                  {#each communityBoxes as box (box.community)}
+                    <rect
+                      x={box.minX}
+                      y={box.minY}
+                      width={box.maxX - box.minX}
+                      height={box.maxY - box.minY}
+                      rx="1.5"
+                      fill={box.fill}
+                      stroke={box.stroke}
+                      stroke-width="0.18"
+                      vector-effect="non-scaling-stroke"
+                    />
+                  {/each}
+                  {#each routedEdges as e (e.id)}
+                    <line
+                      x1={e.x1}
+                      y1={e.y1}
+                      x2={e.x2}
+                      y2={e.y2}
+                      stroke="currentColor"
+                      stroke-width="0.12"
+                      stroke-dasharray="0.8 0.6"
+                      opacity="0.6"
+                      class="text-line-3"
+                      vector-effect="non-scaling-stroke"
+                    />
+                  {/each}
+                </g>
+              {/if}
               <g>
                 {#each fallbackSvgEdges as e (e.id)}
+                  {#if !(groupInBox && routedEdgeIds.has(e.id))}
                   {@const focusedEdge = focusEdgeIds.has(e.id)}
                   <line
                     x1={e.x1}
@@ -996,6 +1177,7 @@
                     >
                       {e.label?.slice(0, 28)}
                     </text>
+                  {/if}
                   {/if}
                 {/each}
               </g>

--- a/packages/ui/src/lib/renderers/graph-sigma.test.ts
+++ b/packages/ui/src/lib/renderers/graph-sigma.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from "vitest";
 import {
   buildSigmaGraph,
   colorForType,
+  computeCommunityBoxes,
   computeGraphFocus,
   FOCUS_EDGE_COLOR,
   FOCUS_NODE_STROKE_COLOR,
   nodeVisualRadius,
   reduceSigmaEdge,
   reduceSigmaNode,
+  routeInterCommunityEdges,
   sigmaColorForCommunity,
   sigmaNodeSize,
   withAlpha,
@@ -275,6 +277,7 @@ describe("reduceSigmaEdge", () => {
     color: "rgba(58, 66, 77, 0.34)",
     edgeLabel: "DEPENDS_ON",
     label: "",
+    crossCommunity: false,
     type: "line" as const,
   };
 
@@ -304,5 +307,133 @@ describe("reduceSigmaEdge", () => {
     const out = reduceSigmaEdge("e", attrs, state);
     expect(out.color).toBe(withAlpha(THEME.edge, 0.055));
     expect(out.label).toBe("");
+  });
+
+  it("hides cross-community edges in group-in-a-box mode (overlay owns them)", () => {
+    const cross = { ...attrs, crossCommunity: true };
+    const out = reduceSigmaEdge("e", cross, baseState({ groupInBox: true }));
+    expect(out.hidden).toBe(true);
+
+    // intra-community edges keep rendering natively
+    const intra = reduceSigmaEdge("e", attrs, baseState({ groupInBox: true }));
+    expect(intra.hidden).toBe(false);
+  });
+
+  it("keeps a focused cross-community edge visible even in group mode", () => {
+    const cross = { ...attrs, crossCommunity: true };
+    const out = reduceSigmaEdge(
+      "e",
+      cross,
+      baseState({
+        groupInBox: true,
+        focusId: "a",
+        focus: { nodes: new Set(["a"]), edges: new Set(["e"]) },
+      })
+    );
+    expect(out.hidden).toBe(false);
+    expect(out.color).toBe(FOCUS_EDGE_COLOR);
+  });
+});
+
+describe("buildSigmaGraph cross-community tagging", () => {
+  it("flags edges whose endpoints sit in different communities", () => {
+    // layoutFor assigns community = index % 3 → a:0, b:1, c:2, d:0
+    const g = buildSigmaGraph({
+      nodes: [node("a"), node("b"), node("c"), node("d")],
+      edges: [edge("a", "b", "X"), edge("a", "d", "Y")],
+      layout: layoutFor(["a", "b", "c", "d"]),
+      sizeScales: new Map(),
+      orphanIds: new Set(),
+    });
+    expect(g.getEdgeAttributes("a->b:X").crossCommunity).toBe(true);
+    expect(g.getEdgeAttributes("a->d:Y").crossCommunity).toBe(false);
+  });
+});
+
+describe("computeCommunityBoxes", () => {
+  const nodes = [node("a"), node("b"), node("c"), node("d")];
+
+  function layout(): GraphLayout {
+    const out: GraphLayout = new Map();
+    out.set("a", { x: 10, y: 10, community: 0 });
+    out.set("b", { x: 30, y: 20, community: 0 });
+    out.set("c", { x: 60, y: 70, community: 1 });
+    out.set("d", { x: 80, y: 90, community: 1 });
+    return out;
+  }
+
+  it("draws one padded box per community sized to its members", () => {
+    const boxes = computeCommunityBoxes(nodes, layout(), { padding: 2 });
+    expect(boxes).toHaveLength(2);
+    const [c0, c1] = boxes;
+    expect(c0.community).toBe(0);
+    expect(c0.count).toBe(2);
+    // bounds = [10,30] x [10,20] padded by 2
+    expect(c0.minX).toBe(8);
+    expect(c0.maxX).toBe(32);
+    expect(c0.minY).toBe(8);
+    expect(c0.maxY).toBe(22);
+    expect(c1.community).toBe(1);
+    expect(c1.cx).toBe(70);
+    expect(c1.cy).toBe(80);
+  });
+
+  it("tints boxes with the community colour (theme-aware, translucent)", () => {
+    const boxes = computeCommunityBoxes(nodes, layout(), { dark: true });
+    expect(boxes[0].tint).toMatch(/^hsl\(/);
+    expect(boxes[0].fill).toMatch(/^rgba\(/);
+    expect(boxes[0].stroke).toMatch(/^rgba\(/);
+  });
+
+  it("ignores nodes without a layout position", () => {
+    const partial: GraphLayout = new Map([["a", { x: 5, y: 5, community: 0 }]]);
+    const boxes = computeCommunityBoxes(nodes, partial);
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].count).toBe(1);
+  });
+
+  it("returns nothing for an empty layout", () => {
+    expect(computeCommunityBoxes(nodes, new Map())).toEqual([]);
+  });
+});
+
+describe("routeInterCommunityEdges", () => {
+  function layout(): GraphLayout {
+    const out: GraphLayout = new Map();
+    out.set("a", { x: 10, y: 50, community: 0 });
+    out.set("b", { x: 20, y: 50, community: 0 });
+    out.set("c", { x: 80, y: 50, community: 1 });
+    return out;
+  }
+
+  it("clips cross-community edges to the box borders, skipping intra edges", () => {
+    const nodes = [node("a"), node("b"), node("c")];
+    const boxes = computeCommunityBoxes(nodes, layout(), { padding: 2 });
+    const routed = routeInterCommunityEdges(
+      [edge("a", "b", "INTRA"), edge("a", "c", "CROSS")],
+      layout(),
+      boxes
+    );
+    expect(routed).toHaveLength(1);
+    const r = routed[0];
+    expect(r.sourceCommunity).toBe(0);
+    expect(r.targetCommunity).toBe(1);
+    // source box (community 0) spans x∈[8,22]; the edge runs left→right so it
+    // exits at the box's right border (x = 22), not from the node centre.
+    expect(r.x1).toBeCloseTo(22);
+    // target box (community 1) spans x∈[78,82]; entry at its left border.
+    expect(r.x2).toBeCloseTo(78);
+    expect(r.y1).toBeCloseTo(50);
+    expect(r.y2).toBeCloseTo(50);
+  });
+
+  it("skips edges whose endpoints lack a layout position", () => {
+    const boxes = computeCommunityBoxes([node("a")], layout(), {});
+    const routed = routeInterCommunityEdges(
+      [edge("a", "ghost", "X")],
+      layout(),
+      boxes
+    );
+    expect(routed).toEqual([]);
   });
 });

--- a/packages/ui/src/lib/renderers/graph-sigma.ts
+++ b/packages/ui/src/lib/renderers/graph-sigma.ts
@@ -169,6 +169,12 @@ export interface SigmaEdgeAttributes {
   /** Original edge label, kept so the reducer can surface it on focus only. */
   edgeLabel: string;
   label: string;
+  /**
+   * True when the edge's endpoints sit in different communities — the
+   * group-in-a-box overlay routes these at the box borders, so the native
+   * straight edge is hidden while that mode is on.
+   */
+  crossCommunity: boolean;
   type: "line";
 }
 
@@ -236,16 +242,188 @@ export function buildSigmaGraph(
   for (const edge of edges) {
     if (!graph.hasNode(edge.source) || !graph.hasNode(edge.target)) continue;
     if (graph.hasEdge(edge.id)) continue;
+    const sc = layout.get(edge.source)?.community ?? -1;
+    const tc = layout.get(edge.target)?.community ?? -1;
     graph.addEdgeWithKey(edge.id, edge.source, edge.target, {
       size: 1,
       color: withAlpha(edgeColor, 0.34),
       edgeLabel: edge.label ?? "",
       label: "",
+      crossCommunity: sc !== tc,
       type: "line",
     });
   }
 
   return graph;
+}
+
+// ─── group-in-a-box geometry (pure; consumed by the SVG fallback directly and
+//     by the canvas overlay after a graph→viewport transform) ────────────────
+
+export interface CommunityBox {
+  community: number;
+  /** Member count — drives nothing visual, surfaced for labels/tooltips. */
+  count: number;
+  /** Tint hue for this community (hsl string). */
+  tint: string;
+  /** Faint translucent fill so clusters read without drowning the nodes. */
+  fill: string;
+  /** Stronger translucent stroke for the box border. */
+  stroke: string;
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+  /** Box centre, handy for community labels. */
+  cx: number;
+  cy: number;
+}
+
+export interface CommunityBoxOptions {
+  /** Padding (in layout units) added around the member bounding box. */
+  padding?: number;
+  dark?: boolean;
+}
+
+/**
+ * One bounding box per community, sized to its members with a small padding.
+ * Positions are in the same [0, 100] layout space the SVG fallback draws in;
+ * the canvas overlay maps them through sigma's graph→viewport transform.
+ * Communities are returned in ascending id order so the output is stable.
+ */
+export function computeCommunityBoxes(
+  nodes: GraphNode[],
+  layout: GraphLayout,
+  options: CommunityBoxOptions = {}
+): CommunityBox[] {
+  const { padding = 2.5, dark = true } = options;
+  const bounds = new Map<
+    number,
+    { minX: number; minY: number; maxX: number; maxY: number; count: number }
+  >();
+
+  for (const node of nodes) {
+    const pos = layout.get(node.id);
+    if (!pos) continue;
+    const b = bounds.get(pos.community);
+    if (!b) {
+      bounds.set(pos.community, {
+        minX: pos.x,
+        minY: pos.y,
+        maxX: pos.x,
+        maxY: pos.y,
+        count: 1,
+      });
+    } else {
+      b.minX = Math.min(b.minX, pos.x);
+      b.minY = Math.min(b.minY, pos.y);
+      b.maxX = Math.max(b.maxX, pos.x);
+      b.maxY = Math.max(b.maxY, pos.y);
+      b.count += 1;
+    }
+  }
+
+  return [...bounds.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([community, b]) => {
+      const tint = colorForCommunity(community, dark);
+      return {
+        community,
+        count: b.count,
+        tint,
+        fill: withAlpha(tint, 0.08),
+        stroke: withAlpha(tint, 0.5),
+        minX: b.minX - padding,
+        minY: b.minY - padding,
+        maxX: b.maxX + padding,
+        maxY: b.maxY + padding,
+        cx: (b.minX + b.maxX) / 2,
+        cy: (b.minY + b.maxY) / 2,
+      };
+    });
+}
+
+export interface RoutedEdge {
+  id: string;
+  source: string;
+  target: string;
+  label?: string;
+  sourceCommunity: number;
+  targetCommunity: number;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+interface Box {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+/**
+ * Walk the ray from `p` toward `q` and return the point where it leaves the
+ * box that contains `p`. Used to clip an inter-community edge to its source /
+ * target box borders so the segment connects the boxes rather than cutting
+ * through their interiors.
+ */
+function exitPoint(
+  px: number,
+  py: number,
+  qx: number,
+  qy: number,
+  box: Box
+): { x: number; y: number } {
+  const dx = qx - px;
+  const dy = qy - py;
+  let t = 1;
+  if (dx > 0) t = Math.min(t, (box.maxX - px) / dx);
+  else if (dx < 0) t = Math.min(t, (box.minX - px) / dx);
+  if (dy > 0) t = Math.min(t, (box.maxY - py) / dy);
+  else if (dy < 0) t = Math.min(t, (box.minY - py) / dy);
+  t = Math.max(0, Math.min(1, t));
+  return { x: px + dx * t, y: py + dy * t };
+}
+
+/**
+ * Route every inter-community edge so it runs between the two community box
+ * borders instead of node-centre to node-centre — the group-in-a-box
+ * convention that keeps cross-cluster edges out of unrelated clusters.
+ * Intra-community edges are left to the native renderer and skipped here.
+ */
+export function routeInterCommunityEdges(
+  edges: GraphEdge[],
+  layout: GraphLayout,
+  boxes: CommunityBox[]
+): RoutedEdge[] {
+  const boxByCommunity = new Map(boxes.map((b) => [b.community, b]));
+  const out: RoutedEdge[] = [];
+  for (const edge of edges) {
+    const s = layout.get(edge.source);
+    const t = layout.get(edge.target);
+    if (!s || !t) continue;
+    if (s.community === t.community) continue;
+    const sourceBox = boxByCommunity.get(s.community);
+    const targetBox = boxByCommunity.get(t.community);
+    if (!sourceBox || !targetBox) continue;
+    const start = exitPoint(s.x, s.y, t.x, t.y, sourceBox);
+    const end = exitPoint(t.x, t.y, s.x, s.y, targetBox);
+    out.push({
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
+      label: edge.label,
+      sourceCommunity: s.community,
+      targetCommunity: t.community,
+      x1: start.x,
+      y1: start.y,
+      x2: end.x,
+      y2: end.y,
+    });
+  }
+  return out;
 }
 
 // ─── focus neighbourhood (parity with the canvas focus highlight) ───────────
@@ -284,6 +462,11 @@ export interface SigmaReducerState {
   /** Focus-pulse progress, 0 (rest) → 1 (peak). Held at 0 for reduced motion. */
   pulse: number;
   colors: SigmaThemeColors;
+  /**
+   * Group-in-a-box mode: cross-community edges are drawn by the overlay at the
+   * box borders, so the native straight edge is hidden to avoid double lines.
+   */
+  groupInBox?: boolean;
 }
 
 export interface SigmaNodeDisplay {
@@ -358,9 +541,22 @@ export function reduceSigmaEdge(
   attrs: SigmaEdgeAttributes,
   state: SigmaReducerState
 ): SigmaEdgeDisplay {
-  const { focus, focusId, colors } = state;
+  const { focus, focusId, colors, groupInBox } = state;
   const hasFocus = focusId !== null;
   const focused = focus.edges.has(id);
+
+  // In group-in-a-box mode the overlay owns cross-community edges; hide the
+  // native straight line so it doesn't cut through unrelated clusters.
+  if (groupInBox && attrs.crossCommunity && !focused) {
+    return {
+      size: attrs.size,
+      color: attrs.color,
+      label: "",
+      forceLabel: false,
+      zIndex: 0,
+      hidden: true,
+    };
+  }
 
   if (!hasFocus) {
     return {


### PR DESCRIPTION
Salvaged from AFK worker wNT5V (crashed no-sentinel at stage:tests). Branch carries the complete commit.

Closes #61. Part of PRD #58.

Verified locally: `pnpm --filter @reddb-io/ui test` → **339 pass**, `svelte-check` → **0 errors**.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783032112&installation_id=129708444&pr_number=65&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F65&signature=19ae89da52f365195939df0119327a644dfed77e6f7ff983d3a86eb9e91d8aaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added group-in-a-box visualization mode to display community relationships in graphs with improved edge routing.
  * Added groups toggle button to the toolbar for controlling group visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->