### PR TITLE
feat(appearance): skin-as-data registry + color-mix surface ramp + preview cards (#75)

### DIFF
--- a/packages/ui/src/lib/Appearance.svelte
+++ b/packages/ui/src/lib/Appearance.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+  // Appearance section (#75). Renders each registered skin as a live preview
+  // card — a mini-mockup painted with that skin's *own* derived tokens — and
+  // applies the skin on click. Selection persists across reloads via the skin
+  // store. Dark-only: there is no light/system switch here.
+  import { Check } from 'lucide-svelte'
+  import PageHeader from '$lib/PageHeader.svelte'
+  import { SKINS, skinToCssVars, type Skin } from '$lib/skins/skins'
+  import { skins } from '$lib/skins/skins.svelte'
+
+  // Each preview is painted with the skin's own custom properties so the card
+  // is a faithful, self-contained swatch of the palette — `color-mix` ramps
+  // resolve in the browser exactly as they would once applied.
+  function previewStyle(skin: Skin): string {
+    return Object.entries(skinToCssVars(skin))
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('; ')
+  }
+
+  const selected = $derived(skins.current.name)
+</script>
+
+<div class="h-full overflow-auto bg-bg-0 p-6 text-fg-1">
+  <PageHeader
+    eyebrow="Settings"
+    title="Appearance"
+    subtitle="Pick a skin. Surfaces are derived from a single seed; the accent stays surgical. Dark only."
+  />
+
+  <div class="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-4 max-w-4xl">
+    {#each SKINS as skin (skin.name)}
+      {@const active = skin.name === selected}
+      <button
+        type="button"
+        onclick={() => skins.select(skin.name)}
+        aria-pressed={active}
+        class="group text-left rounded-lg border bg-bg-1 p-3 transition-colors {active
+          ? 'border-accent'
+          : 'border-line-2 hover:border-line-3'}"
+      >
+        <!-- Mini-mockup, painted in the skin's own tokens -->
+        <div
+          class="rounded-md overflow-hidden border border-line-1"
+          style={previewStyle(skin)}
+        >
+          <div class="bg-bg-0 p-3">
+            <!-- faux topbar -->
+            <div class="flex items-center gap-1.5 mb-2.5">
+              <span class="size-2 rounded-full" style="background: var(--color-accent)"></span>
+              <span class="h-1.5 w-12 rounded-full bg-bg-3"></span>
+              <span class="ml-auto h-1.5 w-6 rounded-full bg-bg-2"></span>
+            </div>
+            <!-- faux card with strips -->
+            <div class="rounded-md bg-bg-1 border border-line-2 p-2.5">
+              <div class="h-1.5 w-2/3 rounded-full bg-fg-2 mb-2"></div>
+              <div class="h-1.5 w-full rounded-full bg-bg-3 mb-1.5"></div>
+              <div class="h-1.5 w-4/5 rounded-full bg-bg-3 mb-2.5"></div>
+              <div class="flex items-center gap-1.5">
+                <span
+                  class="h-4 w-12 rounded"
+                  style="background: var(--color-accent)"
+                ></span>
+                <span class="h-4 w-8 rounded bg-bg-2 border border-line-2"></span>
+              </div>
+            </div>
+          </div>
+          <!-- surface ramp strip: bg-0..bg-3 -->
+          <div class="flex h-2.5">
+            <span class="flex-1 bg-bg-0"></span>
+            <span class="flex-1 bg-bg-1"></span>
+            <span class="flex-1 bg-bg-2"></span>
+            <span class="flex-1 bg-bg-3"></span>
+          </div>
+        </div>
+
+        <div class="flex items-center gap-2 mt-3">
+          <span class="type-h2 text-fg-0">{skin.label}</span>
+          {#if active}
+            <span
+              class="inline-flex items-center gap-1 rounded-full bg-accent-soft px-2 py-0.5 text-[10px] font-mono uppercase tracking-wider text-accent"
+            >
+              <Check class="size-3" /> Active
+            </span>
+          {/if}
+        </div>
+        <p class="type-caption m-0 mt-1">{skin.description}</p>
+      </button>
+    {/each}
+  </div>
+</div>

--- a/packages/ui/src/lib/CommandPalette.svelte
+++ b/packages/ui/src/lib/CommandPalette.svelte
@@ -32,6 +32,7 @@
     { id: 'topology', group: 'navigate', label: 'Open cluster', hint: '/cluster', run: () => navigate({ view: 'cluster' }) },
     { id: 'security', group: 'navigate', label: 'Open security', hint: '/security', run: () => navigate({ view: 'security' }) },
     { id: 'settings', group: 'navigate', label: 'Open settings', hint: '/settings', run: () => navigate({ view: 'settings' }) },
+    { id: 'appearance', group: 'navigate', label: 'Open appearance', hint: '/appearance', run: () => navigate({ view: 'appearance' }) },
 
     { id: 'new-query', group: 'data', label: 'New query', shortcut: '⌘T', run: () => { fire('red:new-query'); close() } },
 

--- a/packages/ui/src/lib/Workspace.svelte
+++ b/packages/ui/src/lib/Workspace.svelte
@@ -16,9 +16,11 @@
   import ClusterView from './ClusterView.svelte'
   import SecurityView from './SecurityView.svelte'
   import SettingsView from './SettingsView.svelte'
+  import Appearance from './Appearance.svelte'
   import { connection, setConnectionProvider } from './connections.svelte'
   import { runQueryPreferStream, type ConnectionProvider } from '#reddb'
   import { theme, type Theme } from './theme.svelte'
+  import { skins } from './skins/skins.svelte'
   import { secureStore } from './secureStore.svelte'
   import { pendingChanges, buildUpdateSql, type CommitOutcome } from './pending-changes.svelte'
   import { queryTabs } from './query-tabs.svelte'
@@ -64,7 +66,7 @@
 
   function navigateToBootRoute(route: string) {
     const legacyView = route as View
-    if (legacyView === 'query' || legacyView === 'collections' || legacyView === 'cluster' || legacyView === 'security' || legacyView === 'settings') {
+    if (legacyView === 'query' || legacyView === 'collections' || legacyView === 'cluster' || legacyView === 'security' || legacyView === 'settings' || legacyView === 'appearance') {
       router.go({ view: legacyView }, undefined, true)
       return
     }
@@ -133,6 +135,12 @@
   // start from the persisted value rather than the in-memory default.
   // svelte-ignore state_referenced_locally
   theme.init({ target: themeTarget ?? null, persist: persistTheme, initial: initialTheme })
+
+  // Skin-as-data (#75): apply the persisted skin's seed-derived custom
+  // properties over the active theme. Scoped to the same target the theme
+  // uses, so an embedded host's shadow root is skinned, not the document.
+  // svelte-ignore state_referenced_locally
+  skins.init(themeTarget ?? null)
 
   // Hard lock gate: while the secure store is locked, no automatic network
   // traffic should fire — probing the configured URL would leak its existence
@@ -238,6 +246,8 @@
         <SecurityView />
       {:else if router.view === 'settings'}
         <SettingsView />
+      {:else if router.view === 'appearance'}
+        <Appearance />
       {:else}
         <CollectionsView />
       {/if}

--- a/packages/ui/src/lib/router.svelte.ts
+++ b/packages/ui/src/lib/router.svelte.ts
@@ -23,7 +23,8 @@ export type View =
   | "collections"
   | "cluster"
   | "security"
-  | "settings";
+  | "settings"
+  | "appearance";
 
 /**
  * A navigation intent. `collection` carries a selected collection + subpage
@@ -35,6 +36,7 @@ export type RouteTarget =
   | { view: "cluster" }
   | { view: "security" }
   | { view: "settings" }
+  | { view: "appearance" }
   | { view: "collection"; collection: string; subpage: string };
 
 /** Resolved current location, the reactive surface views read from. */
@@ -79,6 +81,8 @@ export function targetToHref(target: RouteTarget): string {
       return "/security";
     case "settings":
       return "/settings";
+    case "appearance":
+      return "/appearance";
     case "collection":
       return collectionPageHref(target.collection, target.subpage);
   }
@@ -110,6 +114,8 @@ export function pathToLocation(pathname: string): RouteLocation {
     return { view: "security", collection: null, subpage: null };
   if (pathname.startsWith("/settings"))
     return { view: "settings", collection: null, subpage: null };
+  if (pathname.startsWith("/appearance"))
+    return { view: "appearance", collection: null, subpage: null };
   const m = pathname.match(/^\/c\/([^/]+)(?:\/p\/([^/]+))?/);
   if (m) {
     return {

--- a/packages/ui/src/lib/skins/skins.svelte.ts
+++ b/packages/ui/src/lib/skins/skins.svelte.ts
@@ -1,0 +1,64 @@
+// Thin reactive shell over the pure skin core (`skins.ts`).
+//
+// Holds the selected skin in rune state, applies it to the document, and
+// persists the choice so it survives reloads. All the colour math lives in
+// the pure `skinToCssVars` mapping — this file only does DOM + localStorage.
+
+import {
+  DEFAULT_SKIN,
+  STORAGE_KEY,
+  applySkin,
+  skinByName,
+  type Skin,
+} from "./skins";
+
+function readPersisted(): string | null {
+  if (typeof localStorage === "undefined") return null;
+  return localStorage.getItem(STORAGE_KEY);
+}
+
+function persist(name: string) {
+  if (typeof localStorage === "undefined") return;
+  localStorage.setItem(STORAGE_KEY, name);
+}
+
+function rootEl(target?: HTMLElement | null): HTMLElement | null {
+  return (
+    target ??
+    (typeof document !== "undefined" ? document.documentElement : null)
+  );
+}
+
+class SkinStore {
+  /** The currently selected skin (reactive). */
+  current = $state<Skin>(DEFAULT_SKIN);
+  private target: HTMLElement | null = null;
+
+  /**
+   * Sync the store with the persisted selection and apply it. Call once on
+   * mount (after the theme inline script has run). With nothing persisted the
+   * store reports the default skin but leaves the inherited theme untouched.
+   */
+  init(target?: HTMLElement | null) {
+    this.target = rootEl(target);
+    const persisted = readPersisted();
+    if (persisted) {
+      this.current = skinByName(persisted);
+      if (this.target) applySkin(this.current, this.target);
+    }
+  }
+
+  /** Select a skin: apply its vars to the DOM and persist the choice. */
+  select(name: string) {
+    const skin = skinByName(name);
+    this.current = skin;
+    const el = rootEl(this.target);
+    if (el) {
+      this.target = el;
+      applySkin(skin, el);
+    }
+    persist(skin.name);
+  }
+}
+
+export const skins = new SkinStore();

--- a/packages/ui/src/lib/skins/skins.test.ts
+++ b/packages/ui/src/lib/skins/skins.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SKIN,
+  SKINS,
+  skinByName,
+  skinToCssVars,
+  type Skin,
+} from "./skins";
+
+/** Pull the lift percentage out of a `color-mix(in srgb, <lift> P%, <base>)`. */
+function liftPct(expr: string): number {
+  const m = expr.match(/color-mix\(in srgb, \S+ ([\d.]+)%/);
+  expect(m, `expected a color-mix expression, got: ${expr}`).not.toBeNull();
+  return Number(m![1]);
+}
+
+describe("skinToCssVars — pure seed → CSS-var mapping", () => {
+  it("produces the full custom-property set", () => {
+    const vars = skinToCssVars(DEFAULT_SKIN);
+    const expected = [
+      "--color-bg-0",
+      "--color-bg-1",
+      "--color-bg-2",
+      "--color-bg-3",
+      "--color-fg-0",
+      "--color-fg-1",
+      "--color-fg-2",
+      "--color-fg-3",
+      "--color-line-1",
+      "--color-line-2",
+      "--color-line-3",
+      "--color-accent",
+      "--color-accent-soft",
+      "--color-accent-glow",
+      "--color-ambient-glow",
+      "--color-role-primary",
+      "--font-sans",
+      "--font-mono",
+    ];
+    for (const key of expected) expect(vars).toHaveProperty(key);
+  });
+
+  it("keeps bg-0 exactly the seed (the deepest base)", () => {
+    const vars = skinToCssVars(DEFAULT_SKIN);
+    expect(vars["--color-bg-0"]).toBe(DEFAULT_SKIN.colors.bg);
+  });
+
+  it("derives a monotonic bg-0..bg-3 surface ramp via color-mix", () => {
+    // bg-1..bg-3 lift an increasing fraction of white off the bg seed; in the
+    // sRGB space color-mix is linear, so a strictly increasing white fraction
+    // means strictly increasing luminance — a monotonic ramp.
+    for (const skin of SKINS) {
+      const vars = skinToCssVars(skin);
+      expect(vars["--color-bg-0"]).toBe(skin.colors.bg);
+      for (const v of ["--color-bg-1", "--color-bg-2", "--color-bg-3"]) {
+        expect(vars[v]).toContain("color-mix(in srgb, #ffffff");
+        expect(vars[v]).toContain(skin.colors.bg);
+      }
+      const lifts = [
+        liftPct(vars["--color-bg-1"]),
+        liftPct(vars["--color-bg-2"]),
+        liftPct(vars["--color-bg-3"]),
+      ];
+      expect(lifts[0]).toBeLessThan(lifts[1]);
+      expect(lifts[1]).toBeLessThan(lifts[2]);
+    }
+  });
+
+  it("derives a monotonic fg-0..fg-3 text ramp fading toward bg", () => {
+    for (const skin of SKINS) {
+      const vars = skinToCssVars(skin);
+      // fg-0 is the pure seed; lower levels mix a *decreasing* fraction of fg
+      // into bg, so readability steps down monotonically.
+      expect(vars["--color-fg-0"]).toBe(skin.colors.fg);
+      const mixes = [
+        liftPct(vars["--color-fg-1"]),
+        liftPct(vars["--color-fg-2"]),
+        liftPct(vars["--color-fg-3"]),
+      ];
+      expect(mixes[0]).toBeGreaterThan(mixes[1]);
+      expect(mixes[1]).toBeGreaterThan(mixes[2]);
+    }
+  });
+
+  it("derives accent washes from the accent seed via color-mix with transparent", () => {
+    const vars = skinToCssVars(DEFAULT_SKIN);
+    const accent = DEFAULT_SKIN.colors.accent;
+    expect(vars["--color-accent"]).toBe(accent);
+    expect(vars["--color-accent-soft"]).toBe(
+      `color-mix(in srgb, ${accent} 12%, transparent)`
+    );
+    expect(vars["--color-accent-glow"]).toBe(
+      `color-mix(in srgb, ${accent} 45%, transparent)`
+    );
+    expect(vars["--color-role-primary"]).toBe(accent);
+  });
+
+  it("maps typography straight through", () => {
+    const vars = skinToCssVars(DEFAULT_SKIN);
+    expect(vars["--font-sans"]).toBe(DEFAULT_SKIN.typography.sans);
+    expect(vars["--font-mono"]).toBe(DEFAULT_SKIN.typography.mono);
+  });
+});
+
+describe("SKINS registry", () => {
+  it("ships 1–2 curated dark skins (not a buffet)", () => {
+    expect(SKINS.length).toBeGreaterThanOrEqual(1);
+    expect(SKINS.length).toBeLessThanOrEqual(2);
+  });
+
+  it("has unique skin names", () => {
+    const names = SKINS.map((s) => s.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("default skin preserves the #ff2056 accent", () => {
+    expect(DEFAULT_SKIN.name).toBe("reddb");
+    expect(DEFAULT_SKIN.colors.accent).toBe("#ff2056");
+    expect(skinToCssVars(DEFAULT_SKIN)["--color-accent"]).toBe("#ff2056");
+  });
+
+  it("every skin produces a complete, valid var set", () => {
+    for (const skin of SKINS) {
+      const vars = skinToCssVars(skin);
+      expect(Object.keys(vars).length).toBeGreaterThan(0);
+      for (const value of Object.values(vars)) expect(value).toBeTruthy();
+    }
+  });
+});
+
+describe("skinByName", () => {
+  it("resolves a known skin", () => {
+    expect(skinByName("nocturne").name).toBe("nocturne");
+  });
+
+  it("falls back to the default for unknown / nullish names", () => {
+    const cases: (string | null | undefined)[] = [
+      "does-not-exist",
+      null,
+      undefined,
+      "",
+    ];
+    for (const c of cases) expect(skinByName(c)).toBe(DEFAULT_SKIN);
+  });
+});
+
+// Adding a skin must be a single data entry — no render-code change. Guard the
+// shape so a new entry can't silently drop a required field.
+describe("adding a skin is data-only", () => {
+  it("every entry satisfies the Skin contract", () => {
+    for (const skin of SKINS as readonly Skin[]) {
+      expect(typeof skin.name).toBe("string");
+      expect(typeof skin.label).toBe("string");
+      expect(typeof skin.description).toBe("string");
+      expect(typeof skin.colors.bg).toBe("string");
+      expect(typeof skin.colors.accent).toBe("string");
+      expect(typeof skin.colors.fg).toBe("string");
+      expect(typeof skin.typography.sans).toBe("string");
+      expect(typeof skin.typography.mono).toBe("string");
+    }
+  });
+});

--- a/packages/ui/src/lib/skins/skins.ts
+++ b/packages/ui/src/lib/skins/skins.ts
@@ -1,0 +1,178 @@
+// Skin-as-data theming (#75).
+//
+// A skin is *plain data*: a name, human labels, a handful of colour seeds
+// (dark), and a type pairing. Adding a skin is a single entry in `SKINS` —
+// no render code changes. The pure `skinToCssVars` mapping turns those seeds
+// into the full `--color-*` custom-property set the app already consumes,
+// deriving the `--color-bg-0..bg-3` surface ramp (and the `fg`/`line` ramps)
+// via CSS `color-mix` so the steps stay perceptually monotonic without
+// hand-tuning every level. The DOM application + persistence below is a thin
+// shell over that pure core.
+//
+// Dark-only by design: every seed is a dark surface, and there is no
+// `light` / `system` branch. The default skin keeps reddb's signature
+// `#ff2056` accent.
+
+export interface SkinSeeds {
+  /** Darkest surface — becomes `--color-bg-0`; every other surface ramps up from it. */
+  bg: string;
+  /** Surgical accent — `--color-accent` and the primary node role. */
+  accent: string;
+  /** Primary text (`--color-fg-0`); the fg ramp darkens toward `bg`. */
+  fg: string;
+}
+
+export interface SkinTypography {
+  /** `--font-sans` stack. */
+  sans: string;
+  /** `--font-mono` stack. */
+  mono: string;
+}
+
+export interface Skin {
+  /** Stable id, persisted in localStorage and used for selection. */
+  name: string;
+  /** Human label shown on the preview card. */
+  label: string;
+  /** One-line description of the mood. */
+  description: string;
+  /** Dark colour seeds. */
+  colors: SkinSeeds;
+  /** Type pairing. */
+  typography: SkinTypography;
+}
+
+const FONT_SANS =
+  "'Inter Variable', 'Inter', system-ui, -apple-system, sans-serif";
+const FONT_MONO =
+  "'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, 'SF Mono', 'Menlo', monospace";
+
+/**
+ * The registry. Two curated dark skins — the mechanism, not a buffet.
+ * The first entry is the default.
+ */
+export const SKINS: readonly Skin[] = [
+  {
+    name: "reddb",
+    label: "Reddb",
+    description: "The signature near-black with a surgical rose accent.",
+    colors: { bg: "#050607", accent: "#ff2056", fg: "#f7f8fa" },
+    typography: { sans: FONT_SANS, mono: FONT_MONO },
+  },
+  {
+    name: "nocturne",
+    label: "Nocturne",
+    description: "Indigo-tinted midnight with a violet accent.",
+    colors: { bg: "#0a0b14", accent: "#7c5cff", fg: "#f5f6fb" },
+    typography: { sans: FONT_SANS, mono: FONT_MONO },
+  },
+] as const;
+
+export const DEFAULT_SKIN = SKINS[0];
+
+export const STORAGE_KEY = "red-ui-skin";
+
+/** Look a skin up by name, falling back to the default. */
+export function skinByName(name: string | null | undefined): Skin {
+  return SKINS.find((s) => s.name === name) ?? DEFAULT_SKIN;
+}
+
+// ─── pure mapping (the unit-testable core) ──────────────────────────────────
+
+/**
+ * `color-mix(in srgb, <lift> P%, <base>)`. In the sRGB space this is a linear
+ * interpolation, so a strictly increasing `pct` of a lighter `lift` yields a
+ * strictly lighter result — which is what keeps the surface ramp monotonic.
+ */
+function mix(lift: string, pct: number, base: string): string {
+  return `color-mix(in srgb, ${lift} ${pct}%, ${base})`;
+}
+
+/** `color-mix(in srgb, <color> P%, transparent)` — a translucent wash of `color`. */
+function alpha(color: string, pct: number): string {
+  return `color-mix(in srgb, ${color} ${pct}%, transparent)`;
+}
+
+/**
+ * Surface ramp `bg-0..bg-3`, lightened from the `bg` seed by an increasing
+ * fraction of white. `bg-0` is the pure seed (0% lift); the lift percentages
+ * are strictly increasing, so the ramp is monotonic by construction.
+ */
+const SURFACE_LIFT = [0, 4, 9, 15] as const;
+/** Hairline ramp `line-1..3`, also lightened from `bg` with white. */
+const LINE_LIFT = [6, 13, 22] as const;
+/**
+ * Text ramp `fg-0..fg-3`, faded from the `fg` seed toward `bg` by a
+ * decreasing fraction of `fg`. `fg-0` is the pure seed (100%); the
+ * percentages decrease, so readability steps down monotonically.
+ */
+const TEXT_MIX = [100, 78, 58, 45] as const;
+
+/**
+ * Pure seed → CSS-var mapping. Returns the complete custom-property set the
+ * app's tokens expect, with the `bg`/`fg`/`line` ramps derived via `color-mix`
+ * and the accent washes derived from the accent seed. No DOM, no I/O — this is
+ * what the unit tests exercise.
+ */
+export function skinToCssVars(skin: Skin): Record<string, string> {
+  const { bg, accent, fg } = skin.colors;
+  const white = "#ffffff";
+
+  const vars: Record<string, string> = {
+    // Surfaces — monotonic ramp from the bg seed.
+    "--color-bg-0":
+      SURFACE_LIFT[0] === 0 ? bg : mix(white, SURFACE_LIFT[0], bg),
+    "--color-bg-1": mix(white, SURFACE_LIFT[1], bg),
+    "--color-bg-2": mix(white, SURFACE_LIFT[2], bg),
+    "--color-bg-3": mix(white, SURFACE_LIFT[3], bg),
+
+    // Text — monotonic ramp fading toward the bg seed.
+    "--color-fg-0": fg,
+    "--color-fg-1": mix(fg, TEXT_MIX[1], bg),
+    "--color-fg-2": mix(fg, TEXT_MIX[2], bg),
+    "--color-fg-3": mix(fg, TEXT_MIX[3], bg),
+
+    // Hairlines.
+    "--color-line-1": mix(white, LINE_LIFT[0], bg),
+    "--color-line-2": mix(white, LINE_LIFT[1], bg),
+    "--color-line-3": mix(white, LINE_LIFT[2], bg),
+
+    // Surgical accent + washes derived from the accent seed.
+    "--color-accent": accent,
+    "--color-accent-soft": alpha(accent, 12),
+    "--color-accent-glow": alpha(accent, 45),
+    "--color-ambient-glow": alpha(accent, 6),
+
+    // Node roles — primary tracks the accent; replica/embedded stay legible
+    // semantic hues that read on any dark surface.
+    "--color-role-primary": accent,
+    "--color-role-replica": "#60a5fa",
+    "--color-role-embedded": "#4ade80",
+
+    // Semantic — dark-tuned, shared across skins.
+    "--color-ok": "#4ade80",
+    "--color-warn": "#fbbf24",
+    "--color-danger": "#ff5470",
+    "--color-info": "#60a5fa",
+
+    // Typography.
+    "--font-sans": skin.typography.sans,
+    "--font-mono": skin.typography.mono,
+  };
+
+  return vars;
+}
+
+/**
+ * Apply a skin's derived custom properties to a DOM element as inline styles.
+ * Inline styles win over the stylesheet's `:root` rules, so this overrides the
+ * active theme tokens regardless of `data-theme`. The thin shell
+ * (`skins.svelte.ts`) wires this to mount + persistence.
+ */
+export function applySkin(skin: Skin, target: HTMLElement) {
+  const vars = skinToCssVars(skin);
+  for (const [k, v] of Object.entries(vars)) target.style.setProperty(k, v);
+  // Skins are dark-only; pin data-theme so the shadcn semantic aliases that
+  // key off it stay consistent with the inline surface ramp.
+  target.dataset.theme = "dark";
+}

--- a/packages/ui/src/routes/appearance/+page.svelte
+++ b/packages/ui/src/routes/appearance/+page.svelte
@@ -1,0 +1,5 @@
+<!--
+  URL marker only. The Mountable Root (mounted in +layout.svelte) reads the
+  location from the Kit router and renders the Appearance view itself, so this
+  page intentionally renders nothing of its own.
+-->


### PR DESCRIPTION
Salvage of #75 (PRD #69, final child). -r worked (DONE iter 1) then hit the feedback-gate-without-install false fail. #75 forked from stale main (pre-#70), so its branch needed a **rebase onto current main** — resolved 3 keep-both unions (CommandPalette/Workspace/router: settings + appearance side-by-side), fixed a union-type artifact (dangling `;` after `settings` orphaned `appearance` from the View type).

Verified after rebase: ✅ 392 tests, ✅ svelte-check 0/0, ✅ build green.

Closes #75.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783095718&installation_id=129708444&pr_number=81&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F81&signature=30601d35fbe5d608e2a67ce59010a2b28bd8266f8ba05ce24779f69faad7b1f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Appearance settings page to select visual themes
  * Multiple skin themes now available for customization
  * Appearance settings accessible via command palette
  * Selected theme persists across sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->