### PR TITLE
Settings: gate panes by auth grants

### DIFF
--- a/packages/ui/src/lib/SettingsView.svelte
+++ b/packages/ui/src/lib/SettingsView.svelte
@@ -8,6 +8,7 @@
     RefreshCw,
     Search,
     Settings2,
+    ShieldOff,
     SlidersHorizontal,
     Unplug,
     type Icon,
@@ -16,13 +17,16 @@
   import EmptyState from '$lib/EmptyState.svelte'
   import { activity } from '$lib/activity.svelte'
   import { connection } from '$lib/connections.svelte'
+  import { PermissionGate } from '$lib/permission-gate'
   import { SettingsAuthoringClient, type ConfigEntry } from '$lib/settings-authoring-client'
   import {
     SETTINGS_PANES,
     filterConfigEntries,
+    filterSettingsPanesByGrant,
     resolveConfigControl,
     resolvePane,
     type ControlDescriptor,
+    type SettingsPane,
   } from '$lib/settings-sections'
 
   const icons: Record<string, typeof Icon> = {
@@ -30,11 +34,18 @@
   }
 
   let activePaneId = $state(SETTINGS_PANES[0].id)
-  const activePane = $derived(resolvePane(activePaneId))
+  let visiblePanes = $state<SettingsPane[]>([])
+  let permissions = $state<PermissionGate | null>(null)
+  let permissionsLoading = $state(false)
+  let permissionError = $state<string | null>(null)
+  let permissionRun = 0
+
+  const hasVisiblePane = $derived(visiblePanes.length > 0)
+  const activePane = $derived(resolvePane(activePaneId, visiblePanes))
 
   let queries = $state<Record<string, string>>({})
   let searchEl = $state<HTMLInputElement | null>(null)
-  const query = $derived(queries[activePaneId] ?? '')
+  const query = $derived(hasVisiblePane ? (queries[activePane.id] ?? '') : '')
 
   let entries = $state<ConfigEntry[]>([])
   let selectedKey = $state<string | null>(null)
@@ -53,7 +64,8 @@
   )
 
   function setQuery(value: string) {
-    queries = { ...queries, [activePaneId]: value }
+    if (!hasVisiblePane) return
+    queries = { ...queries, [activePane.id]: value }
   }
 
   function onWindowKey(e: KeyboardEvent) {
@@ -64,9 +76,55 @@
     }
   }
 
