### PR TITLE
feat(settings): data-driven section registry + config-key resolver (#73)

### DIFF
--- a/packages/ui/src/lib/SettingsView.svelte
+++ b/packages/ui/src/lib/SettingsView.svelte
@@ -1,31 +1,190 @@
 <script lang="ts">
-  // Settings view — mounts the reusable `SplitView` shell from the ui-kit and
-  // composes it from the kit's settings primitives (`NavItem`, `SectionHeading`,
-  // `Pill`, `ListRow`). The active section is component state (ADR-0001: the
-  // Mountable Root owns no routing here), the nav is local to this view (no
-  // global persistent sidebar), and the search affordance is wired to the
-  // existing ⌘K command palette rather than re-binding ⌘K itself.
+  // Settings view — a data-driven, permission-aware config inspector.
+  //
+  // The sections, their curated keys, and the label/description/enum copy all
+  // live in `settings-sections` as DATA. This view does three things: reads the
+  // *real* config from `connection.client` (no mocks/fixtures), flattens it to
+  // dotted keys, and renders each curated key through `resolveControl` as a
+  // `ListRow`. When the connection is unreachable it falls back to EmptyState.
+  //
+  // Permission-aware by default: a key whose source endpoint is denied or
+  // unsupported is not greyed out — its control is absent, replaced by a small
+  // chip naming the missing grant (with the server's reason in the tooltip).
   import {
     SplitView,
     NavItem,
     SectionHeading,
     Pill,
     ListRow,
-    Button,
     Kbd,
   } from '@reddb-io/ui-kit'
-  import { Settings2, Plug, Palette, Search, type Icon } from 'lucide-svelte'
+  import {
+    Settings2,
+    Database,
+    Network,
+    Plug,
+    Shield,
+    Search,
+    RefreshCw,
+    Lock,
+    Unplug,
+    type Icon,
+  } from 'lucide-svelte'
   import PageHeader from '$lib/PageHeader.svelte'
-  import { SETTINGS_SECTIONS, resolveSection } from '$lib/settings-sections'
+  import EmptyState from '$lib/EmptyState.svelte'
+  import { connection } from '$lib/connections.svelte'
+  import { activity } from '$lib/activity.svelte'
+  import {
+    SECTIONS,
+    resolveSection,
+    resolveControl,
+    sourceForKey,
+    flattenConfig,
+    type ControlDescriptor,
+    type SettingsSource,
+  } from '$lib/settings-sections'
 
   const icons: Record<string, typeof Icon> = {
-    general: Settings2,
-    connection: Plug,
-    appearance: Palette,
+    settings: Settings2,
+    database: Database,
+    network: Network,
+    plug: Plug,
+    shield: Shield,
   }
 
-  let activeId = $state(SETTINGS_SECTIONS[0].id)
+  // The grant a denied source is gated on — shown on the "absent" chip.
+  const GRANTS: Record<SettingsSource, string> = {
+    stats: 'stats:read',
+    cluster: 'cluster:status',
+    capabilities: 'capabilities',
+    session: 'auth:whoami',
+  }
+
+  let activeId = $state(SECTIONS[0].id)
   const active = $derived(resolveSection(activeId))
+
+  // Flattened live config and, per source, the reason its grant is absent
+  // (null ⇒ available). Both are rebuilt atomically on every refresh.
+  let values = $state<Record<string, unknown>>({})
+  let denied = $state<Record<SettingsSource, string | null>>({
+    stats: null,
+    cluster: null,
+    capabilities: null,
+    session: null,
+  })
+  let loading = $state(false)
+
+  const connected = $derived(connection.connected)
+  const activeUrl = $derived(connection.active.url)
+
+  async function refresh() {
+    const client = connection.client
+    if (!client || !connected) {
+      values = {}
+      return
+    }
+    loading = true
+    const next: Record<string, unknown> = {}
+    const nextDenied: Record<SettingsSource, string | null> = {
+      stats: null,
+      cluster: null,
+      capabilities: null,
+      session: null,
+    }
+
+    // /capabilities is the negotiation itself — always available from the store.
+    Object.assign(next, flattenConfig({ capabilities: connection.capabilities }))
+
+    try {
+      const stats = await activity.track('settings · stats', () => client.stats())
+      Object.assign(next, flattenConfig(stats as unknown as Record<string, unknown>))
+    } catch (e) {
+      nextDenied.stats = (e as Error).message
+    }
+
+    // Cluster topology is capability-gated: if the server can't honour
+    // /cluster/status, those keys are absent + explained, never faked.
+    if (!connection.capabilities.clusterStatus) {
+      nextDenied.cluster = 'Server does not expose /cluster/status.'
+    } else {
+      try {
+        const cluster = await activity.track('settings · cluster', () =>
+          client.clusterStatus(),
+        )
+        Object.assign(next, flattenConfig(cluster as unknown as Record<string, unknown>))
+      } catch (e) {
+        nextDenied.cluster = (e as Error).message
+      }
+    }
+
+    try {
+      const session = await activity.track('settings · whoami', () => client.whoami())
+      Object.assign(
+        next,
+        flattenConfig({ session: session as unknown as Record<string, unknown> }),
+      )
+    } catch (e) {
+      nextDenied.session = (e as Error).message
+    }
+
+    values = next
+    denied = nextDenied
+    loading = false
+  }
+
+  $effect(() => {
+    void activeUrl
+    void connected
+    refresh()
+  })
+
+  type RenderRow =
+    | { type: 'value'; key: string; label: string; control: ControlDescriptor; value: unknown }
+    | { type: 'denied'; key: string; label: string; reason: string; grant: string }
+
+  // Resolve the active section's curated keys to render rows. A key whose
+  // source is denied becomes a "denied" row (absent control + explanation); a
+  // key with a live value becomes a "value" row; a key the server simply does
+  // not report is dropped (graceful degradation — no empty placeholder).
+  const rows = $derived.by<RenderRow[]>(() => {
+    const out: RenderRow[] = []
+    for (const key of active.keys) {
+      const src = sourceForKey(key)
+      const reason = denied[src]
+      const label = resolveControl(key).label
+      if (reason) {
+        out.push({ type: 'denied', key, label, reason, grant: GRANTS[src] })
+      } else if (key in values) {
+        out.push({
+          type: 'value',
+          key,
+          label,
+          control: resolveControl(key, values[key]),
+          value: values[key],
+        })
+      }
+    }
+    return out
+  })
+
+  function formatBytes(n: number): string {
+    if (!Number.isFinite(n)) return String(n)
+    const units = ['B', 'KB', 'MB', 'GB', 'TB']
+    let v = n
+    let i = 0
+    while (v >= 1024 && i < units.length - 1) {
+      v /= 1024
+      i++
+    }
+    return `${i === 0 ? v : v.toFixed(1)} ${units[i]}`
+  }
+
+  function formatValue(control: ControlDescriptor, value: unknown): string {
+    if (control.kind === 'number' && control.key.endsWith('_bytes')) {
+      return formatBytes(Number(value))
+    }
+    return String(value)
+  }
 
   // Reuse the global command palette as the search surface — the same ⌘K idiom
   // the topbar uses, so Esc-to-close comes for free from the palette overlay.
@@ -36,74 +195,128 @@
   }
 </script>
 
