### PR TITLE
feat(graph): Leiden community detection with Louvain fallback (#60)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -53,6 +53,7 @@
     "test": "svelte-kit sync && vitest run"
   },
   "dependencies": {
+    "@aflsolutions/graphology-communities-leiden": "^1.1.1",
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@reddb-io/ui-kit": "workspace:*",

--- a/packages/ui/src/lib/renderers/graph-render.test.ts
+++ b/packages/ui/src/lib/renderers/graph-render.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
+import Graph from "graphology";
+import leiden from "@aflsolutions/graphology-communities-leiden";
+import louvain from "graphology-communities-louvain";
 import type { QueryResult } from "#reddb";
 import {
+  assignGraphCommunities,
   compareGraphNodesByCentrality,
   extractGraph,
   graphNodeCentrality,
@@ -348,6 +352,159 @@ describe("runGraphLayout", () => {
     const a = runGraphLayout(nodes, edges);
     const b = runGraphLayout(nodes, edges);
     for (const id of a.keys()) expect(a.get(id)).toEqual(b.get(id));
+  });
+});
+
+describe("assignGraphCommunities (Leiden, Louvain fallback)", () => {
+  // Mulberry32 — deterministic seed so the fixture and the algorithms render
+  // the same partition on every run.
+  function seededRng(seed: number): () => number {
+    let s = seed >>> 0;
+    return () => {
+      s = (s + 0x6d2b79f5) >>> 0;
+      let t = s;
+      t = Math.imul(t ^ (t >>> 15), t | 1);
+      t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+  }
+
+  /**
+   * A planted-partition graph: `groups` dense clusters of `perGroup` nodes,
+   * wired into a ring inside each group (guaranteeing intra-group reach) plus
+   * extra random intra-group edges, joined by a handful of cross-group
+   * bridges. Representative of the clustered topology graphs we render.
+   */
+  function plantedPartition(groups: number, perGroup: number): Graph {
+    const g = new Graph({ type: "undirected", multi: false });
+    const rng = seededRng(1337);
+    for (let gi = 0; gi < groups; gi++) {
+      for (let i = 0; i < perGroup; i++) g.addNode(`g${gi}_n${i}`);
+    }
+    for (let gi = 0; gi < groups; gi++) {
+      const ids = Array.from({ length: perGroup }, (_, i) => `g${gi}_n${i}`);
+      // Ring spine keeps each group connected.
+      for (let i = 0; i < ids.length; i++) {
+        const a = ids[i];
+        const b = ids[(i + 1) % ids.length];
+        if (!g.hasEdge(a, b)) g.addEdge(a, b);
+      }
+      // Extra intra-group density.
+      for (let i = 0; i < ids.length; i++) {
+        for (let j = i + 1; j < ids.length; j++) {
+          if (rng() < 0.45 && !g.hasEdge(ids[i], ids[j]))
+            g.addEdge(ids[i], ids[j]);
+        }
+      }
+    }
+    // Sparse cross-group bridges.
+    for (let gi = 0; gi < groups; gi++) {
+      const next = (gi + 1) % groups;
+      const a = `g${gi}_n0`;
+      const b = `g${next}_n${perGroup - 1}`;
+      if (!g.hasEdge(a, b)) g.addEdge(a, b);
+    }
+    return g;
+  }
+
+  /** Group node ids by their assigned `community` attribute. */
+  function communitiesOf(g: Graph): Map<number, string[]> {
+    const byCommunity = new Map<number, string[]>();
+    g.forEachNode((node, attrs) => {
+      const c = attrs.community as number;
+      const bucket = byCommunity.get(c);
+      if (bucket) bucket.push(node);
+      else byCommunity.set(c, [node]);
+    });
+    return byCommunity;
+  }
+
+  /**
+   * True iff the subgraph induced by `members` is a single connected
+   * component — the property Leiden guarantees and Louvain does not.
+   */
+  function inducedSubgraphConnected(g: Graph, members: string[]): boolean {
+    if (members.length <= 1) return true;
+    const inCommunity = new Set(members);
+    const seen = new Set<string>([members[0]]);
+    const stack = [members[0]];
+    while (stack.length) {
+      const node = stack.pop()!;
+      g.forEachNeighbor(node, (neighbor) => {
+        if (inCommunity.has(neighbor) && !seen.has(neighbor)) {
+          seen.add(neighbor);
+          stack.push(neighbor);
+        }
+      });
+    }
+    return seen.size === members.length;
+  }
+
+  it("uses Leiden when the fork is available", () => {
+    const g = plantedPartition(4, 8);
+    expect(assignGraphCommunities(g, seededRng(7))).toBe("leiden");
+    // Output contract: every node carries a numeric community.
+    g.forEachNode((_, attrs) => {
+      expect(typeof attrs.community).toBe("number");
+    });
+  });
+
+  it("produces internally-connected communities (Leiden's guarantee)", () => {
+    const g = plantedPartition(4, 8);
+    assignGraphCommunities(g, seededRng(7));
+    const byCommunity = communitiesOf(g);
+    expect(byCommunity.size).toBeGreaterThan(1);
+    for (const [community, members] of byCommunity) {
+      expect(
+        inducedSubgraphConnected(g, members),
+        `community ${community} (${members.length} nodes) must be internally connected`
+      ).toBe(true);
+    }
+  });
+
+  it("records modularity vs Louvain on the same fixture", () => {
+    const leidenGraph = plantedPartition(4, 8);
+    const louvainGraph = plantedPartition(4, 8);
+    const leidenOut = leiden.detailed(leidenGraph, { rng: seededRng(7) });
+    const louvainOut = louvain.detailed(louvainGraph, { rng: seededRng(7) });
+
+    // Recorded delta — surfaced in the test log for benchmark tracking.
+    const delta = leidenOut.modularity - louvainOut.modularity;
+    // eslint-disable-next-line no-console
+    console.log(
+      `[graph-layout] modularity — leiden=${leidenOut.modularity.toFixed(4)} ` +
+        `louvain=${louvainOut.modularity.toFixed(4)} delta=${delta.toFixed(4)} ` +
+        `(communities: leiden=${leidenOut.count} louvain=${louvainOut.count})`
+    );
+
+    // Both are real partitions on a clearly-clustered graph; Leiden must not
+    // be materially worse than Louvain on modularity.
+    expect(leidenOut.modularity).toBeGreaterThan(0.3);
+    expect(louvainOut.modularity).toBeGreaterThan(0.3);
+    expect(leidenOut.modularity).toBeGreaterThanOrEqual(
+      louvainOut.modularity - 0.05
+    );
+  });
+
+  it("falls back to Louvain when the Leiden import is missing", () => {
+    const g = plantedPartition(3, 6);
+    expect(assignGraphCommunities(g, seededRng(7), null)).toBe("louvain");
+    g.forEachNode((_, attrs) => {
+      expect(typeof attrs.community).toBe("number");
+    });
+  });
+
+  it("falls back to Louvain when Leiden throws", () => {
+    const g = plantedPartition(3, 6);
+    const throwing = {
+      assign() {
+        throw new Error("simulated yanked fork");
+      },
+    };
+    expect(assignGraphCommunities(g, seededRng(7), throwing)).toBe("louvain");
+    g.forEachNode((_, attrs) => {
+      expect(typeof attrs.community).toBe("number");
+    });
   });
 });
 

--- a/packages/ui/src/lib/renderers/graph-render.ts
+++ b/packages/ui/src/lib/renderers/graph-render.ts
@@ -4,6 +4,7 @@
 
 import type { QueryResult, QueryRow } from "#reddb";
 import Graph from "graphology";
+import leiden from "@aflsolutions/graphology-communities-leiden";
 import louvain from "graphology-communities-louvain";
 import forceAtlas2 from "graphology-layout-forceatlas2";
 
@@ -506,11 +507,53 @@ function seededRng(seed: number): () => number {
   };
 }
 