+  async function refreshPermissions() {
+    const client = connection.client
+    const run = ++permissionRun
+    permissions = null
+    visiblePanes = []
+    permissionError = null
+    entries = []
+    selectedKey = null
+
+    if (!client || !connected) {
+      permissionsLoading = false
+      return
+    }
+
+    permissionsLoading = true
+    const gate = new PermissionGate(client)
+    try {
+      await activity.track('settings · auth.can panes', () =>
+        gate.preload(SETTINGS_PANES.map((pane) => pane.readGrant)),
+      )
+      if (run !== permissionRun) return
+
+      permissions = gate
+      const nextPanes = filterSettingsPanesByGrant(SETTINGS_PANES, gate)
+      visiblePanes = nextPanes
+      if (nextPanes.length > 0 && !nextPanes.some((pane) => pane.id === activePaneId)) {
+        activePaneId = nextPanes[0].id
+      }
+    } catch (e) {
+      if (run !== permissionRun) return
+      visiblePanes = []
+      permissions = null
+      permissionError = (e as Error).message
+    } finally {
+      if (run === permissionRun) permissionsLoading = false
+    }
+  }
+
   async function refresh() {
     const client = connection.client
-    if (!client || !connected) {
+    const gate = permissions
+    if (
+      !client ||
+      !connected ||
+      !gate ||
+      !hasVisiblePane ||
+      !gate.cachedCan(activePane.readGrant) ||
+      activePane.id !== 'config'
+    ) {
       entries = []
       selectedKey = null
       loadError = null
@@ -96,6 +154,15 @@
   $effect(() => {
     void activeUrl
     void connected
+    refreshPermissions()
+  })
+
+  $effect(() => {
+    void activeUrl
+    void connected
+    void activePaneId
+    void permissions
+    void visiblePanes
     refresh()
   })
 
@@ -148,6 +215,10 @@
     a.click()
     URL.revokeObjectURL(url)
   }
+
+  function paneCount(pane: SettingsPane): number {
+    return pane.id === 'config' ? entries.length : 0
+  }
 </script>
 
 <svelte:window onkeydown={onWindowKey} />
@@ -164,7 +235,7 @@
         <div class="mt-1 text-[13px] text-fg-1">Governance surface</div>
       </div>
       <nav class="grid gap-0.5 p-2">
-        {#each SETTINGS_PANES as pane (pane.id)}
+        {#each visiblePanes as pane (pane.id)}
           {@const PaneIcon = icons[pane.icon] ?? Settings2}
           <NavItem
             label={pane.label}
@@ -172,12 +243,18 @@
             onclick={() => (activePaneId = pane.id)}
           >
             {#snippet icon()}<PaneIcon class="size-3.5" />{/snippet}
-            {#snippet trailing()}<Pill>{entries.length}</Pill>{/snippet}
+            {#snippet trailing()}<Pill>{paneCount(pane)}</Pill>{/snippet}
           </NavItem>
         {/each}
       </nav>
       <div class="mt-auto border-t border-line-1 px-3 py-2.5 text-[11px] text-fg-3">
-        <span class="font-mono text-fg-2">{entries.length}</span> live keys
+        {#if permissionsLoading}
+          checking grants
+        {:else if hasVisiblePane}
+          <span class="font-mono text-fg-2">{entries.length}</span> live keys
+        {:else}
+          no readable panes
+        {/if}
       </div>
     </aside>
 
@@ -195,7 +272,7 @@
             type="text"
             placeholder="Search config  ⌘K"
             value={query}
-            disabled={unreachable}
+            disabled={permissionsLoading || !hasVisiblePane || unreachable}
             oninput={(e) => setQuery(e.currentTarget.value)}
             onkeydown={(e) => {
               if (e.key === 'Escape') {
@@ -209,7 +286,22 @@
       </div>
 
       <div class="min-h-0 flex-1 overflow-y-auto">
-        {#if unreachable}
+        {#if permissionsLoading}
+          <div class="grid gap-1 p-2">
+            {#each Array(4) as _, i (i)}
+              <div class="h-12 rounded-md bg-bg-2 motion-safe:animate-pulse"></div>
+            {/each}
+          </div>
+        {:else if !hasVisiblePane}
+          <EmptyState
+            icon={ShieldOff}
+            title={connected ? 'No readable settings panes' : 'No active connection'}
+            message={connected
+              ? 'The current principal has no Settings read grant.'
+              : 'Connect to a reddb instance to inspect its live configuration.'}
+            hint={permissionError ?? (connected ? 'auth.can denied settings reads' : 'red serve')}
+          />
+        {:else if unreachable}
           <EmptyState
             icon={Unplug}
             title={connected ? 'Config is unreachable' : 'No active connection'}
@@ -301,21 +393,44 @@
         <button
           type="button"
           onclick={exportConfig}
-          disabled={loading || entries.length === 0}
+          disabled={permissionsLoading || !hasVisiblePane || loading || entries.length === 0}
           class="inline-flex h-7 items-center justify-center gap-1.5 rounded-md border border-line-2 bg-bg-2 px-2.5 text-[11px] font-mono text-fg-1 transition-colors hover:border-line-3 hover:text-fg-0 disabled:cursor-not-allowed disabled:opacity-40"
         >
           <Download class="size-3.5" />
           export config
         </button>
         <div class="truncate text-[11px] text-fg-3">
-          Live from <span class="font-mono text-fg-2">{activeUrl}</span>.
+          {#if hasVisiblePane}
+            Live from <span class="font-mono text-fg-2">{activeUrl}</span>.
+          {:else}
+            Requires a Settings read grant.
+          {/if}
         </div>
       </div>
     </section>
 
     <main class="min-h-0 min-w-0 overflow-auto bg-bg-0">
       <div class="p-6">
-        <PageHeader eyebrow="Settings" title={activePane.label} subtitle={activePane.blurb}>
+        {#if permissionsLoading}
+          <PageHeader eyebrow="Settings" title="Settings" subtitle="Checking Settings grants." />
+          <EmptyState
+            icon={ShieldOff}
+            title="Checking settings grants"
+            message="red-ui is asking reddb which Settings panes this principal can read."
+            hint="POST /auth/can"
+          />
+        {:else if !hasVisiblePane}
+          <PageHeader eyebrow="Settings" title="Settings" subtitle="No readable governance surface." />
+          <EmptyState
+            icon={ShieldOff}
+            title={connected ? 'No readable settings panes' : 'No active connection'}
+            message={connected
+              ? 'Missing Settings read grant for this principal.'
+              : 'Start or select a reddb target, then return here to inspect live config.'}
+            hint={permissionError ?? (connected ? 'missing Settings read grant' : 'docker compose -f docker/compose.yml up -d')}
+          />
+        {:else}
+          <PageHeader eyebrow="Settings" title={activePane.label} subtitle={activePane.blurb}>
           {#snippet actions()}
             <button
               type="button"
@@ -327,9 +442,9 @@
               refresh
             </button>
           {/snippet}
-        </PageHeader>
+          </PageHeader>
 
-        {#if unreachable}
+          {#if unreachable}
           <EmptyState
             icon={Unplug}
             title={connected ? 'Unable to read config' : 'No active connection'}
@@ -338,13 +453,13 @@
               : 'Start or select a reddb target, then return here to inspect live config.'}
             hint={connected ? loadError ?? activeUrl : 'docker compose -f docker/compose.yml up -d'}
           />
-        {:else if !selectedEntry || !selectedControl}
+          {:else if !selectedEntry || !selectedControl}
           <EmptyState
             icon={FileJson}
             title="No config entry selected"
             message="Select a live SHOW CONFIG row to inspect its read-only control."
           />
-        {:else}
+          {:else}
           <section>
             <SectionHeading title={selectedControl.label} class="mb-2">
               {#snippet icon()}<SlidersHorizontal class="size-3.5" />{/snippet}
@@ -422,6 +537,7 @@
               </ListRow>
             </div>
           </section>
+          {/if}
         {/if}
       </div>
     </main>

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -36,6 +36,7 @@ export * from "./collection-pages";
 export * from "./router.svelte";
 export * from "./settings-sections";
 export * from "./settings-authoring-client";
+export * from "./permission-gate";
 export * from "./cn";
 export * from "./connections.svelte";
 export * from "./shortcuts";

--- a/packages/ui/src/lib/permission-gate.test.ts
+++ b/packages/ui/src/lib/permission-gate.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  PermissionGate,
+  type PermissionCheck,
+  type PermissionDecision,
+  type PermissionTransport,
+} from "./permission-gate";
+
+const configRead: PermissionCheck = {
+  action: "config:read",
+  resource: { kind: "config", name: "*" },
+};
+
+function fakeTransport(
+  decide: (check: PermissionCheck) => boolean
+): PermissionTransport & { calls: PermissionCheck[][] } {
+  const calls: PermissionCheck[][] = [];
+  return {
+    calls,
+    async authCan(checks) {
+      calls.push(checks);
+      return checks.map(
+        (check): PermissionDecision => ({
+          ...check,
+          allowed: decide(check),
+          reason: decide(check) ? "allowed by test" : "default deny",
+        })
+      );
+    },
+  };
+}
+
+describe("PermissionGate", () => {
+  it("answers can(action, resource) from POST /auth/can decisions", async () => {
+    const transport = fakeTransport((check) => check.action === "config:read");
+    const gate = new PermissionGate(transport);
+
+    await expect(gate.can(configRead)).resolves.toBe(true);
+    await expect(
+      gate.can({
+        action: "config:write",
+        resource: { kind: "config", name: "*" },
+      })
+    ).resolves.toBe(false);
+  });
+
+  it("caches grant decisions by action and resource", async () => {
+    const transport = fakeTransport(() => true);
+    const gate = new PermissionGate(transport);
+
+    await expect(gate.can(configRead)).resolves.toBe(true);
+    await expect(gate.can(configRead)).resolves.toBe(true);
+
+    expect(transport.calls).toHaveLength(1);
+    expect(transport.calls[0]).toEqual([configRead]);
+  });
+
+  it("batches preload and exposes synchronous cached decisions for rendering", async () => {
+    const secretMetadata: PermissionCheck = {
+      action: "vault:read_metadata",
+      resource: { kind: "vault", name: "*" },
+    };
+    const transport = fakeTransport(
+      (check) => check.action !== "vault:read_metadata"
+    );
+    const gate = new PermissionGate(transport);
+
+    await gate.preload([configRead, secretMetadata, configRead]);
+
+    expect(transport.calls).toHaveLength(1);
+    expect(transport.calls[0]).toEqual([configRead, secretMetadata]);
+    expect(gate.cachedCan(configRead)).toBe(true);
+    expect(gate.cachedCan(secretMetadata)).toBe(false);
+    expect(gate.cachedDecision(secretMetadata)?.reason).toBe("default deny");
+  });
+
+  it("fails closed and caches denial when auth.can transport fails", async () => {
+    const calls: PermissionCheck[][] = [];
+    const gate = new PermissionGate({
+      async authCan(checks) {
+        calls.push(checks);
+        throw new Error("POST /auth/can unavailable");
+      },
+    });
+
+    await expect(gate.can(configRead)).resolves.toBe(false);
+    await expect(gate.can(configRead)).resolves.toBe(false);
+
+    expect(calls).toHaveLength(1);
+    expect(gate.cachedDecision(configRead)?.reason).toBe(
+      "POST /auth/can unavailable"
+    );
+  });
+});

--- a/packages/ui/src/lib/permission-gate.ts
+++ b/packages/ui/src/lib/permission-gate.ts
@@ -1,0 +1,120 @@
+export interface PermissionResource {
+  kind: string;
+  name: string;
+  tenant?: string;
+}
+
+export interface PermissionCheck {
+  action: string;
+  resource: PermissionResource;
+  current_tenant?: string;
+}
+
+export interface PermissionDecision extends PermissionCheck {
+  allowed: boolean;
+  reason?: string;
+}
+
+export interface PermissionTransport {
+  authCan(checks: PermissionCheck[]): Promise<PermissionDecision[]>;
+}
+
+function keyFor(check: PermissionCheck): string {
+  const tenant = check.resource.tenant ?? "";
+  const currentTenant = check.current_tenant ?? "";
+  return [
+    check.action,
+    check.resource.kind,
+    check.resource.name,
+    tenant,
+    currentTenant,
+  ].join("\u001f");
+}
+
+function deny(check: PermissionCheck, reason: string): PermissionDecision {
+  return { ...check, allowed: false, reason };
+}
+
+export class PermissionGate {
+  readonly #transport: PermissionTransport;
+  readonly #cache = new Map<string, PermissionDecision>();
+  readonly #inFlight = new Map<string, Promise<PermissionDecision>>();
+
+  constructor(transport: PermissionTransport) {
+    this.#transport = transport;
+  }
+
+  cachedDecision(check: PermissionCheck): PermissionDecision | null {
+    return this.#cache.get(keyFor(check)) ?? null;
+  }
+
+  cachedCan(check: PermissionCheck): boolean {
+    return this.cachedDecision(check)?.allowed === true;
+  }
+
+  async decision(check: PermissionCheck): Promise<PermissionDecision> {
+    await this.preload([check]);
+    return (
+      this.cachedDecision(check) ??
+      deny(check, "auth.can did not return a decision")
+    );
+  }
+
+  async can(check: PermissionCheck): Promise<boolean> {
+    return (await this.decision(check)).allowed;
+  }
+
+  async preload(checks: readonly PermissionCheck[]): Promise<void> {
+    const missing = checks.filter((check) => !this.#cache.has(keyFor(check)));
+    if (missing.length === 0) return;
+
+    const unique = new Map<string, PermissionCheck>();
+    for (const check of missing) {
+      const key = keyFor(check);
+      if (!this.#inFlight.has(key)) unique.set(key, check);
+    }
+
+    if (unique.size > 0) {
+      const batch = [...unique.values()];
+      const batchPromise = this.#transport
+        .authCan(batch)
+        .then((results) => {
+          const byKey = new Map(
+            results.map((result) => [keyFor(result), result] as const)
+          );
+          for (const check of batch) {
+            const key = keyFor(check);
+            this.#cache.set(
+              key,
+              byKey.get(key) ?? deny(check, "auth.can omitted this check")
+            );
+          }
+        })
+        .catch((e) => {
+          const reason = (e as Error).message || "auth.can failed";
+          for (const check of batch) {
+            this.#cache.set(keyFor(check), deny(check, reason));
+          }
+        })
+        .finally(() => {
+          for (const check of batch) this.#inFlight.delete(keyFor(check));
+        });
+
+      for (const check of batch) {
+        const key = keyFor(check);
+        this.#inFlight.set(
+          key,
+          batchPromise.then(
+            () =>
+              this.#cache.get(key) ??
+              deny(check, "auth.can did not return a decision")
+          )
+        );
+      }
+    }
+
+    await Promise.all(
+      missing.map((check) => this.#inFlight.get(keyFor(check)))
+    );
+  }
+}

--- a/packages/ui/src/lib/reddb/client.test.ts
+++ b/packages/ui/src/lib/reddb/client.test.ts
@@ -129,4 +129,59 @@ describe("RedClient collection metadata probing", () => {
       })
     );
   });
+
+  it("posts auth.can checks using the server batch envelope", async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) =>
+        Response.json({
+          ok: true,
+          results: [
+            {
+              allowed: true,
+              reason: "allow at p1.statement[0]",
+              action: "config:read",
+              resource: { kind: "config", name: "*" },
+            },
+            {
+              allowed: false,
+              reason: "no statement matched (default deny)",
+              action: "vault:read_metadata",
+              resource: { kind: "vault", name: "*" },
+            },
+          ],
+        })
+    );
+    const client = new RedClient("http://reddb.test", {
+      fetch: fetchMock as typeof fetch,
+    });
+    const checks = [
+      { action: "config:read", resource: { kind: "config", name: "*" } },
+      {
+        action: "vault:read_metadata",
+        resource: { kind: "vault", name: "*" },
+      },
+    ];
+
+    await expect(client.authCan(checks)).resolves.toEqual([
+      {
+        action: "config:read",
+        resource: { kind: "config", name: "*" },
+        allowed: true,
+        reason: "allow at p1.statement[0]",
+      },
+      {
+        action: "vault:read_metadata",
+        resource: { kind: "vault", name: "*" },
+        allowed: false,
+        reason: "no statement matched (default deny)",
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://reddb.test/auth/can",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ checks }),
+      })
+    );
+  });
 });

--- a/packages/ui/src/lib/reddb/client.ts
+++ b/packages/ui/src/lib/reddb/client.ts
@@ -7,6 +7,11 @@ import {
   type RawCapabilities,
   type ServerCapabilities,
 } from "./server-capabilities";
+import type {
+  PermissionCheck,
+  PermissionDecision,
+  PermissionResource,
+} from "../permission-gate";
 
 export interface QueryRow {
   values: Record<string, unknown>;
@@ -199,6 +204,12 @@ export interface AuthPolicy {
   created_at?: number;
 }
 
+interface AuthCanResponse {
+  ok?: boolean;
+  results?: Array<Partial<PermissionDecision>>;
+  error?: string;
+}
+
 export interface ChangeEvent {
   lsn: number;
   timestamp: number;
@@ -277,6 +288,18 @@ function isUnsupportedRoute(e: unknown): boolean {
 function unsupportedCollectionMetadataError(baseUrl: string): Error {
   return new Error(
     `GET /collections/:name unsupported by this reddb server (${baseUrl})`
+  );
+}
+
+function isPermissionResource(value: unknown): value is PermissionResource {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<PermissionResource>;
+  return (
+    typeof candidate.kind === "string" &&
+    candidate.kind.length > 0 &&
+    typeof candidate.name === "string" &&
+    candidate.name.length > 0 &&
+    (candidate.tenant === undefined || typeof candidate.tenant === "string")
   );
 }
 
@@ -673,6 +696,33 @@ export class RedClient {
       "/auth/policies"
     );
     return r.policies ?? [];
+  }
+
+  async authCan(checks: PermissionCheck[]): Promise<PermissionDecision[]> {
+    const r = await this.json<AuthCanResponse>("/auth/can", {
+      method: "POST",
+      body: JSON.stringify({ checks }),
+    });
+    if (!Array.isArray(r.results)) {
+      throw new Error(r.error ?? "POST /auth/can returned no results");
+    }
+    return checks.map((check, index) => {
+      const result = r.results?.[index] ?? {};
+      const resource = isPermissionResource(result.resource)
+        ? result.resource
+        : check.resource;
+      return {
+        action:
+          typeof result.action === "string" ? result.action : check.action,
+        resource,
+        current_tenant:
+          typeof result.current_tenant === "string"
+            ? result.current_tenant
+            : check.current_tenant,
+        allowed: result.allowed === true,
+        reason: typeof result.reason === "string" ? result.reason : undefined,
+      };
+    });
   }
 
   async changes(

--- a/packages/ui/src/lib/settings-sections.test.ts
+++ b/packages/ui/src/lib/settings-sections.test.ts
@@ -4,6 +4,7 @@ import {
   ENUM_OPTIONS,
   SETTINGS_PANES,
   filterConfigEntries,
+  filterSettingsPanesByGrant,
   humanizeKey,
   resolveConfigControl,
   resolvePane,
@@ -18,6 +19,9 @@ describe("settings panes registry", () => {
       expect(pane.label).not.toBe("");
       expect(pane.blurb).not.toBe("");
       expect(pane.icon).not.toBe("");
+      expect(pane.readGrant.action).not.toBe("");
+      expect(pane.readGrant.resource.kind).not.toBe("");
+      expect(pane.readGrant.resource.name).not.toBe("");
     }
   });
 
@@ -25,6 +29,19 @@ describe("settings panes registry", () => {
     expect(resolvePane("config")).toBe(SETTINGS_PANES[0]);
     expect(resolvePane("missing")).toBe(SETTINGS_PANES[0]);
     expect(resolvePane(null)).toBe(SETTINGS_PANES[0]);
+  });
+
+  it("filters panes by cached read grants", () => {
+    expect(
+      filterSettingsPanesByGrant(SETTINGS_PANES, { cachedCan: () => true }).map(
+        (pane) => pane.id
+      )
+    ).toEqual(["config"]);
+    expect(
+      filterSettingsPanesByGrant(SETTINGS_PANES, {
+        cachedCan: (check) => check.action !== "config:read",
+      })
+    ).toEqual([]);
   });
 });
 

--- a/packages/ui/src/lib/settings-sections.ts
+++ b/packages/ui/src/lib/settings-sections.ts
@@ -3,6 +3,7 @@
 // until they have live backing data, keeping the surface "live or empty" rather
 // than rendering placeholders.
 import type { ConfigEntry, ConfigValueType } from "./settings-authoring-client";
+import type { PermissionCheck } from "./permission-gate";
 
 /** The read-only control a config value is rendered through. */
 export type ControlKind = "text" | "number" | "boolean" | "enum" | "list";
@@ -34,6 +35,8 @@ export interface SettingsPane {
   blurb: string;
   /** Icon name resolved to a lucide component in `SettingsView`. */
   icon: string;
+  /** Pane-level grant that must be allowed before this pane is rendered. */
+  readGrant: PermissionCheck;
 }
 
 export const SETTINGS_PANES: SettingsPane[] = [
@@ -42,6 +45,10 @@ export const SETTINGS_PANES: SettingsPane[] = [
     label: "Config",
     blurb: "Live non-secret configuration from SHOW CONFIG.",
     icon: "settings",
+    readGrant: {
+      action: "config:read",
+      resource: { kind: "config", name: "*" },
+    },
   },
 ];
 
@@ -177,8 +184,18 @@ export function resolveConfigControl(entry: ConfigEntry): ControlDescriptor {
   return descriptor;
 }
 
-export function resolvePane(id: string | null): SettingsPane {
-  return SETTINGS_PANES.find((pane) => pane.id === id) ?? SETTINGS_PANES[0];
+export function resolvePane(
+  id: string | null,
+  panes: readonly SettingsPane[] = SETTINGS_PANES
+): SettingsPane {
+  return panes.find((pane) => pane.id === id) ?? panes[0] ?? SETTINGS_PANES[0];
+}
+
+export function filterSettingsPanesByGrant(
+  panes: readonly SettingsPane[],
+  gate: { cachedCan(check: PermissionCheck): boolean }
+): SettingsPane[] {
+  return panes.filter((pane) => gate.cachedCan(pane.readGrant));
 }
 
 export function filterConfigEntries(


### PR DESCRIPTION
Closes #85

Implements the Settings permission gate over POST /auth/can.

Verification from the AFK worktree:
- pnpm --filter @reddb-io/ui test -- permission-gate settings-sections reddb/client: 42 files, 426 tests passed
- pnpm --filter @reddb-io/ui exec svelte-check --tsconfig ./tsconfig.json: 0 errors, 0 warnings
- pnpm --filter @reddb-io/ui build: passed with existing large-chunk/sourcemap warnings only

Worker commit: 6bfe596b5bc83906daebe8e0bd82a375b0625037

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783168639&installation_id=129708444&pr_number=98&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F98&signature=2d24e3387a8a84184bec9883591a7e715bed49d0842b13b56324a24a686048dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Settings UI now respects user permissions—only settings panes you have access to are displayed
  * Permission checks are efficiently cached to improve performance
  * Clear messaging indicates when no settings are accessible due to permission restrictions
  * Export functionality now requires appropriate permission grants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->