-<SplitView searchShortcut={null}>
-  {#snippet search()}
-    <button
-      type="button"
-      onclick={openPalette}
-      class="flex h-7 w-full items-center gap-2 rounded-md border border-line-2 bg-bg-2 px-2.5 text-xs text-fg-2 transition-colors hover:border-line-3 hover:text-fg-1"
-    >
-      <Search class="size-3.5 text-fg-3" />
-      <span class="flex-1 text-left">Search settings</span>
-      <span class="inline-flex gap-0.5"><Kbd>⌘</Kbd><Kbd>K</Kbd></span>
-    </button>
-  {/snippet}
+{#if !connected}
+  <div class="h-full overflow-auto bg-bg-0 p-6">
+    <PageHeader
+      eyebrow="Settings"
+      title="Settings"
+      subtitle="Live configuration for the active reddb connection."
+    />
+    <EmptyState
+      icon={Unplug}
+      title="No active connection"
+      message="Connect to a reddb instance to inspect its live configuration."
+      hint="red serve"
+    />
+  </div>
+{:else}
+  <SplitView searchShortcut={null}>
+    {#snippet search()}
+      <button
+        type="button"
+        onclick={openPalette}
+        class="flex h-7 w-full items-center gap-2 rounded-md border border-line-2 bg-bg-2 px-2.5 text-xs text-fg-2 transition-colors hover:border-line-3 hover:text-fg-1"
+      >
+        <Search class="size-3.5 text-fg-3" />
+        <span class="flex-1 text-left">Search settings</span>
+        <span class="inline-flex gap-0.5"><Kbd>⌘</Kbd><Kbd>K</Kbd></span>
+      </button>
+    {/snippet}
 
-  {#snippet nav()}
-    <nav class="grid gap-0.5 p-2">
-      {#each SETTINGS_SECTIONS as section (section.id)}
-        {@const Icon = icons[section.id] ?? Settings2}
-        <NavItem
-          label={section.label}
-          active={section.id === active.id}
-          onclick={() => (activeId = section.id)}
-        >
-          {#snippet icon()}<Icon class="size-3.5" />{/snippet}
-        </NavItem>
-      {/each}
-    </nav>
-  {/snippet}
+    {#snippet nav()}
+      <nav class="grid gap-0.5 p-2">
+        {#each SECTIONS as section (section.id)}
+          {@const SectionIcon = icons[section.icon] ?? Settings2}
+          <NavItem
+            label={section.label}
+            active={section.id === active.id}
+            onclick={() => (activeId = section.id)}
+          >
+            {#snippet icon()}<SectionIcon class="size-3.5" />{/snippet}
+          </NavItem>
+        {/each}
+      </nav>
+    {/snippet}
 
-  {#snippet footer()}
-    <div class="px-3 py-2.5 text-[11px] text-fg-3">
-      Settings are local to this view.
-    </div>
-  {/snippet}
+    {#snippet footer()}
+      <div class="px-3 py-2.5 text-[11px] text-fg-3">
+        Live from <span class="font-mono text-fg-2">{activeUrl}</span>.
+      </div>
+    {/snippet}
 
-  {#snippet content()}
-    {@const Icon = icons[active.id] ?? Settings2}
-    <div class="p-6">
-      <PageHeader eyebrow="Settings" title={active.label} subtitle={active.blurb} />
+    {#snippet content()}
+      {@const SectionIcon = icons[active.icon] ?? Settings2}
+      <div class="p-6">
+        <PageHeader eyebrow="Settings" title={active.label} subtitle={active.blurb}>
+          {#snippet actions()}
+            <button
+              type="button"
+              onclick={refresh}
+              disabled={loading}
+              class="inline-flex h-7 items-center gap-1.5 rounded-md border border-line-2 bg-bg-2 px-2.5 text-[11px] font-mono text-fg-1 hover:border-line-3 hover:text-fg-0 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <RefreshCw class={loading ? 'size-3.5 animate-spin' : 'size-3.5'} />
+              refresh
+            </button>
+          {/snippet}
+        </PageHeader>
 
-      <section class="mb-6">
-        <SectionHeading title={active.label} class="mb-2">
-          {#snippet icon()}<Icon class="size-3.5" />{/snippet}
-          {#snippet meta()}<Pill>{active.rows.length}</Pill>{/snippet}
-        </SectionHeading>
+        <section class="mb-6">
+          <SectionHeading title={active.label} class="mb-2">
+            {#snippet icon()}<SectionIcon class="size-3.5" />{/snippet}
+            {#snippet meta()}<Pill>{rows.length}</Pill>{/snippet}
+          </SectionHeading>
 
-        <div class="divide-y divide-line-1 overflow-hidden rounded-lg border border-line-1 bg-bg-1">
-          {#each active.rows as row (row.title)}
-            <ListRow title={row.title} description={row.description} hint={row.hint} wide={row.wide}>
-              {#snippet action()}
-                {#if row.wide}
-                  <input
-                    type="text"
-                    value={row.hint ?? ''}
-                    spellcheck="false"
-                    class="h-7 w-full rounded-md border border-line-2 bg-bg-2 px-2.5 font-mono text-[12px] text-fg-1 focus-visible:border-line-3 focus-visible:outline-none"
-                  />
-                {:else if row.status}
-                  <Pill tone={row.status.tone}>{row.status.label}</Pill>
+          {#if rows.length === 0}
+            <div
+              class="rounded-lg border border-dashed border-line-1 bg-bg-1 px-3 py-6 text-center text-[12px] text-fg-3"
+            >
+              This server reports nothing for these keys.
+            </div>
+          {:else}
+            <div
+              class="divide-y divide-line-1 overflow-hidden rounded-lg border border-line-1 bg-bg-1"
+            >
+              {#each rows as row (row.key)}
+                {#if row.type === 'denied'}
+                  <ListRow title={row.label} hint={row.key}>
+                    {#snippet action()}
+                      <span
+                        class="inline-flex items-center gap-1.5 rounded-md border border-line-2 bg-bg-2 px-2 py-1 text-[11px] font-mono text-fg-3"
+                        title={row.reason}
+                      >
+                        <Lock class="size-3" />
+                        requires {row.grant}
+                      </span>
+                    {/snippet}
+                  </ListRow>
                 {:else}
-                  <Button size="sm">Edit</Button>
+                  <ListRow
+                    title={row.label}
+                    description={row.control.description}
+                    hint={row.key}
+                  >
+                    {#snippet action()}
+                      {#if row.control.kind === 'boolean'}
+                        <Pill tone={row.value ? 'accent' : 'muted'}>{row.value ? 'on' : 'off'}</Pill>
+                      {:else if row.control.kind === 'enum'}
+                        <span
+                          class="font-mono text-[12px] text-accent"
+                          title={`Options: ${row.control.options?.join(', ')}`}
+                        >{row.value}</span>
+                      {:else}
+                        <span class="font-mono text-[12px] text-fg-1"
+                          >{formatValue(row.control, row.value)}</span
+                        >
+                      {/if}
+                    {/snippet}
+                  </ListRow>
                 {/if}
-              {/snippet}
-            </ListRow>
-          {/each}
-        </div>
-      </section>
-
-      <p class="max-w-prose text-[13px] leading-relaxed text-fg-2">{active.body}</p>
-    </div>
-  {/snippet}
-</SplitView>
+              {/each}
+            </div>
+          {/if}
+        </section>
+      </div>
+    {/snippet}
+  </SplitView>
+{/if}

--- a/packages/ui/src/lib/settings-sections.test.ts
+++ b/packages/ui/src/lib/settings-sections.test.ts
@@ -1,24 +1,131 @@
 import { describe, expect, it } from "vitest";
-import { SETTINGS_SECTIONS, resolveSection } from "./settings-sections";
+import {
+  SECTIONS,
+  ENUM_OPTIONS,
+  flattenConfig,
+  humanizeKey,
+  resolveControl,
+  resolveSection,
+  sourceForKey,
+} from "./settings-sections";
 
-describe("settings sections", () => {
-  it("ships at least one static section with stable ids", () => {
-    expect(SETTINGS_SECTIONS.length).toBeGreaterThan(0);
-    const ids = SETTINGS_SECTIONS.map((s) => s.id);
+describe("settings sections registry", () => {
+  it("ships sections with stable, unique ids and non-empty curated keys", () => {
+    expect(SECTIONS.length).toBeGreaterThan(0);
+    const ids = SECTIONS.map((s) => s.id);
     expect(new Set(ids).size).toBe(ids.length);
-    for (const section of SETTINGS_SECTIONS) {
+    for (const section of SECTIONS) {
       expect(section.label).not.toBe("");
-      expect(section.body).not.toBe("");
+      expect(section.blurb).not.toBe("");
+      expect(section.icon).not.toBe("");
+      expect(section.keys.length).toBeGreaterThan(0);
     }
   });
 
   it("resolves a known section by id", () => {
-    const target = SETTINGS_SECTIONS[SETTINGS_SECTIONS.length - 1];
+    const target = SECTIONS[SECTIONS.length - 1];
     expect(resolveSection(target.id)).toBe(target);
   });
 
   it("falls back to the first section for unknown or null ids", () => {
-    expect(resolveSection("does-not-exist")).toBe(SETTINGS_SECTIONS[0]);
-    expect(resolveSection(null)).toBe(SETTINGS_SECTIONS[0]);
+    expect(resolveSection("does-not-exist")).toBe(SECTIONS[0]);
+    expect(resolveSection(null)).toBe(SECTIONS[0]);
+  });
+});
+
+describe("resolveControl", () => {
+  it("resolves the curated label and description for a known key", () => {
+    const c = resolveControl("deployment.mode", "embedded");
+    expect(c.label).toBe("Deployment mode");
+    expect(c.description).toBe("How this reddb instance is running.");
+  });
+
+  it("resolves enum kind + options from ENUM_OPTIONS regardless of value", () => {
+    const c = resolveControl("deployment.mode", "docker");
+    expect(c.kind).toBe("enum");
+    expect(c.options).toEqual(ENUM_OPTIONS["deployment.mode"]);
+  });
+
+  it("infers boolean kind from a boolean value", () => {
+    expect(resolveControl("read_only", true).kind).toBe("boolean");
+    expect(resolveControl("capabilities.vcs", false).kind).toBe("boolean");
+  });
+
+  it("infers number kind from a numeric value", () => {
+    expect(resolveControl("store.collection_count", 12).kind).toBe("number");
+  });
+
+  it("defaults to text kind for strings", () => {
+    expect(resolveControl("system.os", "linux").kind).toBe("text");
+  });
+
+  it("falls back gracefully for an unknown key with no value", () => {
+    const c = resolveControl("store.total_memory_bytes");
+    // No curated label exists for this key → humanized last segment.
+    expect(c.label).toBe("Memory in use"); // (curated) — see next case for raw fallback
+    expect(c.kind).toBe("text");
+    expect(c.options).toBeUndefined();
+  });
+
+  it("humanizes an entirely uncurated key and omits description", () => {
+    const c = resolveControl("wal.oldest_lsn", 42);
+    expect(c.label).toBe("Oldest lsn");
+    expect(c.description).toBeUndefined();
+    expect(c.kind).toBe("number");
+  });
+});
+
+describe("humanizeKey", () => {
+  it("uses the last dotted segment, de-snakes, and sentence-cases", () => {
+    expect(humanizeKey("store.total_memory_bytes")).toBe("Total memory bytes");
+    expect(humanizeKey("read_only")).toBe("Read only");
+    expect(humanizeKey("system.cpu-cores")).toBe("Cpu cores");
+  });
+});
+
+describe("sourceForKey", () => {
+  it("routes keys to their live source", () => {
+    expect(sourceForKey("capabilities.vcs")).toBe("capabilities");
+    expect(sourceForKey("session.role")).toBe("session");
+    expect(sourceForKey("deployment.mode")).toBe("cluster");
+    expect(sourceForKey("replication.lag_ms")).toBe("cluster");
+    expect(sourceForKey("store.collection_count")).toBe("stats");
+    expect(sourceForKey("read_only")).toBe("stats");
+  });
+});
+
+describe("flattenConfig", () => {
+  it("flattens nested objects into dotted leaf paths", () => {
+    const flat = flattenConfig({
+      store: { collection_count: 3, total_memory_bytes: 1024 },
+      read_only: true,
+    });
+    expect(flat["store.collection_count"]).toBe(3);
+    expect(flat["store.total_memory_bytes"]).toBe(1024);
+    expect(flat["read_only"]).toBe(true);
+  });
+
+  it("keeps arrays and primitives as leaves and skips null/undefined branches", () => {
+    const flat = flattenConfig({
+      tags: ["a", "b"],
+      deployment: undefined,
+      replication: null,
+      session: { role: "admin" },
+    });
+    expect(flat["tags"]).toEqual(["a", "b"]);
+    expect("deployment" in flat).toBe(false);
+    expect("replication" in flat).toBe(false);
+    expect(flat["session.role"]).toBe("admin");
+  });
+
+  it("round-trips a stats-shaped snapshot into curated keys", () => {
+    const flat = flattenConfig({
+      store: { collection_count: 7, total_entities: 99, cross_ref_count: 0 },
+      system: { os: "linux", arch: "x86_64", cpu_cores: 8 },
+    });
+    for (const key of SECTIONS.find((s) => s.id === "storage")!.keys) {
+      if (key === "store.total_memory_bytes") continue; // omitted by this server
+      expect(flat[key]).toBeDefined();
+    }
   });
 });

--- a/packages/ui/src/lib/settings-sections.ts
+++ b/packages/ui/src/lib/settings-sections.ts
@@ -1,19 +1,36 @@
-// Static settings sections for the minimal settings view. Kept framework-free
-// (no Svelte imports) so the section list and the active-section resolver are
-// trivially unit-testable. Icons are mapped in `SettingsView.svelte`, not here.
+// Data-driven settings registry + a pure config-key resolver.
+//
+// Settings are defined as DATA, not hand-built rows: `SECTIONS` lists the
+// curated config keys per section, and three override maps (`LABELS`,
+// `DESCRIPTIONS`, `ENUM_OPTIONS`) keyed by config path supply the human copy.
+// `resolveControl(key, value)` maps a single reddb config/connection key to a
+// rendered control descriptor (human label, description, input kind, enum
+// options), degrading gracefully for keys nobody curated. Adding a curated key
+// is a one-line edit to a section's `keys` array.
+//
+// Kept framework-free (no Svelte imports) so the registry and the resolver are
+// trivially unit-testable. Icons are mapped to components in `SettingsView`,
+// not here — a section carries only an icon *name*. Mirrors the registry idiom
+// in `renderers/registry`: a tiny pure surface over curated data.
 
-/** A single settings row, rendered through the ui-kit `ListRow` primitive. */
-export interface SettingsRow {
-  /** Row label. */
-  title: string;
-  /** Secondary line under the title. */
+/** The input control a config value is rendered through. */
+export type ControlKind = "text" | "number" | "boolean" | "enum";
+
+/** Where a config key is sourced from — gates permission-aware rendering. */
+export type SettingsSource = "stats" | "cluster" | "capabilities" | "session";
+
+/** A resolved control for one config key. */
+export interface ControlDescriptor {
+  /** The config path this descriptor was resolved from. */
+  key: string;
+  /** Human label — a curated override or a humanized key. */
+  label: string;
+  /** Optional one-line explanation. */
   description?: string;
-  /** Mono value/hint shown beside the title (a key, an id, the active value). */
-  hint?: string;
-  /** Status tone for the trailing pill — omit for no pill. */
-  status?: { label: string; tone: "muted" | "accent" };
-  /** Stack the action beneath the label (the ui-kit `ListRow` `wide` variant). */
-  wide?: boolean;
+  /** Input kind inferred from the curated enum map or the value's type. */
+  kind: ControlKind;
+  /** Allowed values when `kind === "enum"`. */
+  options?: readonly string[];
 }
 
 export interface SettingsSection {
@@ -23,83 +40,204 @@ export interface SettingsSection {
   label: string;
   /** One-line description shown under the section title. */
   blurb: string;
-  /** Static body copy — proof of an end-to-end mount, not live data. */
-  body: string;
-  /** Static rows rendered with the ui-kit settings primitives. */
-  rows: SettingsRow[];
+  /** Icon name resolved to a lucide component in `SettingsView`. */
+  icon: string;
+  /** Curated config keys, rendered top-to-bottom. One-line edit to extend. */
+  keys: string[];
 }
 
-export const SETTINGS_SECTIONS: SettingsSection[] = [
+/**
+ * The curated sections. Each `keys` entry is a flattened reddb config path
+ * (see `flattenConfig`) sourced from `/stats`, `/cluster/status`,
+ * `/capabilities`, or the session (`whoami`). Order is the render order.
+ */
+export const SECTIONS: SettingsSection[] = [
   {
-    id: "general",
-    label: "General",
-    blurb: "Workspace defaults for this red-ui instance.",
-    body: "General preferences live here. This minimal section proves the two-pane shell mounts end-to-end; richer controls land in follow-up issues.",
-    rows: [
-      {
-        title: "Default landing surface",
-        description: "Where ⌘K-less navigation drops you on launch.",
-        hint: "topology",
-        status: { label: "Default", tone: "muted" },
-      },
-      {
-        title: "Confirm destructive actions",
-        description: "Show a diff before drops, truncates, and bulk deletes.",
-        status: { label: "On", tone: "accent" },
-      },
-      {
-        title: "Telemetry",
-        description: "Anonymous usage signals. Off until you opt in.",
-        status: { label: "Off", tone: "muted" },
-      },
+    id: "overview",
+    label: "Overview",
+    blurb: "What this reddb instance is and where it runs.",
+    icon: "settings",
+    keys: [
+      "deployment.mode",
+      "read_only",
+      "system.os",
+      "system.arch",
+      "system.hostname",
+      "system.cpu_cores",
     ],
   },
   {
-    id: "connection",
-    label: "Connection",
-    blurb: "How red-ui reaches your reddb cluster.",
-    body: "Connection settings will surface the active target, transport, and history. They stay permission-aware — controls appear only when the grant exists.",
-    rows: [
-      {
-        title: "Active target",
-        description: "The cluster red-ui is bound to this session.",
-        hint: "red://localhost:5050",
-        status: { label: "Live", tone: "accent" },
-      },
-      {
-        title: "Transport",
-        description: "Negotiated wire protocol for the active target.",
-        hint: "RedWire",
-      },
-      {
-        title: "Connection string",
-        description: "Edit the target URI. Reconnects on save.",
-        hint: "red://",
-        wide: true,
-      },
+    id: "storage",
+    label: "Storage",
+    blurb: "Live store footprint for the active connection.",
+    icon: "database",
+    keys: [
+      "store.collection_count",
+      "store.total_entities",
+      "store.cross_ref_count",
+      "store.total_memory_bytes",
     ],
   },
   {
-    id: "appearance",
-    label: "Appearance",
-    blurb: "Theme and density.",
-    body: "Appearance settings will expose theme and density. red-ui is dark-first; the topbar toggle and the ⌘K palette already switch themes.",
-    rows: [
-      {
-        title: "Theme",
-        description: "red-ui is dark-first. Light mode is not shipped yet.",
-        hint: "dark",
-        status: { label: "Locked", tone: "muted" },
-      },
-      {
-        title: "Density",
-        description: "Compact rows and mono numbers — power-user default.",
-        hint: "compact",
-        status: { label: "Default", tone: "muted" },
-      },
+    id: "cluster",
+    label: "Cluster",
+    blurb: "Deployment and replication topology.",
+    icon: "network",
+    keys: [
+      "deployment.mode",
+      "deployment.file_path",
+      "replication.replica_count",
+      "replication.lag_ms",
     ],
+  },
+  {
+    id: "capabilities",
+    label: "Capabilities",
+    blurb: "Endpoints negotiated for this server version.",
+    icon: "plug",
+    keys: [
+      "capabilities.vcs",
+      "capabilities.clusterStatus",
+      "capabilities.collectionMetadata",
+      "capabilities.cdcStream",
+    ],
+  },
+  {
+    id: "session",
+    label: "Session",
+    blurb: "Who red-ui is authenticated as on this connection.",
+    icon: "shield",
+    keys: ["session.username", "session.role", "session.authenticated"],
   },
 ];
+
+/** Curated label overrides, keyed by config path. */
+export const LABELS: Record<string, string> = {
+  "deployment.mode": "Deployment mode",
+  "deployment.file_path": "Backing file",
+  read_only: "Read-only",
+  "system.os": "Operating system",
+  "system.arch": "Architecture",
+  "system.hostname": "Hostname",
+  "system.cpu_cores": "CPU cores",
+  "store.collection_count": "Collections",
+  "store.total_entities": "Entities",
+  "store.cross_ref_count": "Cross-references",
+  "store.total_memory_bytes": "Memory in use",
+  "replication.replica_count": "Replicas",
+  "replication.lag_ms": "Replication lag",
+  "capabilities.vcs": "Version control",
+  "capabilities.clusterStatus": "Cluster status",
+  "capabilities.collectionMetadata": "Collection metadata",
+  "capabilities.cdcStream": "Change stream",
+  "session.username": "Username",
+  "session.role": "Role",
+  "session.authenticated": "Authenticated",
+};
+
+/** Curated descriptions, keyed by config path. */
+export const DESCRIPTIONS: Record<string, string> = {
+  "deployment.mode": "How this reddb instance is running.",
+  "deployment.file_path": "On-disk store path for an embedded or local server.",
+  read_only: "Whether the store rejects writes (a lock or a replica role).",
+  "store.total_memory_bytes": "Resident memory the store currently holds.",
+  "replication.lag_ms": "How far this replica trails the primary, in ms.",
+  "capabilities.vcs": "Commit and diff endpoints — gated when unsupported.",
+  "capabilities.cdcStream": "Server-sent change stream over /changes/stream.",
+  "session.role": "The role granted to this principal on the active target.",
+};
+
+/** Curated enum options, keyed by config path. Presence ⇒ `kind: "enum"`. */
+export const ENUM_OPTIONS: Record<string, readonly string[]> = {
+  "deployment.mode": ["embedded", "server", "docker", "replicated"],
+};
+
+/**
+ * Turn a config path into a human label when nobody curated one:
+ * `store.total_memory_bytes` → "Total memory bytes". Uses the last path
+ * segment, swaps `_`/`-` for spaces, and sentence-cases the result.
+ */
+export function humanizeKey(key: string): string {
+  const last = key.split(".").pop() ?? key;
+  const words = last.replace(/[_-]+/g, " ").trim();
+  if (!words) return key;
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+/**
+ * Resolve a config key (and its live value) to a rendered control descriptor.
+ *
+ * Resolution order, each degrading gracefully:
+ *  - label: `LABELS[key]` → `humanizeKey(key)`
+ *  - description: `DESCRIPTIONS[key]` → omitted
+ *  - kind: `ENUM_OPTIONS[key]` ⇒ `"enum"`; else inferred from the value's
+ *    runtime type (boolean / number) → `"text"` for everything else, including
+ *    `undefined`. So an unknown key with no value still yields a valid `"text"`
+ *    descriptor rather than throwing.
+ */
+export function resolveControl(
+  key: string,
+  value?: unknown
+): ControlDescriptor {
+  const options = ENUM_OPTIONS[key];
+  const kind: ControlKind = options
+    ? "enum"
+    : typeof value === "boolean"
+      ? "boolean"
+      : typeof value === "number"
+        ? "number"
+        : "text";
+  const descriptor: ControlDescriptor = {
+    key,
+    label: LABELS[key] ?? humanizeKey(key),
+    kind,
+  };
+  const description = DESCRIPTIONS[key];
+  if (description) descriptor.description = description;
+  if (options) descriptor.options = options;
+  return descriptor;
+}
+
+/** Which live source a config key is read from — drives permission-awareness. */
+export function sourceForKey(key: string): SettingsSource {
+  if (key.startsWith("capabilities.")) return "capabilities";
+  if (key.startsWith("session.")) return "session";
+  if (
+    key.startsWith("deployment.") ||
+    key.startsWith("storage.") ||
+    key.startsWith("wal.") ||
+    key.startsWith("throughput.") ||
+    key.startsWith("replication.")
+  ) {
+    return "cluster";
+  }
+  return "stats";
+}
+
+/**
+ * Flatten a nested config snapshot into dotted leaf paths. Nested plain objects
+ * recurse (`{ store: { collection_count: 3 } }` → `"store.collection_count"`);
+ * arrays and primitives are kept as leaf values. `undefined`/`null` branches
+ * are skipped so a server that omits a sub-tree simply yields no keys for it.
+ */
+export function flattenConfig(
+  input: Record<string, unknown>
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const walk = (obj: Record<string, unknown>, prefix: string) => {
+    for (const [k, v] of Object.entries(obj)) {
+      const key = prefix ? `${prefix}.${k}` : k;
+      if (v === undefined || v === null) continue;
+      if (typeof v === "object" && !Array.isArray(v)) {
+        walk(v as Record<string, unknown>, key);
+      } else {
+        out[key] = v;
+      }
+    }
+  };
+  walk(input, "");
+  return out;
+}
 
 /**
  * Resolve a section by id, falling back to the first section when the id is
@@ -107,5 +245,5 @@ export const SETTINGS_SECTIONS: SettingsSection[] = [
  * component state, so this never touches the URL.
  */
 export function resolveSection(id: string | null): SettingsSection {
-  return SETTINGS_SECTIONS.find((s) => s.id === id) ?? SETTINGS_SECTIONS[0];
+  return SECTIONS.find((s) => s.id === id) ?? SECTIONS[0];
 }


### PR DESCRIPTION
Salvage of #73 (PRD #69). The `-r` directive worked — agent emitted DONE on iteration 1 after a single green verification (no loop). But the orchestrator's post-DONE feedback gate ran `pnpm -r test/build` in a fresh `.red/tmp/feedback/` checkout **without pnpm install**, so tsc/vite/svelte-kit were 'not found' → false `blocked:validation`.

Independently verified (isolated worktree, WITH install): ✅ 404/404 tests, ✅ svelte-check 0 errors, ✅ build green, ✅ clean merge-tree.

Closes #73.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783094556&installation_id=129708444&pr_number=80&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F80&signature=1b6ae29ef2b4901e03071e2d07fa1b408e668f73680f31c9a70e5a5fd45f0c37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings now display permission status—accessible settings are shown normally, while inaccessible settings clearly indicate required permissions.
  * Added refresh button to reload configuration from the server.
  * Improved disconnected state messaging.
  * Enhanced control rendering: toggles for booleans, dropdowns for options, human-readable byte value formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->