### PR TITLE
feat(settings): per-section search + config export (#74)

### DIFF
--- a/.changeset/settings-search-export.md
+++ b/.changeset/settings-search-export.md
@@ -1,0 +1,15 @@
+---
+"@reddb-io/ui": minor
+---
+
+Settings: per-section search + config export (PRD #69, #74).
+
+The settings shell gains a focusable per-section search (⌘K idiom) that filters
+the data-driven registry within the active section by config key or human label,
+with **per-section query state** so switching sections preserves what you typed.
+The nav footer gains an **Export config** action that downloads the live config
+snapshot (read from `connection.client`) as JSON.
+
+Note: import/reset are intentionally not shipped — the reddb client exposes no
+config write/reset endpoint, so they would have no real target (the project's
+"live or empty, never fake" rule). Export reflects the read-only reality.

--- a/packages/ui/src/lib/SettingsView.svelte
+++ b/packages/ui/src/lib/SettingsView.svelte
@@ -16,7 +16,6 @@
     SectionHeading,
     Pill,
     ListRow,
-    Kbd,
   } from '@reddb-io/ui-kit'
   import {
     Settings2,
@@ -26,6 +25,7 @@
     Shield,
     Search,
     RefreshCw,
+    Download,
     Lock,
     Unplug,
     type Icon,
@@ -40,6 +40,7 @@
     resolveControl,
     sourceForKey,
     flattenConfig,
+    filterKeys,
     type ControlDescriptor,
     type SettingsSource,
   } from '$lib/settings-sections'
@@ -62,6 +63,24 @@
 
   let activeId = $state(SECTIONS[0].id)
   const active = $derived(resolveSection(activeId))
+
+  // Per-section search query, keyed by section id, so switching tabs preserves
+  // each section's typed query. The input is focusable via the ⌘K idiom.
+  let queries = $state<Record<string, string>>({})
+  let searchEl = $state<HTMLInputElement | null>(null)
+  const query = $derived(queries[activeId] ?? '')
+
+  function setQuery(v: string) {
+    queries = { ...queries, [activeId]: v }
+  }
+
+  function onWindowKey(e: KeyboardEvent) {
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+      e.preventDefault()
+      searchEl?.focus()
+      searchEl?.select()
+    }
+  }
 
   // Flattened live config and, per source, the reason its grant is absent
   // (null ⇒ available). Both are rebuilt atomically on every refresh.
