### PR TITLE
merge: #62 Graph Phase 2 — force-directed edge bundling

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -57,6 +57,7 @@
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@reddb-io/ui-kit": "workspace:*",
     "@reddb-io/ui-mcp": "workspace:*",
+    "@sigma/edge-curve": "^3.1.0",
     "@sigma/node-border": "^3.0.0",
     "@tauri-apps/api": "^2.5.0",
     "@xyflow/svelte": "^1.2.0",

--- a/packages/ui/src/lib/renderers/GraphRenderer.svelte
+++ b/packages/ui/src/lib/renderers/GraphRenderer.svelte
@@ -13,10 +13,17 @@
     type SigmaReducerState,
     type SigmaThemeColors,
   } from './graph-sigma'
+  import {
+    bundleEdges,
+    edgeCurvature,
+    BUNDLE_EDGE_LIMIT,
+    type BundleOptions,
+    type BundlePoint,
+  } from './graph-bundle'
   import { collectionPageHref } from '$lib/collection-pages'
   import { connection } from '$lib/connections.svelte'
   import { activity } from '$lib/activity.svelte'
-  import { Network, Table2, Search, X, Info, Maximize2, Play, Code2, RotateCw, Loader2, Route, AlertTriangle, ZoomIn, ZoomOut } from 'lucide-svelte'
+  import { Network, Table2, Search, X, Info, Maximize2, Play, Code2, RotateCw, Loader2, Route, AlertTriangle, ZoomIn, ZoomOut, Spline } from 'lucide-svelte'
 
   interface Props {
     result: QueryResult
@@ -37,6 +44,11 @@
     y1: number
     x2: number
     y2: number
+    /** Bundled polyline points (`"x,y x,y …"`) when edge bundling is on. */
+    points?: string
+    /** Label anchor — midpoint of the chord, or of the bundled polyline. */
+    mx: number
+    my: number
   }
 
   let { result, collection, subpage }: Props = $props()
@@ -64,6 +76,8 @@
   let canvasError = $state<string | null>(null)
   let renderBudget = $state(350)
   let svgZoom = $state(1)
+  // Force-directed edge bundling — off by default (precomputed, not per-frame).
+  let bundleEnabled = $state(false)
 
   const selectedNodeDetail = $derived(
     selectedNode
@@ -229,7 +243,7 @@
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let sigmaInstance: any = null
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let sigmaModules: { Sigma: any; NodeBorderProgram: any } | null = null
+  let sigmaModules: { Sigma: any; NodeBorderProgram: any; EdgeCurveProgram: any } | null = null
   let cameraRatio = $state(1)
   let pulseProgress = $state(0)
   let pulseRaf = 0
@@ -384,6 +398,44 @@
   // See packages/ui/src/lib/renderers/graph-render.ts → runGraphLayout.
   const layout = $derived(runGraphLayout(drawNodes, drawEdges))
 
+  // ─── force-directed edge bundling (precomputed) ──────────────────────────
+  // FDEB is O(E²) in the compatibility pass, so it runs only when toggled on,
+  // off the per-frame path (memoised by $derived — recomputed when the draw
+  // set or layout changes, never on a camera move or focus change), and only
+  // up to the #59 node ceiling's matching edge cap.
+  const bundleTooLarge = $derived(bundleEnabled && drawEdges.length > BUNDLE_EDGE_LIMIT)
+
+  // Scale the iteration budget down as the edge count grows so the one-time
+  // precompute stays responsive even near the cap.
+  function bundleOptionsForSize(edgeCount: number): Partial<BundleOptions> {
+    if (edgeCount > 800) return { cycles: 4, iterations: 45 }
+    if (edgeCount > 300) return { cycles: 5, iterations: 55 }
+    return {}
+  }
+
+  const bundledPaths = $derived.by<Map<string, BundlePoint[]> | null>(() => {
+    if (!bundleEnabled || viewMode === 'table') return null
+    if (drawEdges.length === 0 || drawEdges.length > BUNDLE_EDGE_LIMIT) return null
+    const positions = drawNodes.map((n) => {
+      const pos = layout.get(n.id)
+      return { id: n.id, x: pos?.x ?? 50, y: pos?.y ?? 50 }
+    })
+    return bundleEdges(
+      positions,
+      drawEdges.map((e) => ({ id: e.id, source: e.source, target: e.target })),
+      bundleOptionsForSize(drawEdges.length),
+    )
+  })
+
+  // Per-edge sigma curvature. The bundle is computed in layout space; sigma's
+  // scene flips y, so the curvature sign is negated for the WebGL curve program.
+  const bundleCurvatures = $derived.by<Map<string, number> | null>(() => {
+    if (!bundledPaths) return null
+    const out = new Map<string, number>()
+    for (const [id, pts] of bundledPaths) out.set(id, -edgeCurvature(pts))
+    return out
+  })
+
   const fallbackSvgNodes = $derived.by<FallbackSvgNode[]>(() => {
     return drawNodes.map((node) => {
       const type = String(node.data.node_type ?? 'node')
@@ -409,12 +461,25 @@
       const source = fallbackSvgNodeById.get(edge.source)
       const target = fallbackSvgNodeById.get(edge.target)
       if (!source || !target) continue
+      const bundled = bundledPaths?.get(edge.id)
+      let points: string | undefined
+      let mx = (source.x + target.x) / 2
+      let my = (source.y + target.y) / 2
+      if (bundled && bundled.length > 2) {
+        points = bundled.map((p) => `${p.x},${p.y}`).join(' ')
+        const midPoint = bundled[Math.floor(bundled.length / 2)]
+        mx = midPoint.x
+        my = midPoint.y
+      }
       out.push({
         ...edge,
         x1: source.x,
         y1: source.y,
         x2: target.x,
         y2: target.y,
+        points,
+        mx,
+        my,
       })
     }
     return out
@@ -502,6 +567,7 @@
       selectedNodeId: selectedNode?.id ?? null,
       pulse: pulseProgress,
       colors: sigmaThemeColors(),
+      bundle: bundleEnabled && bundleCurvatures !== null,
     }
   }
 
@@ -514,6 +580,7 @@
       orphanIds: orphanNodeIds,
       dark: document.documentElement.dataset.theme !== 'light',
       edgeColor: sigmaThemeColors().edge,
+      bundledCurvatures: bundleCurvatures ?? undefined,
     })
   }
 
