### PR TITLE
feat(ui-kit): settings primitives — ListRow, SectionHeading, Pill, NavItem, states (#72)

### DIFF
--- a/packages/ui-kit/src/lib/EmptyState.svelte
+++ b/packages/ui-kit/src/lib/EmptyState.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  // The "live or empty — never fake" fallback: a centered icon + title +
+  // optional description, with an optional `action` slot (a fix command, a
+  // primary button). Used when a list has no rows or a surface is unreachable.
+  import type { Snippet } from 'svelte'
+
+  interface Props {
+    title: string
+    description?: string
+    /** Leading icon, rendered muted above the title. */
+    icon?: Snippet
+    /** Optional call to action beneath the copy. */
+    action?: Snippet
+    class?: string
+  }
+  let { title, description, icon, action, class: klass = '' }: Props = $props()
+</script>
+
+<div class="flex flex-col items-center justify-center gap-2 px-6 py-10 text-center {klass}">
+  {#if icon}
+    <span class="flex size-8 items-center justify-center text-fg-3">{@render icon()}</span>
+  {/if}
+  <p class="text-[13px] text-fg-1">{title}</p>
+  {#if description}
+    <p class="max-w-prose text-[12px] leading-relaxed text-fg-2">{description}</p>
+  {/if}
+  {#if action}
+    <div class="mt-2">{@render action()}</div>
+  {/if}
+</div>

--- a/packages/ui-kit/src/lib/ListRow.svelte
+++ b/packages/ui-kit/src/lib/ListRow.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  // A settings/governance row: a `title` (+ optional `description` and a mono
+  // `hint`) on the left, a right-aligned `action` slot, and an optional `below`
+  // slot that spans the row's full width (for inline editors, diffs, warnings).
+  //
+  // `wide` flips the layout to a stacked variant: the label block sits on top
+  // and the action drops to its own full-width line beneath — for actions that
+  // are too large to sit inline (a long input, a segmented control).
+  import type { Snippet } from 'svelte'
+
+  interface Props {
+    title: string
+    /** Secondary line under the title. */
+    description?: string
+    /** Mono hint — a value, key, or id rendered in the data typeface. */
+    hint?: string
+    /** Right-aligned (inline) or full-width-below (wide) action. */
+    action?: Snippet
+    /** Full-width content beneath the row — editors, diffs, warnings. */
+    below?: Snippet
+    /** Stack the action beneath the label block instead of inline-right. */
+    wide?: boolean
+    class?: string
+  }
+  let {
+    title,
+    description,
+    hint,
+    action,
+    below,
+    wide = false,
+    class: klass = '',
+  }: Props = $props()
+</script>
+
+<div
+  data-wide={wide ? '' : undefined}
+  class={[
+    'px-3 py-2.5',
+    wide ? 'flex flex-col gap-2' : 'flex items-center gap-3',
+    klass,
+  ].join(' ')}
+>
+  <div class={['flex min-w-0 items-baseline gap-2', wide ? '' : 'flex-1'].join(' ')}>
+    <div class="min-w-0">
+      <div class="flex items-baseline gap-2">
+        <span class="truncate text-[13px] text-fg-0">{title}</span>
+        {#if hint}
+          <span class="shrink-0 font-mono text-[11px] text-fg-2">{hint}</span>
+        {/if}
+      </div>
+      {#if description}
+        <p class="mt-0.5 text-[12px] leading-snug text-fg-2">{description}</p>
+      {/if}
+    </div>
+  </div>
+
+  {#if action}
+    <div class={['flex items-center gap-2', wide ? 'w-full' : 'shrink-0'].join(' ')}>
+      {@render action()}
+    </div>
+  {/if}
+
+  {#if below}
+    <div class="w-full">{@render below()}</div>
+  {/if}
+</div>

--- a/packages/ui-kit/src/lib/LoadingState.svelte
+++ b/packages/ui-kit/src/lib/LoadingState.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  // A quiet inline loading affordance — a spinning ring + optional label.
+  // Honors `prefers-reduced-motion` (the spin is dropped when the user asks for
+  // reduced motion). Pair with a surface while its data is in flight.
+  interface Props {
+    label?: string
+    class?: string
+  }
+  let { label = 'Loading…', class: klass = '' }: Props = $props()
+</script>
+
+<div class="flex items-center justify-center gap-2 px-6 py-10 text-fg-2 {klass}">
+  <span
+    class="size-3.5 rounded-full border-2 border-line-2 border-t-fg-2 motion-safe:animate-spin"
+    aria-hidden="true"
+  ></span>
+  {#if label}
+    <span class="text-[12px]">{label}</span>
+  {/if}
+</div>

--- a/packages/ui-kit/src/lib/NavItem.svelte
+++ b/packages/ui-kit/src/lib/NavItem.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  // A navigation entry for the SplitView nav pane: leading icon + label, an
+  // active state (accent-marked, `aria-current="page"`), and an optional
+  // trailing slot (a count Pill, a chevron). Renders as an `<a>` when `href` is
+  // given, otherwise a `<button>` — so it works for both routing and local
+  // section state.
+  import type { Snippet } from 'svelte'
+
+  interface Props {
+    label: string
+    icon?: Snippet
+    trailing?: Snippet
+    active?: boolean
+    href?: string
+    onclick?: (e: MouseEvent) => void
+    class?: string
+  }
+  let {
+    label,
+    icon,
+    trailing,
+    active = false,
+    href,
+    onclick,
+    class: klass = '',
+  }: Props = $props()
+
+  const cls = $derived(
+    [
+      'inline-flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors',
+      active ? 'bg-bg-2 text-fg-0' : 'text-fg-2 hover:bg-bg-2 hover:text-fg-0',
+      klass,
+    ].join(' '),
+  )
+</script>
+
+{#if href}
+  <a {href} {onclick} aria-current={active ? 'page' : undefined} class={cls}>
+    {#if icon}
+      <span class="flex size-3.5 shrink-0 items-center justify-center">{@render icon()}</span>
+    {/if}
+    <span class="flex-1 truncate">{label}</span>
+    {#if trailing}<span class="shrink-0">{@render trailing()}</span>{/if}
+  </a>
+{:else}
+  <button type="button" {onclick} aria-current={active ? 'page' : undefined} class={cls}>
+    {#if icon}
+      <span class="flex size-3.5 shrink-0 items-center justify-center">{@render icon()}</span>
+    {/if}
+    <span class="flex-1 truncate">{label}</span>
+    {#if trailing}<span class="shrink-0">{@render trailing()}</span>{/if}
+  </button>
+{/if}

--- a/packages/ui-kit/src/lib/Pill.svelte
+++ b/packages/ui-kit/src/lib/Pill.svelte
@@ -1,0 +1,28 @@
+<script lang="ts" module>
+  import { tv } from 'tailwind-variants'
+  // A small meta chip for counts/labels next to a heading — quieter than Badge
+  // (no uppercase/tracking), tuned for inline use beside a SectionHeading.
+  export const pill = tv({
+    base:
+      'inline-flex items-center gap-1 px-1.5 h-[18px] rounded-full text-[11px] ' +
+      'font-mono leading-none border',
+    variants: {
+      tone: {
+        muted: 'bg-bg-2 text-fg-2 border-line-2',
+        accent: 'bg-accent/15 text-accent border-accent/30',
+      },
+    },
+    defaultVariants: { tone: 'muted' },
+  })
+</script>
+
+<script lang="ts">
+  interface Props {
+    tone?: 'muted' | 'accent'
+    class?: string
+    children?: import('svelte').Snippet
+  }
+  let { tone = 'muted', class: klass = '', children }: Props = $props()
+</script>
+
+<span class={pill({ tone, class: klass })}>{@render children?.()}</span>

--- a/packages/ui-kit/src/lib/SectionHeading.svelte
+++ b/packages/ui-kit/src/lib/SectionHeading.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  // A section title row: optional leading icon + title + optional trailing meta
+  // (typically a `Pill` count). Density-first — sits above a stack of ListRows.
+  import type { Snippet } from 'svelte'
+
+  interface Props {
+    title: string
+    /** Leading icon (e.g. a lucide component rendered in a snippet). */
+    icon?: Snippet
+    /** Trailing meta — usually a `Pill` with a count. */
+    meta?: Snippet
+    class?: string
+  }
+  let { title, icon, meta, class: klass = '' }: Props = $props()
+</script>
+
+<div class="flex items-center gap-2 {klass}">
+  {#if icon}
+    <span class="flex size-4 shrink-0 items-center justify-center text-fg-2">{@render icon()}</span>
+  {/if}
+  <h2 class="text-[11px] font-mono uppercase tracking-[0.1em] text-fg-2">{title}</h2>
+  {#if meta}
+    <span class="ml-0.5">{@render meta()}</span>
+  {/if}
+</div>

--- a/packages/ui-kit/src/lib/index.ts
+++ b/packages/ui-kit/src/lib/index.ts
@@ -4,6 +4,12 @@ export { default as Card } from "./Card.svelte";
 export { default as NodeBadge } from "./NodeBadge.svelte";
 export { default as Kbd } from "./Kbd.svelte";
 export { default as SplitView } from "./SplitView.svelte";
+export { default as ListRow } from "./ListRow.svelte";
+export { default as SectionHeading } from "./SectionHeading.svelte";
+export { default as Pill } from "./Pill.svelte";
+export { default as NavItem } from "./NavItem.svelte";
+export { default as EmptyState } from "./EmptyState.svelte";
+export { default as LoadingState } from "./LoadingState.svelte";
 export {
   splitViewGridClass,
   isSearchShortcut,

--- a/packages/ui/src/lib/SettingsView.svelte
+++ b/packages/ui/src/lib/SettingsView.svelte
@@ -1,10 +1,19 @@
 <script lang="ts">
-  // Minimal settings view — mounts the reusable `SplitView` shell from the
-  // ui-kit end-to-end. The active section is component state (ADR-0001: the
+  // Settings view — mounts the reusable `SplitView` shell from the ui-kit and
+  // composes it from the kit's settings primitives (`NavItem`, `SectionHeading`,
+  // `Pill`, `ListRow`). The active section is component state (ADR-0001: the
   // Mountable Root owns no routing here), the nav is local to this view (no
   // global persistent sidebar), and the search affordance is wired to the
   // existing ⌘K command palette rather than re-binding ⌘K itself.
-  import { SplitView, Kbd } from '@reddb-io/ui-kit'
+  import {
+    SplitView,
+    NavItem,
+    SectionHeading,
+    Pill,
+    ListRow,
+    Button,
+    Kbd,
+  } from '@reddb-io/ui-kit'
   import { Settings2, Plug, Palette, Search, type Icon } from 'lucide-svelte'
   import PageHeader from '$lib/PageHeader.svelte'
   import { SETTINGS_SECTIONS, resolveSection } from '$lib/settings-sections'
@@ -44,19 +53,13 @@
     <nav class="grid gap-0.5 p-2">
       {#each SETTINGS_SECTIONS as section (section.id)}
         {@const Icon = icons[section.id] ?? Settings2}
-        {@const isActive = section.id === active.id}
-        <button
-          type="button"
+        <NavItem
+          label={section.label}
+          active={section.id === active.id}
           onclick={() => (activeId = section.id)}
-          aria-current={isActive ? 'page' : undefined}
-          class={[
-            'inline-flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors',
-            isActive ? 'bg-bg-2 text-fg-0' : 'text-fg-2 hover:bg-bg-2 hover:text-fg-0',
-          ].join(' ')}
         >
-          <Icon class="size-3.5 shrink-0" />
-          <span class="truncate">{section.label}</span>
-        </button>
+          {#snippet icon()}<Icon class="size-3.5" />{/snippet}
+        </NavItem>
       {/each}
     </nav>
   {/snippet}
@@ -68,9 +71,39 @@
   {/snippet}
 
   {#snippet content()}
+    {@const Icon = icons[active.id] ?? Settings2}
     <div class="p-6">
       <PageHeader eyebrow="Settings" title={active.label} subtitle={active.blurb} />
-      <p class="max-w-prose text-[13px] leading-relaxed text-fg-1">{active.body}</p>
+
+      <section class="mb-6">
+        <SectionHeading title={active.label} class="mb-2">
+          {#snippet icon()}<Icon class="size-3.5" />{/snippet}
+          {#snippet meta()}<Pill>{active.rows.length}</Pill>{/snippet}
+        </SectionHeading>
+
+        <div class="divide-y divide-line-1 overflow-hidden rounded-lg border border-line-1 bg-bg-1">
+          {#each active.rows as row (row.title)}
+            <ListRow title={row.title} description={row.description} hint={row.hint} wide={row.wide}>
+              {#snippet action()}
+                {#if row.wide}
+                  <input
+                    type="text"
+                    value={row.hint ?? ''}
+                    spellcheck="false"
+                    class="h-7 w-full rounded-md border border-line-2 bg-bg-2 px-2.5 font-mono text-[12px] text-fg-1 focus-visible:border-line-3 focus-visible:outline-none"
+                  />
+                {:else if row.status}
+                  <Pill tone={row.status.tone}>{row.status.label}</Pill>
+                {:else}
+                  <Button size="sm">Edit</Button>
+                {/if}
+              {/snippet}
+            </ListRow>
+          {/each}
+        </div>
+      </section>
+
+      <p class="max-w-prose text-[13px] leading-relaxed text-fg-2">{active.body}</p>
     </div>
   {/snippet}
 </SplitView>

--- a/packages/ui/src/lib/settings-primitives.test.ts
+++ b/packages/ui/src/lib/settings-primitives.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { createRawSnippet } from "svelte";
+import { render } from "svelte/server";
+import {
+  ListRow,
+  NavItem,
+  SectionHeading,
+  Pill,
+  EmptyState,
+  LoadingState,
+} from "@reddb-io/ui-kit";
+
+// Light SSR render assertions — the test env is `node`, so we render to a
+// string with `svelte/server` and assert structure rather than mounting a DOM.
+// Slots are supplied as raw snippets returning a marker element.
+const marker = (html: string) =>
+  createRawSnippet(() => ({ render: () => html }));
+
+describe("ListRow", () => {
+  it("renders title, description, and the mono hint", () => {
+    const { body } = render(ListRow, {
+      props: {
+        title: "Active target",
+        description: "The cluster red-ui is bound to.",
+        hint: "red://localhost",
+      },
+    });
+    expect(body).toContain("Active target");
+    expect(body).toContain("The cluster red-ui is bound to.");
+    expect(body).toContain("red://localhost");
+    // The hint rides the mono typeface.
+    expect(body).toContain("font-mono");
+  });
+
+  it("places the action slot and a full-width below slot", () => {
+    const { body } = render(ListRow, {
+      props: {
+        title: "Telemetry",
+        action: marker("<i data-testid='act'></i>"),
+        below: marker("<i data-testid='below'></i>"),
+      },
+    });
+    expect(body).toContain("data-testid='act'");
+    expect(body).toContain("data-testid='below'");
+  });
+
+  it("switches to the stacked layout in `wide` mode", () => {
+    const inline = render(ListRow, { props: { title: "x" } }).body;
+    const wide = render(ListRow, { props: { title: "x", wide: true } }).body;
+    // The default is an inline (items-center) row; wide stacks it as a column.
+    expect(inline).toContain("items-center");
+    expect(inline).not.toContain("data-wide");
+    expect(wide).toContain("flex-col");
+    expect(wide).toContain("data-wide");
+  });
+});
+
+describe("NavItem", () => {
+  it("marks the active item with aria-current=page", () => {
+    const active = render(NavItem, {
+      props: { label: "General", active: true },
+    }).body;
+    const idle = render(NavItem, {
+      props: { label: "General", active: false },
+    }).body;
+    expect(active).toContain('aria-current="page"');
+    expect(idle).not.toContain('aria-current="page"');
+    expect(active).toContain("General");
+  });
+
+  it("renders an anchor when given an href, a button otherwise", () => {
+    const link = render(NavItem, {
+      props: { label: "Go", href: "/settings" },
+    }).body;
+    const btn = render(NavItem, { props: { label: "Go" } }).body;
+    expect(link).toContain("<a");
+    expect(link).toContain('href="/settings"');
+    expect(btn).toContain("<button");
+  });
+
+  it("places the trailing slot", () => {
+    const { body } = render(NavItem, {
+      props: {
+        label: "Tables",
+        trailing: marker("<i data-testid='count'></i>"),
+      },
+    });
+    expect(body).toContain("data-testid='count'");
+  });
+});
+
+describe("SectionHeading", () => {
+  it("renders the title and places the icon + meta slots", () => {
+    const { body } = render(SectionHeading, {
+      props: {
+        title: "Connection",
+        icon: marker("<i data-testid='icon'></i>"),
+        meta: marker("<i data-testid='meta'></i>"),
+      },
+    });
+    expect(body).toContain("Connection");
+    expect(body).toContain("data-testid='icon'");
+    expect(body).toContain("data-testid='meta'");
+  });
+});
+
+describe("Pill", () => {
+  it("defaults to the muted tone and switches to accent", () => {
+    const muted = render(Pill, { props: { children: marker("3") } }).body;
+    const accent = render(Pill, {
+      props: { tone: "accent", children: marker("Live") },
+    }).body;
+    expect(muted).toContain("text-fg-2");
+    expect(accent).toContain("text-accent");
+    expect(accent).toContain("Live");
+  });
+});
+
+describe("EmptyState / LoadingState", () => {
+  it("EmptyState renders title, description, and the action slot", () => {
+    const { body } = render(EmptyState, {
+      props: {
+        title: "No connection",
+        description: "Run `red serve` to start.",
+        action: marker("<i data-testid='fix'></i>"),
+      },
+    });
+    expect(body).toContain("No connection");
+    expect(body).toContain("Run `red serve` to start.");
+    expect(body).toContain("data-testid='fix'");
+  });
+
+  it("LoadingState renders its label and respects reduced motion", () => {
+    const { body } = render(LoadingState, { props: { label: "Probing…" } });
+    expect(body).toContain("Probing…");
+    expect(body).toContain("motion-safe:animate-spin");
+  });
+});

--- a/packages/ui/src/lib/settings-sections.ts
+++ b/packages/ui/src/lib/settings-sections.ts
@@ -2,6 +2,20 @@
 // (no Svelte imports) so the section list and the active-section resolver are
 // trivially unit-testable. Icons are mapped in `SettingsView.svelte`, not here.
 
+/** A single settings row, rendered through the ui-kit `ListRow` primitive. */
+export interface SettingsRow {
+  /** Row label. */
+  title: string;
+  /** Secondary line under the title. */
+  description?: string;
+  /** Mono value/hint shown beside the title (a key, an id, the active value). */
+  hint?: string;
+  /** Status tone for the trailing pill — omit for no pill. */
+  status?: { label: string; tone: "muted" | "accent" };
+  /** Stack the action beneath the label (the ui-kit `ListRow` `wide` variant). */
+  wide?: boolean;
+}
+
 export interface SettingsSection {
   /** Stable identifier used as the active-section key (component state only). */
   id: string;
@@ -11,6 +25,8 @@ export interface SettingsSection {
   blurb: string;
   /** Static body copy — proof of an end-to-end mount, not live data. */
   body: string;
+  /** Static rows rendered with the ui-kit settings primitives. */
+  rows: SettingsRow[];
 }
 
 export const SETTINGS_SECTIONS: SettingsSection[] = [
@@ -19,18 +35,69 @@ export const SETTINGS_SECTIONS: SettingsSection[] = [
     label: "General",
     blurb: "Workspace defaults for this red-ui instance.",
     body: "General preferences live here. This minimal section proves the two-pane shell mounts end-to-end; richer controls land in follow-up issues.",
+    rows: [
+      {
+        title: "Default landing surface",
+        description: "Where ⌘K-less navigation drops you on launch.",
+        hint: "topology",
+        status: { label: "Default", tone: "muted" },
+      },
+      {
+        title: "Confirm destructive actions",
+        description: "Show a diff before drops, truncates, and bulk deletes.",
+        status: { label: "On", tone: "accent" },
+      },
+      {
+        title: "Telemetry",
+        description: "Anonymous usage signals. Off until you opt in.",
+        status: { label: "Off", tone: "muted" },
+      },
+    ],
   },
   {
     id: "connection",
     label: "Connection",
     blurb: "How red-ui reaches your reddb cluster.",
     body: "Connection settings will surface the active target, transport, and history. They stay permission-aware — controls appear only when the grant exists.",
+    rows: [
+      {
+        title: "Active target",
+        description: "The cluster red-ui is bound to this session.",
+        hint: "red://localhost:5050",
+        status: { label: "Live", tone: "accent" },
+      },
+      {
+        title: "Transport",
+        description: "Negotiated wire protocol for the active target.",
+        hint: "RedWire",
+      },
+      {
+        title: "Connection string",
+        description: "Edit the target URI. Reconnects on save.",
+        hint: "red://",
+        wide: true,
+      },
+    ],
   },
   {
     id: "appearance",
     label: "Appearance",
     blurb: "Theme and density.",
     body: "Appearance settings will expose theme and density. red-ui is dark-first; the topbar toggle and the ⌘K palette already switch themes.",
+    rows: [
+      {
+        title: "Theme",
+        description: "red-ui is dark-first. Light mode is not shipped yet.",
+        hint: "dark",
+        status: { label: "Locked", tone: "muted" },
+      },
+      {
+        title: "Density",
+        description: "Compact rows and mono numbers — power-user default.",
+        hint: "compact",
+        status: { label: "Default", tone: "muted" },
+      },
+    ],
   },
 ];
 


### PR DESCRIPTION
Salvage of AFK worker w5HJQ for #72 (PRD #69). Inner agent committed the work (19e9377) but never emitted `<promise>DONE</promise>` — same no-sentinel re-invocation loop (caught at iteration 2/20).

Independently verified in an isolated worktree:
- ✅ 392/392 tests (39 files; incl. settings-primitives.test.ts)
- ✅ svelte-check 0/0 on both @reddb-io/ui (4455 files) and @reddb-io/ui-kit (92 files)
- ✅ build green
- ✅ clean merge-tree against current main

6 primitives (ListRow/SectionHeading/Pill/NavItem/EmptyState/LoadingState) in @reddb-io/ui-kit + SettingsView composition + settings-sections data.

Closes #72.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783089790&installation_id=129708444&pr_number=78&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F78&signature=456e31f6674003235606d08aeffd0a51ec3576cfcc8f3c44ce500d46214e4079"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new UI components: EmptyState, ListRow, LoadingState, NavItem, Pill, and SectionHeading for building consistent interfaces
  * Redesigned Settings view with improved layout and navigation using new components
  * Enhanced list rows with responsive wide-mode layout support
  * Added status indicators and metadata display capabilities

* **Tests**
  * Added comprehensive test coverage for new UI components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->