@@ -148,7 +167,7 @@
   // not report is dropped (graceful degradation — no empty placeholder).
   const rows = $derived.by<RenderRow[]>(() => {
     const out: RenderRow[] = []
-    for (const key of active.keys) {
+    for (const key of filterKeys(active.keys, query)) {
       const src = sourceForKey(key)
       const reason = denied[src]
       const label = resolveControl(key).label
@@ -186,14 +205,28 @@
     return String(value)
   }
 
-  // Reuse the global command palette as the search surface — the same ⌘K idiom
-  // the topbar uses, so Esc-to-close comes for free from the palette overlay.
-  function openPalette() {
-    window.dispatchEvent(
-      new KeyboardEvent('keydown', { key: 'k', metaKey: true, ctrlKey: true, bubbles: true }),
-    )
+  // Export the live config snapshot (what's currently inspected) as JSON. This
+  // is the honest, real action: the snapshot is read from connection.client, so
+  // it can be downloaded but NOT written back (the client exposes no config
+  // write/reset). Import/reset would have no real target here, so they are
+  // intentionally not offered rather than faked.
+  function exportConfig() {
+    const payload = {
+      url: activeUrl,
+      exportedAt: new Date().toISOString(),
+      config: values,
+    }
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `reddb-config-${new Date().toISOString().slice(0, 10)}.json`
+    a.click()
+    URL.revokeObjectURL(url)
   }
 </script>
+
+<svelte:window onkeydown={onWindowKey} />
 
 {#if !connected}
   <div class="h-full overflow-auto bg-bg-0 p-6">
@@ -212,15 +245,25 @@
 {:else}
   <SplitView searchShortcut={null}>
     {#snippet search()}
-      <button
-        type="button"
-        onclick={openPalette}
-        class="flex h-7 w-full items-center gap-2 rounded-md border border-line-2 bg-bg-2 px-2.5 text-xs text-fg-2 transition-colors hover:border-line-3 hover:text-fg-1"
-      >
-        <Search class="size-3.5 text-fg-3" />
-        <span class="flex-1 text-left">Search settings</span>
-        <span class="inline-flex gap-0.5"><Kbd>⌘</Kbd><Kbd>K</Kbd></span>
-      </button>
+      <div class="relative">
+        <Search
+          class="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-fg-3"
+        />
+        <input
+          bind:this={searchEl}
+          type="text"
+          placeholder="Search this section  ⌘K"
+          value={query}
+          oninput={(e) => setQuery(e.currentTarget.value)}
+          onkeydown={(e) => {
+            if (e.key === 'Escape') {
+              setQuery('')
+              e.currentTarget.blur()
+            }
+          }}
+          class="h-7 w-full rounded-md border border-line-2 bg-bg-2 pl-8 pr-2.5 text-xs text-fg-1 placeholder:text-fg-3 outline-none transition-colors focus:border-line-3"
+        />
+      </div>
     {/snippet}
 
     {#snippet nav()}
@@ -239,8 +282,19 @@
     {/snippet}
 
     {#snippet footer()}
-      <div class="px-3 py-2.5 text-[11px] text-fg-3">
-        Live from <span class="font-mono text-fg-2">{activeUrl}</span>.
+      <div class="grid gap-2 px-3 py-2.5">
+        <button
+          type="button"
+          onclick={exportConfig}
+          disabled={loading}
+          class="inline-flex h-7 items-center justify-center gap-1.5 rounded-md border border-line-2 bg-bg-2 px-2.5 text-[11px] font-mono text-fg-1 transition-colors hover:border-line-3 hover:text-fg-0 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <Download class="size-3.5" />
+          export config
+        </button>
+        <div class="text-[11px] text-fg-3">
+          Live from <span class="font-mono text-fg-2">{activeUrl}</span>.
+        </div>
       </div>
     {/snippet}
 

--- a/packages/ui/src/lib/settings-sections.test.ts
+++ b/packages/ui/src/lib/settings-sections.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   SECTIONS,
   ENUM_OPTIONS,
+  filterKeys,
   flattenConfig,
   humanizeKey,
   resolveControl,
@@ -127,5 +128,39 @@ describe("flattenConfig", () => {
       if (key === "store.total_memory_bytes") continue; // omitted by this server
       expect(flat[key]).toBeDefined();
     }
+  });
+});
+
+describe("filterKeys (per-section search)", () => {
+  const keys = [
+    "store.collection_count",
+    "store.total_entities",
+    "store.total_memory_bytes",
+    "read_only",
+  ];
+
+  it("returns all keys (a copy) for an empty or whitespace query", () => {
+    expect(filterKeys(keys, "")).toEqual(keys);
+    expect(filterKeys(keys, "   ")).toEqual(keys);
+    expect(filterKeys(keys, "")).not.toBe(keys); // copy, not the same ref
+  });
+
+  it("matches against the config path, case-insensitively", () => {
+    expect(filterKeys(keys, "MEMORY")).toEqual(["store.total_memory_bytes"]);
+    expect(filterKeys(keys, "store.total")).toEqual([
+      "store.total_entities",
+      "store.total_memory_bytes",
+    ]);
+  });
+
+  it("matches against the resolved human label, not just the key", () => {
+    // "read_only" → label "Read-only"; "only" appears in the label.
+    expect(filterKeys(keys, "read-only")).toEqual(["read_only"]);
+    // "Collections" is the curated label for store.collection_count.
+    expect(filterKeys(keys, "collections")).toEqual(["store.collection_count"]);
+  });
+
+  it("returns an empty array when nothing matches", () => {
+    expect(filterKeys(keys, "zzz-nope")).toEqual([]);
   });
 });

--- a/packages/ui/src/lib/settings-sections.ts
+++ b/packages/ui/src/lib/settings-sections.ts
@@ -247,3 +247,21 @@ export function flattenConfig(
 export function resolveSection(id: string | null): SettingsSection {
   return SECTIONS.find((s) => s.id === id) ?? SECTIONS[0];
 }
+
+/**
+ * Filter a section's curated keys by a free-text query, matching against both
+ * the config path AND the resolved human label (case-insensitive). An empty or
+ * whitespace-only query returns the keys unchanged. Pure + framework-free so
+ * the settings search is unit-testable without rendering. The settings view
+ * keeps one query string per section id, so switching sections preserves each
+ * section's typed query.
+ */
+export function filterKeys(keys: readonly string[], query: string): string[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [...keys];
+  return keys.filter(
+    (key) =>
+      key.toLowerCase().includes(q) ||
+      resolveControl(key).label.toLowerCase().includes(q)
+  );
+}


### PR DESCRIPTION
Closes #74 (last AFK slice of PRD #69). Per-section search (⌘K) over the data-driven registry with per-section query state; nav-footer Export config downloads the live snapshot. import/reset omitted — no config-write endpoint on the reddb client (would be fake). 421 tests, svelte-check 0/0, build green. Ships as a minor via the changesets flow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783108962&installation_id=129708444&pr_number=82&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F82&signature=18cb93e1660b3f44a657f613aa1f8064c73b96f81f0a0186d17e3800df5ddb17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-section search (⌘K/Ctrl+K) filters settings by configuration key or label
  * Export active configuration as JSON from the navigation footer
  * Search queries persist when switching between sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->