@@ -563,18 +630,26 @@
     void (async () => {
       try {
         if (!sigmaModules) {
-          const [sig, nb] = await Promise.all([
+          const [sig, nb, ec] = await Promise.all([
             import('sigma'),
             import('@sigma/node-border'),
+            import('@sigma/edge-curve'),
           ])
-          sigmaModules = { Sigma: sig.default, NodeBorderProgram: nb.NodeBorderProgram }
+          sigmaModules = {
+            Sigma: sig.default,
+            NodeBorderProgram: nb.NodeBorderProgram,
+            EdgeCurveProgram: ec.default,
+          }
         }
         if (killed || !sigmaContainer) return
-        const { Sigma, NodeBorderProgram } = sigmaModules
+        const { Sigma, NodeBorderProgram, EdgeCurveProgram } = sigmaModules
         instance = new Sigma(buildCurrentSigmaGraph(), container, {
           allowInvalidContainer: true,
           defaultNodeType: 'border',
           nodeProgramClasses: { border: NodeBorderProgram },
+          // 'line' is the built-in straight program; 'curved' bows bundled
+          // edges. The edge reducer picks per-edge based on the bundle toggle.
+          edgeProgramClasses: { curved: EdgeCurveProgram },
           defaultEdgeType: 'line',
           renderEdgeLabels: true,
           labelFont: '"JetBrains Mono Variable", monospace',
@@ -616,6 +691,8 @@
     void nodeSizeScales
     void orphanNodeIds
     void graphThemeVersion
+    void bundleCurvatures
+    void bundleEnabled
     const instance = sigmaInstance
     if (!instance || viewMode !== 'canvas') return
     // Label colours are static settings (reducers can't set them), so refresh
@@ -782,6 +859,27 @@
             <ZoomIn class="size-3.5" />
           </button>
         </div>
+      {/if}
+
+      {#if viewMode !== 'table'}
+        <button
+          type="button"
+          class={[
+            'inline-flex items-center gap-1 h-6 px-2 rounded border cursor-pointer transition-colors',
+            bundleEnabled ? 'border-accent/40 bg-accent/10 text-accent' : 'border-line-1 text-fg-3 hover:text-fg-1 hover:border-line-2',
+          ].join(' ')}
+          onclick={() => (bundleEnabled = !bundleEnabled)}
+          aria-pressed={bundleEnabled}
+          title="Force-directed edge bundling — collapse parallel edges onto shared trunks to untangle dense subgraphs"
+        >
+          <Spline class="size-3" />
+          bundle
+        </button>
+        {#if bundleTooLarge}
+          <span class="text-warn" title={`Bundling is skipped above ${BUNDLE_EDGE_LIMIT.toLocaleString()} drawn edges — narrow the filter or lower the limit`}>
+            bundling skipped ({drawEdges.length.toLocaleString()} edges)
+          </span>
+        {/if}
       {/if}
 
       <button
@@ -962,28 +1060,48 @@
               <g>
                 {#each fallbackSvgEdges as e (e.id)}
                   {@const focusedEdge = focusEdgeIds.has(e.id)}
-                  <line
-                    x1={e.x1}
-                    y1={e.y1}
-                    x2={e.x2}
-                    y2={e.y2}
-                    stroke={activeFocusNodeId ? (focusedEdge ? focusEdgeColor : 'currentColor') : 'currentColor'}
-                    stroke-width={activeFocusNodeId ? (focusedEdge ? '0.27' : '0.055') : '0.105'}
-                    opacity={activeFocusNodeId ? (focusedEdge ? '0.98' : '0.055') : '0.36'}
-                    class="text-line-3 cursor-pointer hover:text-accent"
-                    vector-effect="non-scaling-stroke"
-                    role="button"
-                    tabindex="0"
-                    aria-label={`${e.label ?? 'edge'} from ${e.source} to ${e.target}`}
-                    onclick={(event) => { event.stopPropagation(); clearGraphFocus(); selectEdge(e) }}
-                    onkeydown={(event) => onSelectableKey(event, () => { clearGraphFocus(); selectEdge(e) })}
-                  >
-                    <title>{e.label ?? 'edge'}: {e.source} -> {e.target}</title>
-                  </line>
+                  {#if e.points}
+                    <polyline
+                      points={e.points}
+                      fill="none"
+                      stroke={activeFocusNodeId ? (focusedEdge ? focusEdgeColor : 'currentColor') : 'currentColor'}
+                      stroke-width={activeFocusNodeId ? (focusedEdge ? '0.27' : '0.055') : '0.105'}
+                      opacity={activeFocusNodeId ? (focusedEdge ? '0.98' : '0.07') : '0.4'}
+                      stroke-linejoin="round"
+                      class="text-line-3 cursor-pointer hover:text-accent"
+                      vector-effect="non-scaling-stroke"
+                      role="button"
+                      tabindex="0"
+                      aria-label={`${e.label ?? 'edge'} from ${e.source} to ${e.target}`}
+                      onclick={(event) => { event.stopPropagation(); clearGraphFocus(); selectEdge(e) }}
+                      onkeydown={(event) => onSelectableKey(event, () => { clearGraphFocus(); selectEdge(e) })}
+                    >
+                      <title>{e.label ?? 'edge'}: {e.source} -> {e.target}</title>
+                    </polyline>
+                  {:else}
+                    <line
+                      x1={e.x1}
+                      y1={e.y1}
+                      x2={e.x2}
+                      y2={e.y2}
+                      stroke={activeFocusNodeId ? (focusedEdge ? focusEdgeColor : 'currentColor') : 'currentColor'}
+                      stroke-width={activeFocusNodeId ? (focusedEdge ? '0.27' : '0.055') : '0.105'}
+                      opacity={activeFocusNodeId ? (focusedEdge ? '0.98' : '0.055') : '0.36'}
+                      class="text-line-3 cursor-pointer hover:text-accent"
+                      vector-effect="non-scaling-stroke"
+                      role="button"
+                      tabindex="0"
+                      aria-label={`${e.label ?? 'edge'} from ${e.source} to ${e.target}`}
+                      onclick={(event) => { event.stopPropagation(); clearGraphFocus(); selectEdge(e) }}
+                      onkeydown={(event) => onSelectableKey(event, () => { clearGraphFocus(); selectEdge(e) })}
+                    >
+                      <title>{e.label ?? 'edge'}: {e.source} -> {e.target}</title>
+                    </line>
+                  {/if}
                   {#if showSvgEdgeLabel(e)}
                     <text
-                      x={(e.x1 + e.x2) / 2 + 0.45}
-                      y={(e.y1 + e.y2) / 2 - 0.45}
+                      x={e.mx + 0.45}
+                      y={e.my - 0.45}
                       fill="#f6d36b"
                       opacity="0.96"
                       font-size="1"

--- a/packages/ui/src/lib/renderers/graph-bundle.test.ts
+++ b/packages/ui/src/lib/renderers/graph-bundle.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+import {
+  BUNDLE_EDGE_LIMIT,
+  bundleEdges,
+  countEdgeCrossings,
+  edgeCurvature,
+  edgeInk,
+  type BundleEdgeInput,
+  type BundleNodePosition,
+  type BundlePoint,
+} from "./graph-bundle";
+
+// A dense bipartite showcase: two facing columns wired all-to-all. Used for
+// the structural assertions (every edge bows toward its compatible
+// neighbours).
+function bipartite(k: number): {
+  nodes: BundleNodePosition[];
+  edges: BundleEdgeInput[];
+} {
+  const nodes: BundleNodePosition[] = [];
+  const edges: BundleEdgeInput[] = [];
+  for (let i = 0; i < k; i++) {
+    nodes.push({ id: `L${i}`, x: 0, y: (i / (k - 1)) * 100 });
+    nodes.push({ id: `R${i}`, x: 100, y: (i / (k - 1)) * 100 });
+  }
+  for (let i = 0; i < k; i++) {
+    for (let j = 0; j < k; j++) {
+      edges.push({ id: `L${i}->R${j}`, source: `L${i}`, target: `R${j}` });
+    }
+  }
+  return { nodes, edges };
+}
+
+// Two clustered flows that cross: A(top-left)→B(bottom-right) over
+// C(bottom-left)→D(top-right). Straight, every A→B line crosses every C→D
+// line (~k² crossings); bundled, each flow collapses to a trunk and the two
+// trunks cross only a handful of times — the textbook FDEB win.
+function crossingFlows(k: number): {
+  nodes: BundleNodePosition[];
+  edges: BundleEdgeInput[];
+} {
+  const nodes: BundleNodePosition[] = [];
+  const edges: BundleEdgeInput[] = [];
+  for (let i = 0; i < k; i++) {
+    // Flow 1: constant slope +1 (parallel, no internal crossings).
+    nodes.push({ id: `A${i}`, x: 10, y: 8 + i * 1.5 });
+    nodes.push({ id: `B${i}`, x: 90, y: 88 + i * 1.5 });
+    // Flow 2: constant slope -1, crossing flow 1 as a whole.
+    nodes.push({ id: `C${i}`, x: 10, y: 92 - i * 1.5 });
+    nodes.push({ id: `D${i}`, x: 90, y: 12 - i * 1.5 });
+    edges.push({ id: `A${i}->B${i}`, source: `A${i}`, target: `B${i}` });
+    edges.push({ id: `C${i}->D${i}`, source: `C${i}`, target: `D${i}` });
+  }
+  return { nodes, edges };
+}
+
+function straightPolylines(
+  nodes: BundleNodePosition[],
+  edges: BundleEdgeInput[]
+): BundlePoint[][] {
+  const pos = new Map(nodes.map((n) => [n.id, { x: n.x, y: n.y }]));
+  return edges.map((e) => [pos.get(e.source)!, pos.get(e.target)!]);
+}
+
+describe("bundleEdges", () => {
+  it("returns a polyline for every edge with endpoints preserved", () => {
+    const nodes: BundleNodePosition[] = [
+      { id: "a", x: 0, y: 0 },
+      { id: "b", x: 100, y: 0 },
+    ];
+    const edges: BundleEdgeInput[] = [{ id: "e", source: "a", target: "b" }];
+    const bundled = bundleEdges(nodes, edges);
+    const path = bundled.get("e")!;
+    expect(path[0]).toEqual({ x: 0, y: 0 });
+    expect(path[path.length - 1]).toEqual({ x: 100, y: 0 });
+  });
+
+  it("drops dangling edges and gives self-loops a straight stub", () => {
+    const nodes: BundleNodePosition[] = [
+      { id: "a", x: 0, y: 0 },
+      { id: "b", x: 10, y: 10 },
+    ];
+    const edges: BundleEdgeInput[] = [
+      { id: "loop", source: "a", target: "a" },
+      { id: "dangling", source: "a", target: "ghost" },
+      { id: "ab", source: "a", target: "b" },
+    ];
+    const bundled = bundleEdges(nodes, edges);
+    expect(bundled.has("dangling")).toBe(false);
+    expect(bundled.get("loop")).toEqual([
+      { x: 0, y: 0 },
+      { x: 0, y: 0 },
+    ]);
+    expect(bundled.get("ab")![0]).toEqual({ x: 0, y: 0 });
+  });
+
+  it("is deterministic — identical input yields identical output", () => {
+    const { nodes, edges } = bipartite(5);
+    const a = bundleEdges(nodes, edges);
+    const b = bundleEdges(nodes, edges);
+    for (const [id, path] of a) {
+      expect(b.get(id)).toEqual(path);
+    }
+  });
+
+  it("cuts edge ink (clutter) on dense crossing flows", () => {
+    const { nodes, edges } = crossingFlows(7);
+    const straightInk = edgeInk(straightPolylines(nodes, edges), 3);
+    const bundledInk = edgeInk([...bundleEdges(nodes, edges).values()], 3);
+    expect(straightInk).toBeGreaterThan(0);
+    // FDEB collapses compatible edges onto shared trunks, so the painted area
+    // (the hairball) drops meaningfully — the measurable bundling win.
+    expect(bundledInk).toBeLessThan(straightInk * 0.75);
+  });
+
+  it("pulls compatible edges off their straight chords", () => {
+    const { nodes, edges } = bipartite(4);
+    const bundled = bundleEdges(nodes, edges);
+    // The edge between the two middle-ish rows should bow away from its chord.
+    const path = bundled.get("L0->R3")!;
+    expect(path.length).toBeGreaterThan(2);
+    const maxDev = Math.max(
+      ...path.slice(1, -1).map((pt) => {
+        // perpendicular distance to the straight chord (0,0)→(100,100)
+        return Math.abs(pt.x - pt.y) / Math.SQRT2;
+      })
+    );
+    expect(maxDev).toBeGreaterThan(0.5);
+  });
+
+  it("honours a reduced cycle/iteration budget without throwing", () => {
+    const { nodes, edges } = bipartite(5);
+    const bundled = bundleEdges(nodes, edges, { cycles: 2, iterations: 10 });
+    expect(bundled.size).toBe(edges.length);
+  });
+});
+
+describe("edgeCurvature", () => {
+  it("is zero for straight or degenerate polylines", () => {
+    expect(
+      edgeCurvature([
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ])
+    ).toBe(0);
+    expect(
+      edgeCurvature([
+        { x: 0, y: 0 },
+        { x: 5, y: 0 },
+        { x: 10, y: 0 },
+      ])
+    ).toBe(0);
+  });
+
+  it("signs the bow by which side of the chord the polyline bends", () => {
+    const left = edgeCurvature([
+      { x: 0, y: 0 },
+      { x: 5, y: 5 },
+      { x: 10, y: 0 },
+    ]);
+    const right = edgeCurvature([
+      { x: 0, y: 0 },
+      { x: 5, y: -5 },
+      { x: 10, y: 0 },
+    ]);
+    expect(left).toBeGreaterThan(0);
+    expect(right).toBeLessThan(0);
+    expect(left).toBeCloseTo(-right);
+  });
+
+  it("clamps extreme deviations into the [-1, 1] range", () => {
+    const c = edgeCurvature([
+      { x: 0, y: 0 },
+      { x: 5, y: 100 },
+      { x: 10, y: 0 },
+    ]);
+    expect(c).toBeLessThanOrEqual(1);
+    expect(c).toBeGreaterThanOrEqual(-1);
+  });
+});
+
+describe("countEdgeCrossings", () => {
+  it("counts a single proper crossing", () => {
+    const polylines: BundlePoint[][] = [
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 10 },
+      ],
+      [
+        { x: 0, y: 10 },
+        { x: 10, y: 0 },
+      ],
+    ];
+    expect(countEdgeCrossings(polylines)).toBe(1);
+  });
+
+  it("does not count edges that merely share a node endpoint", () => {
+    const polylines: BundlePoint[][] = [
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 10 },
+      ],
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: -10 },
+      ],
+    ];
+    expect(countEdgeCrossings(polylines)).toBe(0);
+  });
+});
+
+describe("edgeInk", () => {
+  it("counts the distinct grid cells a polyline paints", () => {
+    // A 10-long horizontal segment at cell size 5 lands in cells 0 and 1.
+    const ink = edgeInk(
+      [
+        [
+          { x: 0, y: 0 },
+          { x: 10, y: 0 },
+        ],
+      ],
+      5
+    );
+    expect(ink).toBeGreaterThanOrEqual(2);
+  });
+
+  it("counts overlapping edges' shared cells once", () => {
+    const single = edgeInk(
+      [
+        [
+          { x: 0, y: 0 },
+          { x: 20, y: 0 },
+        ],
+      ],
+      5
+    );
+    const overlapping = edgeInk(
+      [
+        [
+          { x: 0, y: 0 },
+          { x: 20, y: 0 },
+        ],
+        [
+          { x: 0, y: 0 },
+          { x: 20, y: 0 },
+        ],
+      ],
+      5
+    );
+    // Two coincident edges paint no more cells than one.
+    expect(overlapping).toBe(single);
+  });
+});
+
+describe("BUNDLE_EDGE_LIMIT", () => {
+  it("is a sane positive cap", () => {
+    expect(BUNDLE_EDGE_LIMIT).toBeGreaterThan(0);
+  });
+});

--- a/packages/ui/src/lib/renderers/graph-bundle.ts
+++ b/packages/ui/src/lib/renderers/graph-bundle.ts
@@ -1,0 +1,401 @@
+// Force-directed edge bundling (FDEB) for the graph renderer.
+//
+// Pure, DOM-free, and deterministic — no sigma/WebGL imports — so it stays
+// unit-testable in the node environment alongside graph-render/graph-sigma.
+// The algorithm is the Holten & van Wijk force-directed scheme (the same one
+// d3.ForceBundle popularised): each edge is subdivided into points that are
+// pulled toward the corresponding points of *compatible* edges, so edges that
+// run roughly parallel collapse onto shared trunks and the "hairball" of a
+// dense subgraph untangles into legible bundles.
+//
+// It is meant to be **precomputed** (memoised by the caller, recomputed only
+// when the draw set or layout changes) — never run per animation frame. The
+// caller caps edge count via BUNDLE_EDGE_LIMIT because the compatibility step
+// is O(E²).
+
+export interface BundlePoint {
+  x: number;
+  y: number;
+}
+
+export interface BundleNodePosition {
+  id: string;
+  x: number;
+  y: number;
+}
+
+export interface BundleEdgeInput {
+  id: string;
+  source: string;
+  target: string;
+}
+
+export interface BundleOptions {
+  /** Global bundling stiffness (spring constant K). */
+  stiffness: number;
+  /** Initial displacement step size, halved every cycle. */
+  stepSize: number;
+  /** Number of cycles (each doubles the subdivision count). */
+  cycles: number;
+  /** Iterations in the first cycle, decayed by iterationRate each cycle. */
+  iterations: number;
+  /** Multiplicative decay applied to the iteration count per cycle. */
+  iterationRate: number;
+  /** Factor the subdivision-point count grows by each cycle. */
+  subdivisionRate: number;
+  /** Edges with a combined compatibility below this don't attract. */
+  compatibilityThreshold: number;
+}
+
+export const DEFAULT_BUNDLE_OPTIONS: BundleOptions = {
+  stiffness: 0.1,
+  stepSize: 0.1,
+  cycles: 6,
+  iterations: 60,
+  iterationRate: 2 / 3,
+  subdivisionRate: 2,
+  compatibilityThreshold: 0.6,
+};
+
+// Above this many edges in the draw set, the O(E²) compatibility pass gets too
+// costly to run synchronously; the renderer skips bundling and says so.
+export const BUNDLE_EDGE_LIMIT = 1500;
+
+const EPS = 1e-6;
+
+interface Segment {
+  id: string;
+  s: BundlePoint;
+  t: BundlePoint;
+  len: number;
+}
+
+function distance(a: BundlePoint, b: BundlePoint): number {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+function midpoint(s: BundlePoint, t: BundlePoint): BundlePoint {
+  return { x: (s.x + t.x) / 2, y: (s.y + t.y) / 2 };
+}
+
+/**
+ * Resample a polyline to exactly `interior + 2` points evenly spaced by arc
+ * length (endpoints preserved). FDEB redistributes subdivision points this way
+ * at the start of every cycle so the spring forces stay balanced.
+ */
+function resample(points: BundlePoint[], interior: number): BundlePoint[] {
+  const count = interior + 2;
+  const cum: number[] = [0];
+  for (let i = 1; i < points.length; i++) {
+    cum.push(cum[i - 1] + distance(points[i], points[i - 1]));
+  }
+  const total = cum[cum.length - 1];
+  if (total < EPS) {
+    return Array.from({ length: count }, () => ({ ...points[0] }));
+  }
+  const out: BundlePoint[] = [];
+  let seg = 1;
+  for (let k = 0; k < count; k++) {
+    const target = (total * k) / (count - 1);
+    while (seg < points.length - 1 && cum[seg] < target) seg++;
+    const t0 = cum[seg - 1];
+    const span = cum[seg] - t0 || 1;
+    const pct = Math.max(0, Math.min(1, (target - t0) / span));
+    out.push({
+      x: points[seg - 1].x + pct * (points[seg].x - points[seg - 1].x),
+      y: points[seg - 1].y + pct * (points[seg].y - points[seg - 1].y),
+    });
+  }
+  return out;
+}
+
+// ─── pairwise edge compatibility (angle · scale · position · visibility) ─────
+
+function angleCompatibility(p: Segment, q: Segment): number {
+  const dot =
+    (p.t.x - p.s.x) * (q.t.x - q.s.x) + (p.t.y - p.s.y) * (q.t.y - q.s.y);
+  return Math.abs(dot / (p.len * q.len));
+}
+
+function scaleCompatibility(p: Segment, q: Segment): number {
+  const lavg = (p.len + q.len) / 2;
+  return 2 / (lavg / Math.min(p.len, q.len) + Math.max(p.len, q.len) / lavg);
+}
+
+function positionCompatibility(p: Segment, q: Segment): number {
+  const lavg = (p.len + q.len) / 2;
+  return lavg / (lavg + distance(midpoint(p.s, p.t), midpoint(q.s, q.t)));
+}
+
+function projectOntoLine(point: BundlePoint, line: Segment): BundlePoint {
+  const l2 = line.len * line.len;
+  const r =
+    ((line.s.y - point.y) * (line.s.y - line.t.y) -
+      (line.s.x - point.x) * (line.t.x - line.s.x)) /
+    l2;
+  return {
+    x: line.s.x + r * (line.t.x - line.s.x),
+    y: line.s.y + r * (line.t.y - line.s.y),
+  };
+}
+
+function edgeVisibility(p: Segment, q: Segment): number {
+  const i0 = projectOntoLine(q.s, p);
+  const i1 = projectOntoLine(q.t, p);
+  const im = midpoint(i0, i1);
+  const denom = distance(i0, i1);
+  if (denom < EPS) return 0;
+  return Math.max(0, 1 - (2 * distance(im, midpoint(q.s, q.t))) / denom);
+}
+
+function visibilityCompatibility(p: Segment, q: Segment): number {
+  return Math.min(edgeVisibility(p, q), edgeVisibility(q, p));
+}
+
+function compatibilityScore(p: Segment, q: Segment): number {
+  return (
+    angleCompatibility(p, q) *
+    scaleCompatibility(p, q) *
+    positionCompatibility(p, q) *
+    visibilityCompatibility(p, q)
+  );
+}
+
+function compatibilityLists(
+  segments: Segment[],
+  threshold: number
+): number[][] {
+  const lists: number[][] = segments.map(() => []);
+  for (let i = 0; i < segments.length; i++) {
+    for (let j = i + 1; j < segments.length; j++) {
+      if (compatibilityScore(segments[i], segments[j]) >= threshold) {
+        lists[i].push(j);
+        lists[j].push(i);
+      }
+    }
+  }
+  return lists;
+}
+
+/**
+ * Run force-directed edge bundling. Returns a polyline (source → … → target,
+ * endpoints included) for every input edge whose endpoints resolve. Edges that
+ * are dropped, self-loops, or zero-length get a straight two-point polyline so
+ * the caller always has geometry to draw.
+ */
+export function bundleEdges(
+  nodes: BundleNodePosition[],
+  edges: BundleEdgeInput[],
+  options: Partial<BundleOptions> = {}
+): Map<string, BundlePoint[]> {
+  const opts = { ...DEFAULT_BUNDLE_OPTIONS, ...options };
+  const pos = new Map(nodes.map((n) => [n.id, { x: n.x, y: n.y }]));
+  const result = new Map<string, BundlePoint[]>();
+
+  const segments: Segment[] = [];
+  for (const e of edges) {
+    const s = pos.get(e.source);
+    const t = pos.get(e.target);
+    if (!s || !t) continue;
+    // Straight fallback for every resolvable edge; bundleable ones overwrite it.
+    result.set(e.id, [{ ...s }, { ...t }]);
+    if (e.source === e.target) continue;
+    const len = distance(s, t);
+    if (len < EPS) continue;
+    segments.push({ id: e.id, s: { ...s }, t: { ...t }, len });
+  }
+
+  if (segments.length < 2) return result;
+
+  const subdivisions: BundlePoint[][] = segments.map((seg) => [
+    { ...seg.s },
+    { ...seg.t },
+  ]);
+  const compat = compatibilityLists(segments, opts.compatibilityThreshold);
+
+  let p = 1;
+  let step = opts.stepSize;
+  let iterations = opts.iterations;
+
+  for (let i = 0; i < subdivisions.length; i++) {
+    subdivisions[i] = resample(subdivisions[i], p);
+  }
+
+  for (let cycle = 0; cycle < opts.cycles; cycle++) {
+    const rounds = Math.max(1, Math.round(iterations));
+    for (let iter = 0; iter < rounds; iter++) {
+      const forces = segments.map((_, ei) =>
+        computeForces(
+          ei,
+          subdivisions,
+          compat,
+          segments[ei].len,
+          p,
+          step,
+          opts.stiffness
+        )
+      );
+      for (let ei = 0; ei < segments.length; ei++) {
+        for (let i = 1; i <= p; i++) {
+          subdivisions[ei][i].x += forces[ei][i].x;
+          subdivisions[ei][i].y += forces[ei][i].y;
+        }
+      }
+    }
+    step *= 0.5;
+    p *= opts.subdivisionRate;
+    iterations *= opts.iterationRate;
+    for (let i = 0; i < subdivisions.length; i++) {
+      subdivisions[i] = resample(subdivisions[i], p);
+    }
+  }
+
+  for (let ei = 0; ei < segments.length; ei++) {
+    result.set(
+      segments[ei].id,
+      subdivisions[ei].map((pt) => ({ x: pt.x, y: pt.y }))
+    );
+  }
+  return result;
+}
+
+function computeForces(
+  ei: number,
+  subdivisions: BundlePoint[][],
+  compat: number[][],
+  edgeLen: number,
+  p: number,
+  step: number,
+  stiffness: number
+): BundlePoint[] {
+  const kp = stiffness / (edgeLen * (p + 1));
+  const points = subdivisions[ei];
+  const forces: BundlePoint[] = [{ x: 0, y: 0 }];
+  for (let i = 1; i <= p; i++) {
+    const prev = points[i - 1];
+    const cur = points[i];
+    const next = points[i + 1];
+    // Spring force keeps the subdivision points evenly distributed.
+    let fx = kp * (prev.x - 2 * cur.x + next.x);
+    let fy = kp * (prev.y - 2 * cur.y + next.y);
+    // Electrostatic force pulls toward the matching point of compatible edges.
+    for (const oe of compat[ei]) {
+      const other = subdivisions[oe][i];
+      const dx = other.x - cur.x;
+      const dy = other.y - cur.y;
+      if (Math.abs(dx) > EPS || Math.abs(dy) > EPS) {
+        const d = Math.hypot(dx, dy);
+        fx += dx / d;
+        fy += dy / d;
+      }
+    }
+    forces.push({ x: step * fx, y: step * fy });
+  }
+  forces.push({ x: 0, y: 0 });
+  return forces;
+}
+
+/**
+ * Map a bundled polyline onto a single sigma `curvature` value: the signed
+ * perpendicular deviation of its most-displaced point, scaled so a quadratic
+ * Bézier reproduces that bow (mid-curve deviation = ½·curvature·length).
+ *
+ * Sigma's WebGL scene flips y relative to layout space, so the caller negates
+ * this when feeding @sigma/edge-curve. Returns 0 for straight / degenerate
+ * polylines.
+ */
+export function edgeCurvature(points: BundlePoint[]): number {
+  if (points.length < 3) return 0;
+  const s = points[0];
+  const t = points[points.length - 1];
+  const dx = t.x - s.x;
+  const dy = t.y - s.y;
+  const len = Math.hypot(dx, dy);
+  if (len < EPS) return 0;
+  // Signed distance to the source→target line along the left normal (-dy, dx).
+  let maxDev = 0;
+  for (let i = 1; i < points.length - 1; i++) {
+    const px = points[i].x - s.x;
+    const py = points[i].y - s.y;
+    const dev = (px * -dy + py * dx) / len;
+    if (Math.abs(dev) > Math.abs(maxDev)) maxDev = dev;
+  }
+  const curvature = (2 * maxDev) / len;
+  return Math.max(-1, Math.min(1, curvature));
+}
+
+// ─── crossing metric (validates "measurable drop in crossings") ──────────────
+
+function cross(a: BundlePoint, b: BundlePoint, c: BundlePoint): number {
+  return (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x);
+}
+
+function segmentsCross(
+  p1: BundlePoint,
+  p2: BundlePoint,
+  p3: BundlePoint,
+  p4: BundlePoint
+): boolean {
+  const d1 = cross(p3, p4, p1);
+  const d2 = cross(p3, p4, p2);
+  const d3 = cross(p1, p2, p3);
+  const d4 = cross(p1, p2, p4);
+  // Strict signs ⇒ proper crossings only; segments that merely touch at a
+  // shared node endpoint (a d of 0) are not counted.
+  return (
+    ((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) &&
+    ((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0))
+  );
+}
+
+/**
+ * Count proper crossings between distinct polylines (straight edges are
+ * two-point polylines). A correctness primitive for the geometry; note that
+ * FDEB does *not* aim to reduce topological crossings (two edges with
+ * interleaved endpoints must cross however they are routed) — use `edgeInk`
+ * to measure the clutter reduction bundling actually delivers.
+ */
+export function countEdgeCrossings(polylines: BundlePoint[][]): number {
+  let crossings = 0;
+  for (let a = 0; a < polylines.length; a++) {
+    const A = polylines[a];
+    for (let b = a + 1; b < polylines.length; b++) {
+      const B = polylines[b];
+      for (let i = 1; i < A.length; i++) {
+        for (let j = 1; j < B.length; j++) {
+          if (segmentsCross(A[i - 1], A[i], B[j - 1], B[j])) crossings++;
+        }
+      }
+    }
+  }
+  return crossings;
+}
+
+/**
+ * "Edge ink": the number of distinct grid cells the edge polylines paint, at a
+ * given cell size. This is the standard quality measure for edge bundling —
+ * the visual signal behind "untangle the hairball". Bundling routes compatible
+ * edges onto shared trunks, so their strokes overlap and the painted area (and
+ * thus the visible crossing clutter) drops measurably. Lower is tighter.
+ */
+export function edgeInk(polylines: BundlePoint[][], cellSize: number): number {
+  const cells = new Set<string>();
+  const half = cellSize / 2;
+  for (const poly of polylines) {
+    for (let i = 1; i < poly.length; i++) {
+      const a = poly[i - 1];
+      const b = poly[i];
+      const steps = Math.max(
+        1,
+        Math.ceil(Math.hypot(b.x - a.x, b.y - a.y) / half)
+      );
+      for (let s = 0; s <= steps; s++) {
+        const u = s / steps;
+        const x = Math.floor((a.x + u * (b.x - a.x)) / cellSize);
+        const y = Math.floor((a.y + u * (b.y - a.y)) / cellSize);
+        cells.add(`${x},${y}`);
+      }
+    }
+  }
+  return cells.size;
+}

--- a/packages/ui/src/lib/renderers/graph-sigma.test.ts
+++ b/packages/ui/src/lib/renderers/graph-sigma.test.ts
@@ -54,6 +54,7 @@ const baseState = (
   selectedNodeId: null,
   pulse: 0,
   colors: THEME,
+  bundle: false,
   ...over,
 });
 
@@ -135,6 +136,16 @@ describe("buildSigmaGraph", () => {
     expect(e.edgeLabel).toBe("KNOWS");
     expect(e.label).toBe(""); // not shown until the edge is focused
     expect(e.type).toBe("line");
+    expect(e.curvature).toBe(0); // straight until bundling supplies a curvature
+  });
+
+  it("stamps bundling curvature onto edges when supplied", () => {
+    const g = buildSigmaGraph({
+      ...params,
+      bundledCurvatures: new Map([["a->b:KNOWS", 0.42]]),
+    });
+    expect(g.getEdgeAttributes("a->b:KNOWS").curvature).toBe(0.42);
+    expect(g.getEdgeAttributes("b->c:AT").curvature).toBe(0); // default
   });
 
   it("drops edges whose endpoints were filtered out", () => {
@@ -275,6 +286,7 @@ describe("reduceSigmaEdge", () => {
     color: "rgba(58, 66, 77, 0.34)",
     edgeLabel: "DEPENDS_ON",
     label: "",
+    curvature: 0.3,
     type: "line" as const,
   };
 
@@ -282,6 +294,26 @@ describe("reduceSigmaEdge", () => {
     const out = reduceSigmaEdge("e", attrs, baseState());
     expect(out.label).toBe("");
     expect(out.color).toBe(withAlpha(THEME.edge, 0.34));
+  });
+
+  it("keeps edges straight while bundling is off", () => {
+    const out = reduceSigmaEdge("e", attrs, baseState());
+    expect(out.type).toBe("line");
+  });
+
+  it("switches curved edges to the curve program when bundling is on", () => {
+    const out = reduceSigmaEdge("e", attrs, baseState({ bundle: true }));
+    expect(out.type).toBe("curved");
+    expect(out.curvature).toBe(0.3);
+  });
+
+  it("keeps near-straight edges on the line program even when bundling", () => {
+    const out = reduceSigmaEdge(
+      "e",
+      { ...attrs, curvature: 0 },
+      baseState({ bundle: true })
+    );
+    expect(out.type).toBe("line");
   });
 
   it("lights the focused fan and surfaces its label", () => {

--- a/packages/ui/src/lib/renderers/graph-sigma.ts
+++ b/packages/ui/src/lib/renderers/graph-sigma.ts
@@ -169,7 +169,13 @@ export interface SigmaEdgeAttributes {
   /** Original edge label, kept so the reducer can surface it on focus only. */
   edgeLabel: string;
   label: string;
-  type: "line";
+  /**
+   * Bundling curvature consumed by @sigma/edge-curve when bundling is on. 0 for
+   * a straight chord; the reducer flips the edge to the "curved" program only
+   * when bundling is active.
+   */
+  curvature: number;
+  type: "line" | "curved";
 }
 
 export interface BuildSigmaGraphParams {
@@ -180,6 +186,12 @@ export interface BuildSigmaGraphParams {
   orphanIds: Set<string>;
   dark?: boolean;
   edgeColor?: string;
+  /**
+   * Per-edge bundling curvature (sigma scene space), keyed by edge id. When
+   * present and non-zero, the edge carries the value so the curve program can
+   * bow it onto its bundle. Absent / 0 → straight edge.
+   */
+  bundledCurvatures?: Map<string, number>;
 }
 
 /**
@@ -199,6 +211,7 @@ export function buildSigmaGraph(
     orphanIds,
     dark = true,
     edgeColor = "#3a424d",
+    bundledCurvatures,
   } = params;
 
   const graph = new Graph<SigmaNodeAttributes, SigmaEdgeAttributes>({
@@ -241,6 +254,7 @@ export function buildSigmaGraph(
       color: withAlpha(edgeColor, 0.34),
       edgeLabel: edge.label ?? "",
       label: "",
+      curvature: bundledCurvatures?.get(edge.id) ?? 0,
       type: "line",
     });
   }
@@ -284,6 +298,8 @@ export interface SigmaReducerState {
   /** Focus-pulse progress, 0 (rest) → 1 (peak). Held at 0 for reduced motion. */
   pulse: number;
   colors: SigmaThemeColors;
+  /** Edge bundling on → edges render through the curve program. */
+  bundle: boolean;
 }
 
 export interface SigmaNodeDisplay {
@@ -303,6 +319,10 @@ export interface SigmaEdgeDisplay {
   forceLabel: boolean;
   zIndex: number;
   hidden: boolean;
+  /** Which edge program draws this edge: straight "line" or bundled "curved". */
+  type: "line" | "curved";
+  /** Bow magnitude/sign for the curve program (ignored by the line program). */
+  curvature: number;
 }
 
 const NODE_LABEL_MAX = 36;
@@ -358,9 +378,16 @@ export function reduceSigmaEdge(
   attrs: SigmaEdgeAttributes,
   state: SigmaReducerState
 ): SigmaEdgeDisplay {
-  const { focus, focusId, colors } = state;
+  const { focus, focusId, colors, bundle } = state;
   const hasFocus = focusId !== null;
   const focused = focus.edges.has(id);
+
+  // The sigma edge reducer's return *replaces* the edge data, so type and
+  // curvature must be carried through on every branch or the curve program
+  // can't see them. Bundle off → always the straight line program.
+  const curvature = attrs.curvature;
+  const type: "line" | "curved" =
+    bundle && Math.abs(curvature) > 1e-4 ? "curved" : "line";
 
   if (!hasFocus) {
     return {
@@ -370,6 +397,8 @@ export function reduceSigmaEdge(
       forceLabel: false,
       zIndex: 0,
       hidden: false,
+      type,
+      curvature,
     };
   }
 
@@ -381,6 +410,8 @@ export function reduceSigmaEdge(
       forceLabel: Boolean(attrs.edgeLabel),
       zIndex: 2,
       hidden: false,
+      type,
+      curvature,
     };
   }
 
@@ -391,5 +422,7 @@ export function reduceSigmaEdge(
     forceLabel: false,
     zIndex: 0,
     hidden: false,
+    type,
+    curvature,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       "@reddb-io/ui-mcp":
         specifier: workspace:*
         version: link:../mcp
+      "@sigma/edge-curve":
+        specifier: ^3.1.0
+        version: 3.1.0(sigma@3.0.3(graphology-types@0.24.8))
       "@sigma/node-border":
         specifier: ^3.0.0
         version: 3.0.0(sigma@3.0.3(graphology-types@0.24.8))
@@ -1669,6 +1672,14 @@ packages:
       }
     cpu: [x64]
     os: [win32]
+
+  "@sigma/edge-curve@3.1.0":
+    resolution:
+      {
+        integrity: sha512-OFWkfAXEsm+X8l1K4K49cC0psB0gQ+gqxKA08HG5piNPdzrDZ5gG9Gza6htZ5AirOVwd/4/uq/gPpD5En+H+3Q==,
+      }
+    peerDependencies:
+      sigma: ">=3.0.0-beta.10"
 
   "@sigma/node-border@3.0.0":
     resolution:
@@ -5270,6 +5281,10 @@ snapshots:
 
   "@rollup/rollup-win32-x64-msvc@4.60.4":
     optional: true
+
+  "@sigma/edge-curve@3.1.0(sigma@3.0.3(graphology-types@0.24.8))":
+    dependencies:
+      sigma: 3.0.3(graphology-types@0.24.8)
 
   "@sigma/node-border@3.0.0(sigma@3.0.3(graphology-types@0.24.8))":
     dependencies:


### PR DESCRIPTION
Salvaged from AFK worker wH0CI (crashed no-sentinel after iteration cap at stage:tests). Branch carries the complete commit.

Closes #62. Part of PRD #58.

Verified locally: `pnpm --filter @reddb-io/ui test` → **348 pass**, `svelte-check` → **0 errors**, `build` → **clean** (new sigma-edge-curve chunk bundles).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783035795&installation_id=129708444&pr_number=66&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F66&signature=8ee019be924fef6bbac0dcbaf1b9f01777ccce3fbe3cfe0b87038204afa603b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added force-directed edge bundling to improve visualization of densely-connected graphs by curving edges to reduce visual clutter.
  * Added toolbar toggle to enable/disable edge bundling.
  * Edges now render as curved paths when bundling is enabled.
  * Works seamlessly with both canvas and SVG rendering modes.

* **Tests**
  * Added comprehensive test coverage for edge bundling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->