### PR TITLE
Settings surface: Config pane reads live config

### DIFF
--- a/.red/adr/0007-settings-authoring-over-query-surface.md
+++ b/.red/adr/0007-settings-authoring-over-query-surface.md
@@ -1,0 +1,46 @@
+# ADR-0007: Settings authoring uses reddb's SQL query surface
+
+The Settings surface reads and, in later slices, authors Config, Secrets, and
+Policies through reddb SQL statements over the existing RedClient `query()` path.
+The Core should not learn separate per-key REST config endpoints for this
+surface.
+
+## Decision
+
+- Config reads use `SHOW CONFIG` over `POST /query`.
+- Config writes/deletes in future slices should use the matching SQL config
+  statements over the same query path.
+- Secrets and Policies should appear as panes only when their real query-backed
+  readers exist. Until then the Settings surface shows only Config.
+- Permission checks remain orthogonal to the query surface and will be layered in
+  through the server's auth capability surface when those panes ship.
+
+## Projection Finding
+
+Confirmed on 2026-06-04 against the repo's `docker/compose.yml` primary
+(`ghcr.io/reddb-io/reddb:1.9.1`, `http://localhost:15055`) and against reddb
+source:
+
+- `SHOW CONFIG` returns a table projection with columns `key` and `value`.
+- The live response had `statement: "show_config"`, `engine:
+"runtime-config"`, `record_count: 109`, and `result.columns: ["key",
+"value"]`.
+- It does not currently project `value_type` or `schema_version`.
+- `LIST CONFIG <collection>`, `GET CONFIG <collection> <key>`, and config write
+  responses do project `value_type` and `schema_version`.
+
+Source pointers:
+
+- reddb `crates/reddb-server/src/runtime/impl_core.rs` handles
+  `QueryExpr::ShowConfig` with `UnifiedResult::with_columns(vec!["key",
+"value"])`.
+- reddb `crates/reddb-server/src/runtime/impl_config.rs` projects
+  `value_type` and `schema_version` for the explicit config CRUD/list path.
+
+## Consequence
+
+The Config pane parser accepts the confirmed live `SHOW CONFIG` shape and also
+accepts enriched rows if reddb later adds `value_type` and `schema_version` to
+`SHOW CONFIG`. Until that happens, the read-only control resolver falls back to
+the runtime JSON value type for `SHOW CONFIG` rows and marks schema metadata as
+unknown rather than fabricating it.

--- a/packages/ui/src/lib/SettingsView.svelte
+++ b/packages/ui/src/lib/SettingsView.svelte
@@ -1,77 +1,59 @@
 <script lang="ts">
-  // Settings view — a data-driven, permission-aware config inspector.
-  //
-  // The sections, their curated keys, and the label/description/enum copy all
-  // live in `settings-sections` as DATA. This view does three things: reads the
-  // *real* config from `connection.client` (no mocks/fixtures), flattens it to
-  // dotted keys, and renders each curated key through `resolveControl` as a
-  // `ListRow`. When the connection is unreachable it falls back to EmptyState.
-  //
-  // Permission-aware by default: a key whose source endpoint is denied or
-  // unsupported is not greyed out — its control is absent, replaced by a small
-  // chip naming the missing grant (with the server's reason in the tooltip).
+  // Settings surface: a bounded pane shell whose only real pane in this slice
+  // is Config. The list is populated by live SHOW CONFIG over RedClient.query().
+  import { ListRow, NavItem, Pill, SectionHeading } from '@reddb-io/ui-kit'
   import {
-    SplitView,
-    NavItem,
-    SectionHeading,
-    Pill,
-    ListRow,
-  } from '@reddb-io/ui-kit'
-  import {
-    Settings2,
-    Database,
-    Network,
-    Plug,
-    Shield,
-    Search,
-    RefreshCw,
     Download,
-    Lock,
+    FileJson,
+    RefreshCw,
+    Search,
+    Settings2,
+    SlidersHorizontal,
     Unplug,
     type Icon,
   } from 'lucide-svelte'
   import PageHeader from '$lib/PageHeader.svelte'
   import EmptyState from '$lib/EmptyState.svelte'
-  import { connection } from '$lib/connections.svelte'
   import { activity } from '$lib/activity.svelte'
+  import { connection } from '$lib/connections.svelte'
+  import { SettingsAuthoringClient, type ConfigEntry } from '$lib/settings-authoring-client'
   import {
-    SECTIONS,
-    resolveSection,
-    resolveControl,
-    sourceForKey,
-    flattenConfig,
-    filterKeys,
+    SETTINGS_PANES,
+    filterConfigEntries,
+    resolveConfigControl,
+    resolvePane,
     type ControlDescriptor,
-    type SettingsSource,
   } from '$lib/settings-sections'
 
   const icons: Record<string, typeof Icon> = {
     settings: Settings2,
-    database: Database,
-    network: Network,
-    plug: Plug,
-    shield: Shield,
   }
 
-  // The grant a denied source is gated on — shown on the "absent" chip.
-  const GRANTS: Record<SettingsSource, string> = {
-    stats: 'stats:read',
-    cluster: 'cluster:status',
-    capabilities: 'capabilities',
-    session: 'auth:whoami',
-  }
+  let activePaneId = $state(SETTINGS_PANES[0].id)
+  const activePane = $derived(resolvePane(activePaneId))
 
-  let activeId = $state(SECTIONS[0].id)
-  const active = $derived(resolveSection(activeId))
-
-  // Per-section search query, keyed by section id, so switching tabs preserves
-  // each section's typed query. The input is focusable via the ⌘K idiom.
   let queries = $state<Record<string, string>>({})
   let searchEl = $state<HTMLInputElement | null>(null)
-  const query = $derived(queries[activeId] ?? '')
+  const query = $derived(queries[activePaneId] ?? '')
 
-  function setQuery(v: string) {
-    queries = { ...queries, [activeId]: v }
+  let entries = $state<ConfigEntry[]>([])
+  let selectedKey = $state<string | null>(null)
+  let loading = $state(false)
+  let loadError = $state<string | null>(null)
+
+  const connected = $derived(connection.connected)
+  const activeUrl = $derived(connection.active.url)
+  const unreachable = $derived(!connected || loadError !== null)
+  const rows = $derived(filterConfigEntries(entries, query))
+  const selectedEntry = $derived(
+    rows.find((entry) => entry.key === selectedKey) ?? rows[0] ?? null,
+  )
+  const selectedControl = $derived(
+    selectedEntry ? resolveConfigControl(selectedEntry) : null,
+  )
+
+  function setQuery(value: string) {
+    queries = { ...queries, [activePaneId]: value }
   }
 
   function onWindowKey(e: KeyboardEvent) {
@@ -82,73 +64,33 @@
     }
   }
 