+/** Algorithm that actually labelled communities on the graph. */
+export type CommunityAlgorithm = "leiden" | "louvain";
+
+/** Minimal surface we depend on from a community-detection package. */
+interface CommunityAssigner {
+  assign(graph: Graph, options?: Record<string, unknown>): void;
+}
+
+/**
+ * Assign a `community` number to every node, preferring Leiden.
+ *
+ * Leiden (Traag et al. 2019) is the state-of-the-art successor to Louvain
+ * and — unlike Louvain — guarantees every community is internally
+ * well-connected. We adopt the third-party `@aflsolutions/...-leiden` fork
+ * (the canonical package is unpublished); to contain its supply-chain risk
+ * a yanked/broken fork must never break the graph view, so any failure
+ * (missing/partial module or a throw mid-run) falls back to the canonical
+ * Louvain pass. Both share the seeded `rng` so renders stay deterministic.
+ *
+ * The `leidenImpl` parameter is injectable purely so the fallback path is
+ * testable; production callers always use the bundled fork.
+ */
+export function assignGraphCommunities(
+  g: Graph,
+  rng: () => number,
+  leidenImpl: CommunityAssigner | null | undefined = leiden as CommunityAssigner
+): CommunityAlgorithm {
+  try {
+    if (!leidenImpl || typeof leidenImpl.assign !== "function") {
+      throw new Error("Leiden community detection unavailable");
+    }
+    leidenImpl.assign(g, { attributes: { community: "community" }, rng });
+    return "leiden";
+  } catch {
+    // Fork yanked, broken, or threw — fall back to canonical Louvain so the
+    // graph view always renders with communities.
+    louvain.assign(g, { nodeCommunityAttribute: "community", rng });
+    return "louvain";
+  }
+}
+
 /**
  * Compute a community-aware layout for the graph.
  *
- * Pipeline: Louvain detects communities, ForceAtlas2 positions nodes so
- * communities cluster spatially. Output is normalised to a [0, 100] box
+ * Pipeline: Leiden detects communities (Louvain fallback), ForceAtlas2
+ * positions nodes so communities cluster spatially. Output is normalised
+ * to a [0, 100] box
  * matching the existing renderer's coordinate space, with a 5% padding so
  * nodes don't touch the viewport edge.
  *
@@ -552,8 +595,8 @@ export function runGraphLayout(
     g.addEdge(e.source, e.target);
   }
 
-  // Louvain needs at least one edge; degenerate graphs get every node in
-  // its own community and a grid fallback below.
+  // Community detection needs at least one edge; degenerate graphs get
+  // every node in its own community and a grid fallback below.
   if (g.size === 0) {
     const cols = Math.ceil(Math.sqrt(nodes.length));
     nodes.forEach((n, i) => {
@@ -568,7 +611,7 @@ export function runGraphLayout(
     return out;
   }
 
-  louvain.assign(g, { nodeCommunityAttribute: "community", rng });
+  assignGraphCommunities(g, rng);
 
   const settings = forceAtlas2.inferSettings(g);
   forceAtlas2.assign(g, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
 
   packages/ui:
     dependencies:
+      "@aflsolutions/graphology-communities-leiden":
+        specifier: ^1.1.1
+        version: 1.1.1(graphology-types@0.24.8)
       "@fontsource-variable/inter":
         specifier: ^5.2.8
         version: 5.2.8
@@ -184,6 +187,14 @@ importers:
         version: 5.9.3
 
 packages:
+  "@aflsolutions/graphology-communities-leiden@1.1.1":
+    resolution:
+      {
+        integrity: sha512-kqjUf7oofB2c3RKvUIP3dIqwMzZxtVdDYLtr2Z2DFOmWa9RbNfUeQRns+UeODtWtEfwh6j83UiMRxRMDIdGC5A==,
+      }
+    peerDependencies:
+      graphology-types: ">=0.19.0"
+
   "@babel/runtime@7.29.7":
     resolution:
       {
@@ -4569,6 +4580,14 @@ packages:
       }
 
 snapshots:
+  "@aflsolutions/graphology-communities-leiden@1.1.1(graphology-types@0.24.8)":
+    dependencies:
+      graphology-indices: 0.17.0(graphology-types@0.24.8)
+      graphology-types: 0.24.8
+      graphology-utils: 2.5.2(graphology-types@0.24.8)
+      mnemonist: 0.39.8
+      pandemonium: 2.4.1
+
   "@babel/runtime@7.29.7": {}
 
   "@changesets/apply-release-plan@7.1.1":


### PR DESCRIPTION
Salvage of AFK worker w67DP attempt for #60 (PRD #58). Inner agent completed + committed the work (335 tests pass, svelte-check clean, build green) but a wall-clock guard false-flagged it `blocked:stalled` during the final svelte-check after a transient `uv_cwd` cwd hiccup.

Verified locally in an isolated worktree off the snapshot branch:
- ✅ 335/335 tests (incl. `produces internally-connected communities (Leiden's guarantee)` — structural DFS assertion on a planted-partition fixture, the property Louvain does NOT guarantee)
- ✅ svelte-check 0 errors 0 warnings
- ✅ build green
- modularity benchmark: leiden=0.6949 louvain=0.6949 (tied; the load-bearing test is the structural connectivity one, not modularity)

Leiden adopted via the `@aflsolutions/graphology-communities-leiden` fork with a Louvain fallback for supply-chain safety (yanked/broken fork can never break the graph view).

Closes #60.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783079941&installation_id=129708444&pr_number=76&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F76&signature=504c58fda3f112fc57f6bfa9c70357e410096e95868807864fee3bb4b4ef0c2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced graph visualization with improved community detection capabilities using the Leiden algorithm, with Louvain as an automatic fallback.

* **Tests**
  * Added comprehensive tests for community detection functionality and algorithm selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/red-ui/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->