-  // Flattened live config and, per source, the reason its grant is absent
-  // (null ⇒ available). Both are rebuilt atomically on every refresh.
-  let values = $state<Record<string, unknown>>({})
-  let denied = $state<Record<SettingsSource, string | null>>({
-    stats: null,
-    cluster: null,
-    capabilities: null,
-    session: null,
-  })
-  let loading = $state(false)
-
-  const connected = $derived(connection.connected)
-  const activeUrl = $derived(connection.active.url)
-
   async function refresh() {
     const client = connection.client
     if (!client || !connected) {
-      values = {}
+      entries = []
+      selectedKey = null
+      loadError = null
       return
     }
+
     loading = true
-    const next: Record<string, unknown> = {}
-    const nextDenied: Record<SettingsSource, string | null> = {
-      stats: null,
-      cluster: null,
-      capabilities: null,
-      session: null,
-    }
-
-    // /capabilities is the negotiation itself — always available from the store.
-    Object.assign(next, flattenConfig({ capabilities: connection.capabilities }))
-
+    loadError = null
     try {
-      const stats = await activity.track('settings · stats', () => client.stats())
-      Object.assign(next, flattenConfig(stats as unknown as Record<string, unknown>))
-    } catch (e) {
-      nextDenied.stats = (e as Error).message
-    }
-
-    // Cluster topology is capability-gated: if the server can't honour
-    // /cluster/status, those keys are absent + explained, never faked.
-    if (!connection.capabilities.clusterStatus) {
-      nextDenied.cluster = 'Server does not expose /cluster/status.'
-    } else {
-      try {
-        const cluster = await activity.track('settings · cluster', () =>
-          client.clusterStatus(),
-        )
-        Object.assign(next, flattenConfig(cluster as unknown as Record<string, unknown>))
-      } catch (e) {
-        nextDenied.cluster = (e as Error).message
-      }
-    }
-
-    try {
-      const session = await activity.track('settings · whoami', () => client.whoami())
-      Object.assign(
-        next,
-        flattenConfig({ session: session as unknown as Record<string, unknown> }),
+      const authoring = new SettingsAuthoringClient(client)
+      const next = await activity.track('settings · show config', () =>
+        authoring.showConfig(),
       )
+      entries = next
+      if (!selectedKey || !next.some((entry) => entry.key === selectedKey)) {
+        selectedKey = next[0]?.key ?? null
+      }
     } catch (e) {
-      nextDenied.session = (e as Error).message
+      entries = []
+      selectedKey = null
+      loadError = (e as Error).message
+    } finally {
+      loading = false
     }
-
-    values = next
-    denied = nextDenied
-    loading = false
   }
 
   $effect(() => {
@@ -157,64 +99,46 @@
     refresh()
   })
 
-  type RenderRow =
-    | { type: 'value'; key: string; label: string; control: ControlDescriptor; value: unknown }
-    | { type: 'denied'; key: string; label: string; reason: string; grant: string }
-
-  // Resolve the active section's curated keys to render rows. A key whose
-  // source is denied becomes a "denied" row (absent control + explanation); a
-  // key with a live value becomes a "value" row; a key the server simply does
-  // not report is dropped (graceful degradation — no empty placeholder).
-  const rows = $derived.by<RenderRow[]>(() => {
-    const out: RenderRow[] = []
-    for (const key of filterKeys(active.keys, query)) {
-      const src = sourceForKey(key)
-      const reason = denied[src]
-      const label = resolveControl(key).label
-      if (reason) {
-        out.push({ type: 'denied', key, label, reason, grant: GRANTS[src] })
-      } else if (key in values) {
-        out.push({
-          type: 'value',
-          key,
-          label,
-          control: resolveControl(key, values[key]),
-          value: values[key],
-        })
-      }
-    }
-    return out
-  })
-
   function formatBytes(n: number): string {
     if (!Number.isFinite(n)) return String(n)
     const units = ['B', 'KB', 'MB', 'GB', 'TB']
-    let v = n
+    let value = n
     let i = 0
-    while (v >= 1024 && i < units.length - 1) {
-      v /= 1024
+    while (value >= 1024 && i < units.length - 1) {
+      value /= 1024
       i++
     }
-    return `${i === 0 ? v : v.toFixed(1)} ${units[i]}`
+    return `${i === 0 ? value : value.toFixed(1)} ${units[i]}`
   }
 
-  function formatValue(control: ControlDescriptor, value: unknown): string {
-    if (control.kind === 'number' && control.key.endsWith('_bytes')) {
-      return formatBytes(Number(value))
-    }
+  function formatValue(entry: ConfigEntry): string {
+    const value = entry.value
+    if (typeof value === 'number' && entry.key.endsWith('_bytes')) return formatBytes(value)
+    if (Array.isArray(value)) return `${value.length} item${value.length === 1 ? '' : 's'}`
+    if (value && typeof value === 'object') return JSON.stringify(value)
+    if (value === null || value === undefined) return 'null'
     return String(value)
   }
 
-  // Export the live config snapshot (what's currently inspected) as JSON. This
-  // is the honest, real action: the snapshot is read from connection.client, so
-  // it can be downloaded but NOT written back (the client exposes no config
-  // write/reset). Import/reset would have no real target here, so they are
-  // intentionally not offered rather than faked.
+  function formatLongValue(value: unknown): string {
+    if (Array.isArray(value) || (value && typeof value === 'object')) {
+      return JSON.stringify(value, null, 2)
+    }
+    if (value === null || value === undefined) return 'null'
+    return String(value)
+  }
+
   function exportConfig() {
     const payload = {
       url: activeUrl,
       exportedAt: new Date().toISOString(),
-      config: values,
+      projection: 'SHOW CONFIG',
+      config: entries.map((entry) => ({
+        key: entry.key,
+        value: entry.value,
+        value_type: entry.valueType ?? null,
+        schema_version: entry.schemaVersion ?? null,
+      })),
     }
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' })
     const url = URL.createObjectURL(blob)
@@ -228,85 +152,175 @@
 
 <svelte:window onkeydown={onWindowKey} />
 
-{#if !connected}
-  <div class="h-full overflow-auto bg-bg-0 p-6">
-    <PageHeader
-      eyebrow="Settings"
-      title="Settings"
-      subtitle="Live configuration for the active reddb connection."
-    />
-    <EmptyState
-      icon={Unplug}
-      title="No active connection"
-      message="Connect to a reddb instance to inspect its live configuration."
-      hint="red serve"
-    />
-  </div>
-{:else}
-  <SplitView searchShortcut={null}>
-    {#snippet search()}
-      <div class="relative">
-        <Search
-          class="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-fg-3"
-        />
-        <input
-          bind:this={searchEl}
-          type="text"
-          placeholder="Search this section  ⌘K"
-          value={query}
-          oninput={(e) => setQuery(e.currentTarget.value)}
-          onkeydown={(e) => {
-            if (e.key === 'Escape') {
-              setQuery('')
-              e.currentTarget.blur()
-            }
-          }}
-          class="h-7 w-full rounded-md border border-line-2 bg-bg-2 pl-8 pr-2.5 text-xs text-fg-1 placeholder:text-fg-3 outline-none transition-colors focus:border-line-3"
-        />
+<div class="@container h-full min-h-0 bg-bg-0">
+  <div
+    class="grid h-full min-h-0 grid-cols-1 @min-[62rem]:grid-cols-[13rem_minmax(18rem,24rem)_minmax(0,1fr)]"
+  >
+    <aside
+      class="flex min-h-0 flex-col border-b border-line-1 bg-bg-1 @min-[62rem]:border-b-0 @min-[62rem]:border-r"
+    >
+      <div class="border-b border-line-1 px-3 py-3">
+        <div class="type-label">Settings</div>
+        <div class="mt-1 text-[13px] text-fg-1">Governance surface</div>
       </div>
-    {/snippet}
-
-    {#snippet nav()}
       <nav class="grid gap-0.5 p-2">
-        {#each SECTIONS as section (section.id)}
-          {@const SectionIcon = icons[section.icon] ?? Settings2}
+        {#each SETTINGS_PANES as pane (pane.id)}
+          {@const PaneIcon = icons[pane.icon] ?? Settings2}
           <NavItem
-            label={section.label}
-            active={section.id === active.id}
-            onclick={() => (activeId = section.id)}
+            label={pane.label}
+            active={pane.id === activePane.id}
+            onclick={() => (activePaneId = pane.id)}
           >
-            {#snippet icon()}<SectionIcon class="size-3.5" />{/snippet}
+            {#snippet icon()}<PaneIcon class="size-3.5" />{/snippet}
+            {#snippet trailing()}<Pill>{entries.length}</Pill>{/snippet}
           </NavItem>
         {/each}
       </nav>
-    {/snippet}
+      <div class="mt-auto border-t border-line-1 px-3 py-2.5 text-[11px] text-fg-3">
+        <span class="font-mono text-fg-2">{entries.length}</span> live keys
+      </div>
+    </aside>
 
-    {#snippet footer()}
-      <div class="grid gap-2 px-3 py-2.5">
+    <section
+      class="flex min-h-0 flex-col border-b border-line-1 bg-bg-1 @min-[62rem]:border-b-0 @min-[62rem]:border-r"
+      aria-label={`${activePane.label} entries`}
+    >
+      <div class="border-b border-line-1 p-2">
+        <div class="relative">
+          <Search
+            class="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-fg-3"
+          />
+          <input
+            bind:this={searchEl}
+            type="text"
+            placeholder="Search config  ⌘K"
+            value={query}
+            disabled={unreachable}
+            oninput={(e) => setQuery(e.currentTarget.value)}
+            onkeydown={(e) => {
+              if (e.key === 'Escape') {
+                setQuery('')
+                e.currentTarget.blur()
+              }
+            }}
+            class="h-7 w-full rounded-md border border-line-2 bg-bg-2 pl-8 pr-2.5 text-xs text-fg-1 placeholder:text-fg-3 outline-none transition-colors focus:border-line-3 disabled:cursor-not-allowed disabled:opacity-50"
+          />
+        </div>
+      </div>
+
+      <div class="min-h-0 flex-1 overflow-y-auto">
+        {#if unreachable}
+          <EmptyState
+            icon={Unplug}
+            title={connected ? 'Config is unreachable' : 'No active connection'}
+            message={connected
+              ? 'red-ui could not read SHOW CONFIG from the active target.'
+              : 'Connect to a reddb instance to inspect its live configuration.'}
+            hint={connected ? loadError ?? activeUrl : 'red serve'}
+          />
+        {:else if loading && rows.length === 0}
+          <div class="grid gap-1 p-2">
+            {#each Array(8) as _, i (i)}
+              <div class="h-12 rounded-md bg-bg-2 motion-safe:animate-pulse"></div>
+            {/each}
+          </div>
+        {:else if rows.length === 0}
+          <EmptyState
+            icon={Search}
+            title={query ? 'No config matches' : 'No config reported'}
+            message={query
+              ? 'Search checks the config key and curated human label.'
+              : 'SHOW CONFIG returned no rows for this connection.'}
+          />
+        {:else}
+          <div class="grid gap-1 p-2">
+            {#each rows as entry (entry.key)}
+              {@const control = resolveConfigControl(entry)}
+              <div
+                class={[
+                  'grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-md px-2.5 py-2 transition-colors',
+                  selectedEntry?.key === entry.key
+                    ? 'bg-bg-3 text-fg-0'
+                    : 'text-fg-1 hover:bg-bg-2',
+                ].join(' ')}
+              >
+                <button
+                  type="button"
+                  aria-current={selectedEntry?.key === entry.key ? 'page' : undefined}
+                  onclick={() => (selectedKey = entry.key)}
+                  class="min-w-0 text-left"
+                >
+                  <span class="block truncate text-[13px]">{control.label}</span>
+                  <span class="block truncate font-mono text-[11px] text-fg-3">{entry.key}</span>
+                </button>
+
+                {#if control.kind === 'boolean'}
+                  <label
+                    class="inline-flex h-6 items-center gap-1.5 rounded border border-line-2 bg-bg-2 px-1.5 font-mono text-[11px] text-fg-2"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={entry.value === true}
+                      disabled
+                      tabindex="-1"
+                      class="size-3 accent-current"
+                    />
+                    {entry.value ? 'true' : 'false'}
+                  </label>
+                {:else if control.kind === 'enum'}
+                  <select
+                    disabled
+                    tabindex="-1"
+                    value={String(entry.value)}
+                    class="h-6 w-28 rounded border border-line-2 bg-bg-2 px-1.5 font-mono text-[11px] text-accent disabled:opacity-100"
+                    aria-label={control.label}
+                  >
+                    {#if !control.options?.includes(String(entry.value))}
+                      <option value={String(entry.value)}>{formatValue(entry)}</option>
+                    {/if}
+                    {#each control.options ?? [] as option}
+                      <option value={option}>{option}</option>
+                    {/each}
+                  </select>
+                {:else}
+                  <input
+                    readonly
+                    tabindex="-1"
+                    aria-label={control.label}
+                    value={formatValue(entry)}
+                    class="h-6 w-28 rounded border border-line-2 bg-bg-2 px-1.5 font-mono text-[11px] text-fg-2 outline-none"
+                  />
+                {/if}
+              </div>
+            {/each}
+          </div>
+        {/if}
+      </div>
+
+      <div class="grid gap-2 border-t border-line-1 px-3 py-2.5">
         <button
           type="button"
           onclick={exportConfig}
-          disabled={loading}
+          disabled={loading || entries.length === 0}
           class="inline-flex h-7 items-center justify-center gap-1.5 rounded-md border border-line-2 bg-bg-2 px-2.5 text-[11px] font-mono text-fg-1 transition-colors hover:border-line-3 hover:text-fg-0 disabled:cursor-not-allowed disabled:opacity-40"
         >
           <Download class="size-3.5" />
           export config
         </button>
-        <div class="text-[11px] text-fg-3">
+        <div class="truncate text-[11px] text-fg-3">
           Live from <span class="font-mono text-fg-2">{activeUrl}</span>.
         </div>
       </div>
-    {/snippet}
+    </section>
 
-    {#snippet content()}
-      {@const SectionIcon = icons[active.icon] ?? Settings2}
+    <main class="min-h-0 min-w-0 overflow-auto bg-bg-0">
       <div class="p-6">
-        <PageHeader eyebrow="Settings" title={active.label} subtitle={active.blurb}>
+        <PageHeader eyebrow="Settings" title={activePane.label} subtitle={activePane.blurb}>
           {#snippet actions()}
             <button
               type="button"
               onclick={refresh}
-              disabled={loading}
+              disabled={loading || !connected}
               class="inline-flex h-7 items-center gap-1.5 rounded-md border border-line-2 bg-bg-2 px-2.5 text-[11px] font-mono text-fg-1 hover:border-line-3 hover:text-fg-0 disabled:cursor-not-allowed disabled:opacity-40"
             >
               <RefreshCw class={loading ? 'size-3.5 animate-spin' : 'size-3.5'} />
@@ -315,62 +329,101 @@
           {/snippet}
         </PageHeader>
 
-        <section class="mb-6">
-          <SectionHeading title={active.label} class="mb-2">
-            {#snippet icon()}<SectionIcon class="size-3.5" />{/snippet}
-            {#snippet meta()}<Pill>{rows.length}</Pill>{/snippet}
-          </SectionHeading>
+        {#if unreachable}
+          <EmptyState
+            icon={Unplug}
+            title={connected ? 'Unable to read config' : 'No active connection'}
+            message={connected
+              ? 'The Config pane is intentionally empty because SHOW CONFIG did not complete.'
+              : 'Start or select a reddb target, then return here to inspect live config.'}
+            hint={connected ? loadError ?? activeUrl : 'docker compose -f docker/compose.yml up -d'}
+          />
+        {:else if !selectedEntry || !selectedControl}
+          <EmptyState
+            icon={FileJson}
+            title="No config entry selected"
+            message="Select a live SHOW CONFIG row to inspect its read-only control."
+          />
+        {:else}
+          <section>
+            <SectionHeading title={selectedControl.label} class="mb-2">
+              {#snippet icon()}<SlidersHorizontal class="size-3.5" />{/snippet}
+              {#snippet meta()}<Pill>{selectedControl.kind}</Pill>{/snippet}
+            </SectionHeading>
 
-          {#if rows.length === 0}
-            <div
-              class="rounded-lg border border-dashed border-line-1 bg-bg-1 px-3 py-6 text-center text-[12px] text-fg-3"
-            >
-              This server reports nothing for these keys.
-            </div>
-          {:else}
-            <div
-              class="divide-y divide-line-1 overflow-hidden rounded-lg border border-line-1 bg-bg-1"
-            >
-              {#each rows as row (row.key)}
-                {#if row.type === 'denied'}
-                  <ListRow title={row.label} hint={row.key}>
-                    {#snippet action()}
-                      <span
-                        class="inline-flex items-center gap-1.5 rounded-md border border-line-2 bg-bg-2 px-2 py-1 text-[11px] font-mono text-fg-3"
-                        title={row.reason}
-                      >
-                        <Lock class="size-3" />
-                        requires {row.grant}
-                      </span>
-                    {/snippet}
-                  </ListRow>
-                {:else}
-                  <ListRow
-                    title={row.label}
-                    description={row.control.description}
-                    hint={row.key}
-                  >
-                    {#snippet action()}
-                      {#if row.control.kind === 'boolean'}
-                        <Pill tone={row.value ? 'accent' : 'muted'}>{row.value ? 'on' : 'off'}</Pill>
-                      {:else if row.control.kind === 'enum'}
-                        <span
-                          class="font-mono text-[12px] text-accent"
-                          title={`Options: ${row.control.options?.join(', ')}`}
-                        >{row.value}</span>
-                      {:else}
-                        <span class="font-mono text-[12px] text-fg-1"
-                          >{formatValue(row.control, row.value)}</span
-                        >
+            <div class="divide-y divide-line-1 overflow-hidden rounded-lg border border-line-1 bg-bg-1">
+              <ListRow
+                title={selectedControl.label}
+                description={selectedControl.description}
+                hint={selectedEntry.key}
+                wide
+              >
+                {#snippet action()}
+                  {#if selectedControl.kind === 'boolean'}
+                    <label
+                      class="inline-flex h-8 items-center gap-2 rounded-md border border-line-2 bg-bg-2 px-2.5 font-mono text-[12px] text-fg-1"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedEntry.value === true}
+                        disabled
+                        class="size-3 accent-current"
+                      />
+                      {selectedEntry.value ? 'true' : 'false'}
+                    </label>
+                  {:else if selectedControl.kind === 'enum'}
+                    <select
+                      disabled
+                      value={String(selectedEntry.value)}
+                      class="h-8 min-w-[12rem] rounded-md border border-line-2 bg-bg-2 px-2.5 font-mono text-[12px] text-fg-1 disabled:opacity-100"
+                    >
+                      {#if !selectedControl.options?.includes(String(selectedEntry.value))}
+                        <option value={String(selectedEntry.value)}>{formatValue(selectedEntry)}</option>
                       {/if}
-                    {/snippet}
-                  </ListRow>
-                {/if}
-              {/each}
+                      {#each selectedControl.options ?? [] as option}
+                        <option value={option}>{option}</option>
+                      {/each}
+                    </select>
+                  {:else if selectedControl.kind === 'list'}
+                    <textarea
+                      readonly
+                      rows="5"
+                      value={formatLongValue(selectedEntry.value)}
+                      class="min-h-24 w-full resize-y rounded-md border border-line-2 bg-bg-2 px-2.5 py-2 font-mono text-[12px] text-fg-1 outline-none"
+                    ></textarea>
+                  {:else}
+                    <input
+                      readonly
+                      type={selectedControl.kind === 'number' ? 'text' : 'text'}
+                      value={formatValue(selectedEntry)}
+                      class="h-8 w-full rounded-md border border-line-2 bg-bg-2 px-2.5 font-mono text-[12px] text-fg-1 outline-none"
+                    />
+                  {/if}
+                {/snippet}
+              </ListRow>
+
+              <ListRow title="Key" hint={selectedEntry.key}>
+                {#snippet action()}
+                  <span class="font-mono text-[12px] text-fg-1">{selectedEntry.key}</span>
+                {/snippet}
+              </ListRow>
+
+              <ListRow title="Schema">
+                {#snippet action()}
+                  <div class="flex flex-wrap justify-end gap-1.5">
+                    <Pill>{selectedControl.valueType ?? 'runtime type'}</Pill>
+                    <Pill
+                      >schema {selectedControl.schemaVersion === undefined
+                        ? 'unknown'
+                        : selectedControl.schemaVersion}</Pill
+                    >
+                  </div>
+                {/snippet}
+              </ListRow>
             </div>
-          {/if}
-        </section>
+          </section>
+        {/if}
       </div>
-    {/snippet}
-  </SplitView>
-{/if}
+    </main>
+  </div>
+</div>

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -35,6 +35,7 @@ export * from "./collection-catalog";
 export * from "./collection-pages";
 export * from "./router.svelte";
 export * from "./settings-sections";
+export * from "./settings-authoring-client";
 export * from "./cn";
 export * from "./connections.svelte";
 export * from "./shortcuts";

--- a/packages/ui/src/lib/settings-authoring-client.test.ts
+++ b/packages/ui/src/lib/settings-authoring-client.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import type { QueryResult } from "./reddb/client";
+import {
+  SettingsAuthoringClient,
+  parseShowConfigResult,
+  type QueryTransport,
+} from "./settings-authoring-client";
+
+function result(records: Array<Record<string, unknown>>): QueryResult {
+  return {
+    ok: true,
+    query: "SHOW CONFIG",
+    record_count: records.length,
+    result: {
+      columns: Object.keys(records[0] ?? {}),
+      records: records.map((values) => ({ values })),
+    },
+  };
+}
+
+describe("parseShowConfigResult", () => {
+  it("parses the confirmed live SHOW CONFIG projection: key + value", () => {
+    expect(
+      parseShowConfigResult(
+        result([
+          { key: "red.auth.enabled", value: false },
+          { key: "red.server.max_scan_limit", value: 1000 },
+        ])
+      )
+    ).toEqual([
+      { key: "red.auth.enabled", value: false },
+      { key: "red.server.max_scan_limit", value: 1000 },
+    ]);
+  });
+
+  it("also accepts enriched config rows with value_type + schema_version", () => {
+    expect(
+      parseShowConfigResult(
+        result([
+          {
+            collection: "red_config",
+            key: "feature_flag",
+            value: true,
+            version: 3,
+            value_type: "bool",
+            schema_version: 2,
+            tags: null,
+            tombstone: false,
+          },
+        ])
+      )
+    ).toEqual([
+      {
+        collection: "red_config",
+        key: "feature_flag",
+        value: true,
+        version: 3,
+        valueType: "bool",
+        schemaVersion: 2,
+        tags: null,
+      },
+    ]);
+  });
+
+  it("tolerates alternate schema column spellings and skips tombstones", () => {
+    expect(
+      parseShowConfigResult(
+        result([
+          {
+            key: "live",
+            value: "ok",
+            "value-type": "string",
+            "schema-version": 1,
+          },
+          { key: "deleted", value: null, tombstone: true },
+          { key: null, value: "ignored" },
+        ])
+      )
+    ).toEqual([
+      {
+        key: "live",
+        value: "ok",
+        valueType: "string",
+        schemaVersion: 1,
+      },
+    ]);
+  });
+
+  it("throws the server error when the query envelope is not ok", () => {
+    expect(() =>
+      parseShowConfigResult({
+        ok: false,
+        query: "SHOW CONFIG",
+        record_count: 0,
+        result: { columns: [], records: [] },
+        error: "permission denied",
+      })
+    ).toThrow("permission denied");
+  });
+});
+
+describe("SettingsAuthoringClient", () => {
+  it("reads SHOW CONFIG over the query transport", async () => {
+    const calls: string[] = [];
+    const transport: QueryTransport = {
+      async query(sql) {
+        calls.push(sql);
+        return result([{ key: "red.auth.enabled", value: false }]);
+      },
+    };
+
+    await expect(
+      new SettingsAuthoringClient(transport).showConfig()
+    ).resolves.toEqual([{ key: "red.auth.enabled", value: false }]);
+    expect(calls).toEqual(["SHOW CONFIG"]);
+  });
+
+  it("passes a prefix when requested", async () => {
+    const calls: string[] = [];
+    const transport: QueryTransport = {
+      async query(sql) {
+        calls.push(sql);
+        return result([]);
+      },
+    };
+
+    await new SettingsAuthoringClient(transport).showConfig("red.ai");
+    expect(calls).toEqual(["SHOW CONFIG red.ai"]);
+  });
+
+  it("rejects unsafe prefixes before calling the transport", async () => {
+    const calls: string[] = [];
+    const transport: QueryTransport = {
+      async query(sql) {
+        calls.push(sql);
+        return result([]);
+      },
+    };
+
+    await expect(
+      new SettingsAuthoringClient(transport).showConfig("red.ai; DROP TABLE x")
+    ).rejects.toThrow("dotted identifier path");
+    expect(calls).toEqual([]);
+  });
+});

--- a/packages/ui/src/lib/settings-authoring-client.ts
+++ b/packages/ui/src/lib/settings-authoring-client.ts
@@ -1,0 +1,110 @@
+import type { QueryResult } from "./reddb/client";
+
+export type ConfigValueType =
+  | "bool"
+  | "boolean"
+  | "int"
+  | "integer"
+  | "float"
+  | "number"
+  | "count"
+  | "string"
+  | "text"
+  | "url"
+  | "object"
+  | "array"
+  | "list";
+
+export interface ConfigEntry {
+  key: string;
+  value: unknown;
+  collection?: string;
+  version?: number;
+  valueType?: ConfigValueType;
+  schemaVersion?: number;
+  tags?: unknown;
+}
+
+export interface QueryTransport {
+  query(sql: string): Promise<QueryResult>;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function readValueType(
+  values: Record<string, unknown>
+): ConfigValueType | undefined {
+  const raw =
+    optionalString(values.value_type) ??
+    optionalString(values.valueType) ??
+    optionalString(values["value-type"]);
+  return raw?.toLowerCase() as ConfigValueType | undefined;
+}
+
+function readSchemaVersion(
+  values: Record<string, unknown>
+): number | undefined {
+  return (
+    optionalNumber(values.schema_version) ??
+    optionalNumber(values.schemaVersion) ??
+    optionalNumber(values["schema-version"])
+  );
+}
+
+function normalizeConfigPrefix(prefix: string | undefined): string | undefined {
+  const suffix = prefix?.trim();
+  if (!suffix) return undefined;
+  if (!/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/.test(suffix)) {
+    throw new Error("SHOW CONFIG prefix must be a dotted identifier path");
+  }
+  return suffix;
+}
+
+export function parseShowConfigResult(result: QueryResult): ConfigEntry[] {
+  if (!result.ok) throw new Error(result.error ?? "SHOW CONFIG failed");
+
+  const entries: ConfigEntry[] = [];
+  for (const record of result.result.records) {
+    const values = record.values;
+    const key = optionalString(values.key);
+    if (!key || values.tombstone === true) continue;
+
+    const entry: ConfigEntry = {
+      key,
+      value: values.value,
+    };
+    const collection = optionalString(values.collection);
+    const version = optionalNumber(values.version);
+    const valueType = readValueType(values);
+    const schemaVersion = readSchemaVersion(values);
+
+    if (collection) entry.collection = collection;
+    if (version !== undefined) entry.version = version;
+    if (valueType) entry.valueType = valueType;
+    if (schemaVersion !== undefined) entry.schemaVersion = schemaVersion;
+    if ("tags" in values) entry.tags = values.tags;
+    entries.push(entry);
+  }
+
+  return entries.sort((left, right) => left.key.localeCompare(right.key));
+}
+
+export class SettingsAuthoringClient {
+  constructor(private readonly transport: QueryTransport) {}
+
+  async showConfig(prefix?: string): Promise<ConfigEntry[]> {
+    const suffix = normalizeConfigPrefix(prefix);
+    const result = await this.transport.query(
+      suffix ? `SHOW CONFIG ${suffix}` : "SHOW CONFIG"
+    );
+    return parseShowConfigResult(result);
+  }
+}

--- a/packages/ui/src/lib/settings-sections.test.ts
+++ b/packages/ui/src/lib/settings-sections.test.ts
@@ -1,166 +1,115 @@
 import { describe, expect, it } from "vitest";
+import type { ConfigEntry } from "./settings-authoring-client";
 import {
-  SECTIONS,
   ENUM_OPTIONS,
-  filterKeys,
-  flattenConfig,
+  SETTINGS_PANES,
+  filterConfigEntries,
   humanizeKey,
-  resolveControl,
-  resolveSection,
-  sourceForKey,
+  resolveConfigControl,
+  resolvePane,
 } from "./settings-sections";
 
-describe("settings sections registry", () => {
-  it("ships sections with stable, unique ids and non-empty curated keys", () => {
-    expect(SECTIONS.length).toBeGreaterThan(0);
-    const ids = SECTIONS.map((s) => s.id);
+describe("settings panes registry", () => {
+  it("ships only real panes with stable, unique ids", () => {
+    expect(SETTINGS_PANES.map((pane) => pane.id)).toEqual(["config"]);
+    const ids = SETTINGS_PANES.map((pane) => pane.id);
     expect(new Set(ids).size).toBe(ids.length);
-    for (const section of SECTIONS) {
-      expect(section.label).not.toBe("");
-      expect(section.blurb).not.toBe("");
-      expect(section.icon).not.toBe("");
-      expect(section.keys.length).toBeGreaterThan(0);
+    for (const pane of SETTINGS_PANES) {
+      expect(pane.label).not.toBe("");
+      expect(pane.blurb).not.toBe("");
+      expect(pane.icon).not.toBe("");
     }
   });
 
-  it("resolves a known section by id", () => {
-    const target = SECTIONS[SECTIONS.length - 1];
-    expect(resolveSection(target.id)).toBe(target);
-  });
-
-  it("falls back to the first section for unknown or null ids", () => {
-    expect(resolveSection("does-not-exist")).toBe(SECTIONS[0]);
-    expect(resolveSection(null)).toBe(SECTIONS[0]);
+  it("resolves a pane by id and falls back to Config", () => {
+    expect(resolvePane("config")).toBe(SETTINGS_PANES[0]);
+    expect(resolvePane("missing")).toBe(SETTINGS_PANES[0]);
+    expect(resolvePane(null)).toBe(SETTINGS_PANES[0]);
   });
 });
 
-describe("resolveControl", () => {
-  it("resolves the curated label and description for a known key", () => {
-    const c = resolveControl("deployment.mode", "embedded");
-    expect(c.label).toBe("Deployment mode");
-    expect(c.description).toBe("How this reddb instance is running.");
+describe("resolveConfigControl", () => {
+  const entry = (overrides: Partial<ConfigEntry>): ConfigEntry => ({
+    key: "red.auth.enabled",
+    value: false,
+    ...overrides,
   });
 
-  it("resolves enum kind + options from ENUM_OPTIONS regardless of value", () => {
-    const c = resolveControl("deployment.mode", "docker");
-    expect(c.kind).toBe("enum");
-    expect(c.options).toEqual(ENUM_OPTIONS["deployment.mode"]);
+  it("layers curated labels and descriptions over the live key", () => {
+    const control = resolveConfigControl(entry({ key: "red.auth.enabled" }));
+    expect(control.label).toBe("Authentication");
+    expect(control.description).toContain("authentication");
   });
 
-  it("infers boolean kind from a boolean value", () => {
-    expect(resolveControl("read_only", true).kind).toBe("boolean");
-    expect(resolveControl("capabilities.vcs", false).kind).toBe("boolean");
+  it("resolves enum kind + options from curated key data", () => {
+    const control = resolveConfigControl(
+      entry({ key: "durability.mode", value: "sync", valueType: "string" })
+    );
+    expect(control.kind).toBe("enum");
+    expect(control.options).toEqual(ENUM_OPTIONS["durability.mode"]);
   });
 
-  it("infers number kind from a numeric value", () => {
-    expect(resolveControl("store.collection_count", 12).kind).toBe("number");
+  it("uses SHOW CONFIG value_type before runtime fallback", () => {
+    expect(
+      resolveConfigControl(entry({ value: "true", valueType: "bool" })).kind
+    ).toBe("boolean");
+    expect(
+      resolveConfigControl(entry({ value: "42", valueType: "int" })).kind
+    ).toBe("number");
+    expect(
+      resolveConfigControl(entry({ value: "[1,2]", valueType: "array" })).kind
+    ).toBe("list");
   });
 
-  it("defaults to text kind for strings", () => {
-    expect(resolveControl("system.os", "linux").kind).toBe("text");
+  it("falls back to runtime value shape when SHOW CONFIG omits schema columns", () => {
+    expect(resolveConfigControl(entry({ value: true })).kind).toBe("boolean");
+    expect(resolveConfigControl(entry({ value: 42 })).kind).toBe("number");
+    expect(resolveConfigControl(entry({ value: ["main"] })).kind).toBe("list");
+    expect(resolveConfigControl(entry({ value: "reddb" })).kind).toBe("text");
   });
 
-  it("falls back gracefully for an unknown key with no value", () => {
-    const c = resolveControl("store.total_memory_bytes");
-    // No curated label exists for this key → humanized last segment.
-    expect(c.label).toBe("Memory in use"); // (curated) — see next case for raw fallback
-    expect(c.kind).toBe("text");
-    expect(c.options).toBeUndefined();
-  });
-
-  it("humanizes an entirely uncurated key and omits description", () => {
-    const c = resolveControl("wal.oldest_lsn", 42);
-    expect(c.label).toBe("Oldest lsn");
-    expect(c.description).toBeUndefined();
-    expect(c.kind).toBe("number");
+  it("carries schema metadata when present", () => {
+    const control = resolveConfigControl(
+      entry({ valueType: "bool", schemaVersion: 2 })
+    );
+    expect(control.valueType).toBe("bool");
+    expect(control.schemaVersion).toBe(2);
   });
 });
 
 describe("humanizeKey", () => {
   it("uses the last dotted segment, de-snakes, and sentence-cases", () => {
-    expect(humanizeKey("store.total_memory_bytes")).toBe("Total memory bytes");
+    expect(humanizeKey("red.storage.page_size")).toBe("Page size");
     expect(humanizeKey("read_only")).toBe("Read only");
     expect(humanizeKey("system.cpu-cores")).toBe("Cpu cores");
   });
 });
 
-describe("sourceForKey", () => {
-  it("routes keys to their live source", () => {
-    expect(sourceForKey("capabilities.vcs")).toBe("capabilities");
-    expect(sourceForKey("session.role")).toBe("session");
-    expect(sourceForKey("deployment.mode")).toBe("cluster");
-    expect(sourceForKey("replication.lag_ms")).toBe("cluster");
-    expect(sourceForKey("store.collection_count")).toBe("stats");
-    expect(sourceForKey("read_only")).toBe("stats");
-  });
-});
-
-describe("flattenConfig", () => {
-  it("flattens nested objects into dotted leaf paths", () => {
-    const flat = flattenConfig({
-      store: { collection_count: 3, total_memory_bytes: 1024 },
-      read_only: true,
-    });
-    expect(flat["store.collection_count"]).toBe(3);
-    expect(flat["store.total_memory_bytes"]).toBe(1024);
-    expect(flat["read_only"]).toBe(true);
-  });
-
-  it("keeps arrays and primitives as leaves and skips null/undefined branches", () => {
-    const flat = flattenConfig({
-      tags: ["a", "b"],
-      deployment: undefined,
-      replication: null,
-      session: { role: "admin" },
-    });
-    expect(flat["tags"]).toEqual(["a", "b"]);
-    expect("deployment" in flat).toBe(false);
-    expect("replication" in flat).toBe(false);
-    expect(flat["session.role"]).toBe("admin");
-  });
-
-  it("round-trips a stats-shaped snapshot into curated keys", () => {
-    const flat = flattenConfig({
-      store: { collection_count: 7, total_entities: 99, cross_ref_count: 0 },
-      system: { os: "linux", arch: "x86_64", cpu_cores: 8 },
-    });
-    for (const key of SECTIONS.find((s) => s.id === "storage")!.keys) {
-      if (key === "store.total_memory_bytes") continue; // omitted by this server
-      expect(flat[key]).toBeDefined();
-    }
-  });
-});
-
-describe("filterKeys (per-section search)", () => {
-  const keys = [
-    "store.collection_count",
-    "store.total_entities",
-    "store.total_memory_bytes",
-    "read_only",
+describe("filterConfigEntries (per-pane search)", () => {
+  const entries: ConfigEntry[] = [
+    { key: "red.auth.enabled", value: false },
+    { key: "red.server.max_body_size", value: 1048576 },
+    { key: "durability.mode", value: "sync" },
   ];
 
-  it("returns all keys (a copy) for an empty or whitespace query", () => {
-    expect(filterKeys(keys, "")).toEqual(keys);
-    expect(filterKeys(keys, "   ")).toEqual(keys);
-    expect(filterKeys(keys, "")).not.toBe(keys); // copy, not the same ref
+  it("returns all entries (a copy) for an empty or whitespace query", () => {
+    expect(filterConfigEntries(entries, "")).toEqual(entries);
+    expect(filterConfigEntries(entries, "   ")).toEqual(entries);
+    expect(filterConfigEntries(entries, "")).not.toBe(entries);
   });
 
-  it("matches against the config path, case-insensitively", () => {
-    expect(filterKeys(keys, "MEMORY")).toEqual(["store.total_memory_bytes"]);
-    expect(filterKeys(keys, "store.total")).toEqual([
-      "store.total_entities",
-      "store.total_memory_bytes",
-    ]);
+  it("matches config keys case-insensitively", () => {
+    expect(
+      filterConfigEntries(entries, "SERVER").map((entry) => entry.key)
+    ).toEqual(["red.server.max_body_size"]);
   });
 
-  it("matches against the resolved human label, not just the key", () => {
-    // "read_only" → label "Read-only"; "only" appears in the label.
-    expect(filterKeys(keys, "read-only")).toEqual(["read_only"]);
-    // "Collections" is the curated label for store.collection_count.
-    expect(filterKeys(keys, "collections")).toEqual(["store.collection_count"]);
-  });
-
-  it("returns an empty array when nothing matches", () => {
-    expect(filterKeys(keys, "zzz-nope")).toEqual([]);
+  it("matches curated human labels", () => {
+    expect(
+      filterConfigEntries(entries, "authentication").map((entry) => entry.key)
+    ).toEqual(["red.auth.enabled"]);
+    expect(
+      filterConfigEntries(entries, "durability").map((entry) => entry.key)
+    ).toEqual(["durability.mode"]);
   });
 });

--- a/packages/ui/src/lib/settings-sections.ts
+++ b/packages/ui/src/lib/settings-sections.ts
@@ -1,29 +1,17 @@
-// Data-driven settings registry + a pure config-key resolver.
-//
-// Settings are defined as DATA, not hand-built rows: `SECTIONS` lists the
-// curated config keys per section, and three override maps (`LABELS`,
-// `DESCRIPTIONS`, `ENUM_OPTIONS`) keyed by config path supply the human copy.
-// `resolveControl(key, value)` maps a single reddb config/connection key to a
-// rendered control descriptor (human label, description, input kind, enum
-// options), degrading gracefully for keys nobody curated. Adding a curated key
-// is a one-line edit to a section's `keys` array.
-//
-// Kept framework-free (no Svelte imports) so the registry and the resolver are
-// trivially unit-testable. Icons are mapped to components in `SettingsView`,
-// not here — a section carries only an icon *name*. Mirrors the registry idiom
-// in `renderers/registry`: a tiny pure surface over curated data.
+// Data-driven settings registry + pure schema resolver for the Settings surface.
+// This slice ships only the real Config pane. Secrets and Policies are absent
+// until they have live backing data, keeping the surface "live or empty" rather
+// than rendering placeholders.
+import type { ConfigEntry, ConfigValueType } from "./settings-authoring-client";
 
-/** The input control a config value is rendered through. */
-export type ControlKind = "text" | "number" | "boolean" | "enum";
-
-/** Where a config key is sourced from — gates permission-aware rendering. */
-export type SettingsSource = "stats" | "cluster" | "capabilities" | "session";
+/** The read-only control a config value is rendered through. */
+export type ControlKind = "text" | "number" | "boolean" | "enum" | "list";
 
 /** A resolved control for one config key. */
 export interface ControlDescriptor {
   /** The config path this descriptor was resolved from. */
   key: string;
-  /** Human label — a curated override or a humanized key. */
+  /** Human label: a curated override or a humanized key. */
   label: string;
   /** Optional one-line explanation. */
   description?: string;
@@ -31,10 +19,14 @@ export interface ControlDescriptor {
   kind: ControlKind;
   /** Allowed values when `kind === "enum"`. */
   options?: readonly string[];
+  /** Server-reported config schema type, when SHOW CONFIG projects it. */
+  valueType?: ConfigValueType;
+  /** Server-reported config schema version, when SHOW CONFIG projects it. */
+  schemaVersion?: number;
 }
 
-export interface SettingsSection {
-  /** Stable identifier used as the active-section key (component state only). */
+export interface SettingsPane {
+  /** Stable identifier used as the active-pane key (component state only). */
   id: string;
   /** Nav label. */
   label: string;
@@ -42,119 +34,88 @@ export interface SettingsSection {
   blurb: string;
   /** Icon name resolved to a lucide component in `SettingsView`. */
   icon: string;
-  /** Curated config keys, rendered top-to-bottom. One-line edit to extend. */
-  keys: string[];
 }
 
-/**
- * The curated sections. Each `keys` entry is a flattened reddb config path
- * (see `flattenConfig`) sourced from `/stats`, `/cluster/status`,
- * `/capabilities`, or the session (`whoami`). Order is the render order.
- */
-export const SECTIONS: SettingsSection[] = [
+export const SETTINGS_PANES: SettingsPane[] = [
   {
-    id: "overview",
-    label: "Overview",
-    blurb: "What this reddb instance is and where it runs.",
+    id: "config",
+    label: "Config",
+    blurb: "Live non-secret configuration from SHOW CONFIG.",
     icon: "settings",
-    keys: [
-      "deployment.mode",
-      "read_only",
-      "system.os",
-      "system.arch",
-      "system.hostname",
-      "system.cpu_cores",
-    ],
-  },
-  {
-    id: "storage",
-    label: "Storage",
-    blurb: "Live store footprint for the active connection.",
-    icon: "database",
-    keys: [
-      "store.collection_count",
-      "store.total_entities",
-      "store.cross_ref_count",
-      "store.total_memory_bytes",
-    ],
-  },
-  {
-    id: "cluster",
-    label: "Cluster",
-    blurb: "Deployment and replication topology.",
-    icon: "network",
-    keys: [
-      "deployment.mode",
-      "deployment.file_path",
-      "replication.replica_count",
-      "replication.lag_ms",
-    ],
-  },
-  {
-    id: "capabilities",
-    label: "Capabilities",
-    blurb: "Endpoints negotiated for this server version.",
-    icon: "plug",
-    keys: [
-      "capabilities.vcs",
-      "capabilities.clusterStatus",
-      "capabilities.collectionMetadata",
-      "capabilities.cdcStream",
-    ],
-  },
-  {
-    id: "session",
-    label: "Session",
-    blurb: "Who red-ui is authenticated as on this connection.",
-    icon: "shield",
-    keys: ["session.username", "session.role", "session.authenticated"],
   },
 ];
 
 /** Curated label overrides, keyed by config path. */
 export const LABELS: Record<string, string> = {
-  "deployment.mode": "Deployment mode",
-  "deployment.file_path": "Backing file",
-  read_only: "Read-only",
-  "system.os": "Operating system",
-  "system.arch": "Architecture",
-  "system.hostname": "Hostname",
-  "system.cpu_cores": "CPU cores",
-  "store.collection_count": "Collections",
-  "store.total_entities": "Entities",
-  "store.cross_ref_count": "Cross-references",
-  "store.total_memory_bytes": "Memory in use",
-  "replication.replica_count": "Replicas",
-  "replication.lag_ms": "Replication lag",
-  "capabilities.vcs": "Version control",
-  "capabilities.clusterStatus": "Cluster status",
-  "capabilities.collectionMetadata": "Collection metadata",
-  "capabilities.cdcStream": "Change stream",
-  "session.username": "Username",
-  "session.role": "Role",
-  "session.authenticated": "Authenticated",
+  "durability.mode": "Durability mode",
+  "concurrency.locking.enabled": "Locking",
+  "cache.blob.l1_bytes_max": "Blob L1 cache",
+  "cache.blob.l2_bytes_max": "Blob L2 cache",
+  "red.auth.enabled": "Authentication",
+  "red.auth.require_auth": "Require authentication",
+  "red.auth.session_ttl_secs": "Session TTL",
+  "red.backup.backend": "Backup backend",
+  "red.backup.enabled": "Backups",
+  "red.backup.interval_secs": "Backup interval",
+  "red.cdc.enabled": "Change data capture",
+  "red.config.secret.auto_decrypt": "Auto-decrypt config secrets",
+  "red.config.secret.auto_encrypt": "Auto-encrypt config secrets",
+  "red.server.max_body_size": "Max request body",
+  "red.server.max_scan_limit": "Max scan limit",
+  "red.server.read_timeout_ms": "Read timeout",
+  "red.server.write_timeout_ms": "Write timeout",
+  "red.storage.page_size": "Page size",
+  "red.storage.page_cache_capacity": "Page cache capacity",
+  "red.storage.verify_checksums": "Verify checksums",
+  "red.system.os": "Operating system",
+  "red.system.arch": "Architecture",
+  "red.system.hostname": "Hostname",
+  "red.system.cpu_cores": "CPU cores",
+  "red.system.total_memory_bytes": "System memory",
+  "red.vcs.default_branch": "Default branch",
+  "red.vcs.protected_branches": "Protected branches",
+  "runtime.result_cache.backend": "Result cache backend",
+  "runtime.result_cache.enabled": "Result cache",
+  "storage.bgwriter.delay_ms": "Background writer delay",
+  "storage.btree.lehman_yao": "Lehman-Yao B-tree",
+  "storage.wal.max_interval_ms": "WAL max interval",
+  "system.bootstrap.completed": "Bootstrap completed",
+  "system.bootstrap.preset": "Bootstrap preset",
 };
 
 /** Curated descriptions, keyed by config path. */
 export const DESCRIPTIONS: Record<string, string> = {
-  "deployment.mode": "How this reddb instance is running.",
-  "deployment.file_path": "On-disk store path for an embedded or local server.",
-  read_only: "Whether the store rejects writes (a lock or a replica role).",
-  "store.total_memory_bytes": "Resident memory the store currently holds.",
-  "replication.lag_ms": "How far this replica trails the primary, in ms.",
-  "capabilities.vcs": "Commit and diff endpoints — gated when unsupported.",
-  "capabilities.cdcStream": "Server-sent change stream over /changes/stream.",
-  "session.role": "The role granted to this principal on the active target.",
+  "durability.mode": "Write durability policy currently reported by reddb.",
+  "red.auth.enabled":
+    "Whether reddb authentication is enabled for this instance.",
+  "red.auth.require_auth": "Whether unauthenticated requests are rejected.",
+  "red.backup.backend": "The selected backup storage backend.",
+  "red.backup.enabled": "Whether scheduled backups are enabled.",
+  "red.cdc.enabled": "Whether the change stream subsystem is enabled.",
+  "red.server.max_body_size":
+    "Maximum accepted HTTP request body size, in bytes.",
+  "red.server.max_scan_limit": "Default cap for scan-heavy API paths.",
+  "red.storage.page_size": "On-disk page size used by the storage engine.",
+  "red.storage.verify_checksums":
+    "Whether page checksums are verified on read.",
+  "red.vcs.default_branch":
+    "Branch name used when VCS features need a default.",
+  "red.vcs.protected_branches":
+    "Branches protected from destructive operations.",
+  "runtime.result_cache.enabled": "Whether query result caching is enabled.",
+  "system.bootstrap.preset": "The bootstrap profile that initialized defaults.",
 };
 
 /** Curated enum options, keyed by config path. Presence ⇒ `kind: "enum"`. */
 export const ENUM_OPTIONS: Record<string, readonly string[]> = {
-  "deployment.mode": ["embedded", "server", "docker", "replicated"],
+  "durability.mode": ["sync", "async", "none"],
+  "red.backup.backend": ["local", "s3", "gcs"],
+  "runtime.result_cache.backend": ["legacy", "blob_cache"],
 };
 
 /**
  * Turn a config path into a human label when nobody curated one:
- * `store.total_memory_bytes` → "Total memory bytes". Uses the last path
+ * `store.total_memory_bytes` becomes "Total memory bytes". Uses the last path
  * segment, swaps `_`/`-` for spaces, and sentence-cases the result.
  */
 export function humanizeKey(key: string): string {
@@ -164,104 +125,71 @@ export function humanizeKey(key: string): string {
   return words.charAt(0).toUpperCase() + words.slice(1);
 }
 
-/**
- * Resolve a config key (and its live value) to a rendered control descriptor.
- *
- * Resolution order, each degrading gracefully:
- *  - label: `LABELS[key]` → `humanizeKey(key)`
- *  - description: `DESCRIPTIONS[key]` → omitted
- *  - kind: `ENUM_OPTIONS[key]` ⇒ `"enum"`; else inferred from the value's
- *    runtime type (boolean / number) → `"text"` for everything else, including
- *    `undefined`. So an unknown key with no value still yields a valid `"text"`
- *    descriptor rather than throwing.
- */
-export function resolveControl(
-  key: string,
-  value?: unknown
-): ControlDescriptor {
-  const options = ENUM_OPTIONS[key];
+function kindFromValueType(
+  valueType: ConfigValueType | undefined
+): ControlKind | null {
+  switch (valueType) {
+    case "bool":
+    case "boolean":
+      return "boolean";
+    case "int":
+    case "integer":
+    case "float":
+    case "number":
+    case "count":
+      return "number";
+    case "array":
+    case "list":
+      return "list";
+    case "object":
+    case "string":
+    case "text":
+    case "url":
+      return "text";
+    default:
+      return null;
+  }
+}
+
+function kindFromRuntimeValue(value: unknown): ControlKind {
+  if (typeof value === "boolean") return "boolean";
+  if (typeof value === "number") return "number";
+  if (Array.isArray(value)) return "list";
+  return "text";
+}
+
+export function resolveConfigControl(entry: ConfigEntry): ControlDescriptor {
+  const options = ENUM_OPTIONS[entry.key];
   const kind: ControlKind = options
     ? "enum"
-    : typeof value === "boolean"
-      ? "boolean"
-      : typeof value === "number"
-        ? "number"
-        : "text";
+    : (kindFromValueType(entry.valueType) ?? kindFromRuntimeValue(entry.value));
   const descriptor: ControlDescriptor = {
-    key,
-    label: LABELS[key] ?? humanizeKey(key),
+    key: entry.key,
+    label: LABELS[entry.key] ?? humanizeKey(entry.key),
     kind,
   };
-  const description = DESCRIPTIONS[key];
+  const description = DESCRIPTIONS[entry.key];
   if (description) descriptor.description = description;
   if (options) descriptor.options = options;
+  if (entry.valueType) descriptor.valueType = entry.valueType;
+  if (entry.schemaVersion !== undefined)
+    descriptor.schemaVersion = entry.schemaVersion;
   return descriptor;
 }
 
-/** Which live source a config key is read from — drives permission-awareness. */
-export function sourceForKey(key: string): SettingsSource {
-  if (key.startsWith("capabilities.")) return "capabilities";
-  if (key.startsWith("session.")) return "session";
-  if (
-    key.startsWith("deployment.") ||
-    key.startsWith("storage.") ||
-    key.startsWith("wal.") ||
-    key.startsWith("throughput.") ||
-    key.startsWith("replication.")
-  ) {
-    return "cluster";
-  }
-  return "stats";
+export function resolvePane(id: string | null): SettingsPane {
+  return SETTINGS_PANES.find((pane) => pane.id === id) ?? SETTINGS_PANES[0];
 }
 
-/**
- * Flatten a nested config snapshot into dotted leaf paths. Nested plain objects
- * recurse (`{ store: { collection_count: 3 } }` → `"store.collection_count"`);
- * arrays and primitives are kept as leaf values. `undefined`/`null` branches
- * are skipped so a server that omits a sub-tree simply yields no keys for it.
- */
-export function flattenConfig(
-  input: Record<string, unknown>
-): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
-  const walk = (obj: Record<string, unknown>, prefix: string) => {
-    for (const [k, v] of Object.entries(obj)) {
-      const key = prefix ? `${prefix}.${k}` : k;
-      if (v === undefined || v === null) continue;
-      if (typeof v === "object" && !Array.isArray(v)) {
-        walk(v as Record<string, unknown>, key);
-      } else {
-        out[key] = v;
-      }
-    }
-  };
-  walk(input, "");
-  return out;
-}
-
-/**
- * Resolve a section by id, falling back to the first section when the id is
- * unknown or null. The settings view drives the active section purely from
- * component state, so this never touches the URL.
- */
-export function resolveSection(id: string | null): SettingsSection {
-  return SECTIONS.find((s) => s.id === id) ?? SECTIONS[0];
-}
-
-/**
- * Filter a section's curated keys by a free-text query, matching against both
- * the config path AND the resolved human label (case-insensitive). An empty or
- * whitespace-only query returns the keys unchanged. Pure + framework-free so
- * the settings search is unit-testable without rendering. The settings view
- * keeps one query string per section id, so switching sections preserves each
- * section's typed query.
- */
-export function filterKeys(keys: readonly string[], query: string): string[] {
+export function filterConfigEntries(
+  entries: readonly ConfigEntry[],
+  query: string
+): ConfigEntry[] {
   const q = query.trim().toLowerCase();
-  if (!q) return [...keys];
-  return keys.filter(
-    (key) =>
-      key.toLowerCase().includes(q) ||
-      resolveControl(key).label.toLowerCase().includes(q)
+  if (!q) return [...entries];
+  return entries.filter(
+    (entry) =>
+      entry.key.toLowerCase().includes(q) ||
+      resolveConfigControl(entry).label.toLowerCase().includes(q)
   );
 }


### PR DESCRIPTION
Closes #84

Implements the Settings three-pane shell for the Config pane, backed by SHOW CONFIG through RedClient.query().

Verification from the AFK worktree:
- pnpm --filter @reddb-io/ui exec svelte-check --tsconfig ./tsconfig.json
- pnpm --filter @reddb-io/ui exec vitest run src/lib/settings-authoring-client.test.ts src/lib/settings-sections.test.ts
- pnpm --filter @reddb-io/ui test: 41 files, 420 tests
- pnpm --filter @reddb-io/ui build
- Live SHOW CONFIG against http://localhost:15055 returned columns ["key","value"], statement show_config, engine runtime-config, record_count 109.

Note: scripts/seed.sh created available seed data, then failed its final optional fixture verification because ../case-grimm/input/3-gold is absent in this checkout; post-seed SHOW CONFIG was still verified.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783132450&installation_id=129708444&pr_number=97&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F97&signature=72d21f693a7993dc10bd68047c0c9e68b1fea11114136c27a233206434a8e82b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned Settings interface with organized panes displaying live configuration item counts.
  * JSON export now includes enhanced metadata such as value types and schema information.
  * Improved search and filtering capabilities for configuration entries.

* **Improvements**
  * Better display and handling of configuration value types and schema metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->