### PR TITLE
Settings: add masked Secrets pane

### DIFF
--- a/packages/ui/src/lib/SettingsView.svelte
+++ b/packages/ui/src/lib/SettingsView.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-  // Settings surface: a bounded pane shell whose only real pane in this slice
-  // is Config. The list is populated by live SHOW CONFIG over RedClient.query().
+  // Settings surface: a bounded pane shell backed by live SQL introspection.
   import { ListRow, NavItem, Pill, SectionHeading } from '@reddb-io/ui-kit'
   import {
     Download,
     FileJson,
+    KeyRound,
+    Link2,
     RefreshCw,
     Search,
     Settings2,
@@ -18,18 +19,26 @@
   import { activity } from '$lib/activity.svelte'
   import { connection } from '$lib/connections.svelte'
   import { PermissionGate } from '$lib/permission-gate'
-  import { SettingsAuthoringClient, type ConfigEntry } from '$lib/settings-authoring-client'
+  import {
+    SettingsAuthoringClient,
+    type ConfigEntry,
+    type SecretEntry,
+    type SecretReference,
+  } from '$lib/settings-authoring-client'
   import {
     SETTINGS_PANES,
     filterConfigEntries,
+    filterSecretEntries,
     filterSettingsPanesByGrant,
     resolveConfigControl,
     resolvePane,
+    resolveSecretControl,
     type ControlDescriptor,
     type SettingsPane,
   } from '$lib/settings-sections'
 
   const icons: Record<string, typeof Icon> = {
+    key: KeyRound,
     settings: Settings2,
   }
 
@@ -47,20 +56,33 @@
   let searchEl = $state<HTMLInputElement | null>(null)
   const query = $derived(hasVisiblePane ? (queries[activePane.id] ?? '') : '')
 
-  let entries = $state<ConfigEntry[]>([])
-  let selectedKey = $state<string | null>(null)
+  let configEntries = $state<ConfigEntry[]>([])
+  let secretEntries = $state<SecretEntry[]>([])
+  let selectedConfigKey = $state<string | null>(null)
+  let selectedSecretKey = $state<string | null>(null)
   let loading = $state(false)
-  let loadError = $state<string | null>(null)
+  let configLoadError = $state<string | null>(null)
+  let secretsLoadError = $state<string | null>(null)
 
   const connected = $derived(connection.connected)
   const activeUrl = $derived(connection.active.url)
+  const loadError = $derived(activePane.id === 'secrets' ? secretsLoadError : configLoadError)
   const unreachable = $derived(!connected || loadError !== null)
-  const rows = $derived(filterConfigEntries(entries, query))
+  const configRows = $derived(filterConfigEntries(configEntries, query))
+  const secretRows = $derived(filterSecretEntries(secretEntries, query))
+  const activeRowCount = $derived(activePane.id === 'secrets' ? secretRows.length : configRows.length)
+  const activeTotalCount = $derived(activePane.id === 'secrets' ? secretEntries.length : configEntries.length)
   const selectedEntry = $derived(
-    rows.find((entry) => entry.key === selectedKey) ?? rows[0] ?? null,
+    configRows.find((entry) => entry.key === selectedConfigKey) ?? configRows[0] ?? null,
+  )
+  const selectedSecret = $derived(
+    secretRows.find((entry) => entry.key === selectedSecretKey) ?? secretRows[0] ?? null,
   )
   const selectedControl = $derived(
     selectedEntry ? resolveConfigControl(selectedEntry) : null,
+  )
+  const selectedSecretControl = $derived(
+    selectedSecret ? resolveSecretControl(selectedSecret) : null,
   )
 
   function setQuery(value: string) {
@@ -82,8 +104,10 @@
     permissions = null
     visiblePanes = []
     permissionError = null
-    entries = []
-    selectedKey = null
+    configEntries = []
+    secretEntries = []
+    selectedConfigKey = null
+    selectedSecretKey = null
 
     if (!client || !connected) {
       permissionsLoading = false
@@ -122,30 +146,52 @@
       !connected ||
       !gate ||
       !hasVisiblePane ||
-      !gate.cachedCan(activePane.readGrant) ||
-      activePane.id !== 'config'
+      !gate.cachedCan(activePane.readGrant)
     ) {
-      entries = []
-      selectedKey = null
-      loadError = null
+      configEntries = []
+      secretEntries = []
+      selectedConfigKey = null
+      selectedSecretKey = null
+      configLoadError = null
+      secretsLoadError = null
       return
     }
 
     loading = true
-    loadError = null
+    if (activePane.id === 'secrets') {
+      secretsLoadError = null
+    } else {
+      configLoadError = null
+    }
     try {
       const authoring = new SettingsAuthoringClient(client)
-      const next = await activity.track('settings · show config', () =>
-        authoring.showConfig(),
-      )
-      entries = next
-      if (!selectedKey || !next.some((entry) => entry.key === selectedKey)) {
-        selectedKey = next[0]?.key ?? null
+      if (activePane.id === 'secrets') {
+        const next = await activity.track('settings · show secrets', () =>
+          authoring.showSecrets(),
+        )
+        secretEntries = next
+        if (!selectedSecretKey || !next.some((entry) => entry.key === selectedSecretKey)) {
+          selectedSecretKey = next[0]?.key ?? null
+        }
+      } else {
+        const next = await activity.track('settings · show config', () =>
+          authoring.showConfig(),
+        )
+        configEntries = next
+        if (!selectedConfigKey || !next.some((entry) => entry.key === selectedConfigKey)) {
+          selectedConfigKey = next[0]?.key ?? null
+        }
       }
     } catch (e) {
-      entries = []
-      selectedKey = null
-      loadError = (e as Error).message
+      if (activePane.id === 'secrets') {
+        secretEntries = []
+        selectedSecretKey = null
+        secretsLoadError = (e as Error).message
+      } else {
+        configEntries = []
+        selectedConfigKey = null
+        configLoadError = (e as Error).message
+      }
     } finally {
       loading = false
     }
@@ -178,8 +224,18 @@
     return `${i === 0 ? value : value.toFixed(1)} ${units[i]}`
   }
 
+  function formatSecretReference(ref: SecretReference): string {
+    if (ref.masked) return '&***'
+    return `&${ref.collection ? `${ref.collection}.` : ''}${ref.key}`
+  }
+
+  function isSecretReferenceValue(value: unknown): value is SecretReference {
+    return !!value && typeof value === 'object' && !Array.isArray(value) && 'type' in value && value.type === 'secret_ref'
+  }
+
   function formatValue(entry: ConfigEntry): string {
     const value = entry.value
+    if (isSecretReferenceValue(value)) return formatSecretReference(value)
     if (typeof value === 'number' && entry.key.endsWith('_bytes')) return formatBytes(value)
     if (Array.isArray(value)) return `${value.length} item${value.length === 1 ? '' : 's'}`
     if (value && typeof value === 'object') return JSON.stringify(value)
@@ -200,7 +256,7 @@
       url: activeUrl,
       exportedAt: new Date().toISOString(),
       projection: 'SHOW CONFIG',
-      config: entries.map((entry) => ({
+      config: configEntries.map((entry) => ({
         key: entry.key,
         value: entry.value,
         value_type: entry.valueType ?? null,
@@ -217,7 +273,8 @@
   }
 
   function paneCount(pane: SettingsPane): number {
-    return pane.id === 'config' ? entries.length : 0
+    if (pane.id === 'secrets') return secretEntries.length
+    return configEntries.length
   }
 </script>
 
@@ -251,7 +308,7 @@
         {#if permissionsLoading}
           checking grants
         {:else if hasVisiblePane}
-          <span class="font-mono text-fg-2">{entries.length}</span> live keys
+          <span class="font-mono text-fg-2">{activeTotalCount}</span> live rows
         {:else}
           no readable panes
         {/if}
@@ -270,7 +327,7 @@
           <input
             bind:this={searchEl}
             type="text"
-            placeholder="Search config  ⌘K"
+            placeholder={`Search ${activePane.label.toLowerCase()}  ⌘K`}
             value={query}
             disabled={permissionsLoading || !hasVisiblePane || unreachable}
             oninput={(e) => setQuery(e.currentTarget.value)}
@@ -304,29 +361,58 @@
         {:else if unreachable}
           <EmptyState
             icon={Unplug}
-            title={connected ? 'Config is unreachable' : 'No active connection'}
+            title={connected ? `${activePane.label} is unreachable` : 'No active connection'}
             message={connected
-              ? 'red-ui could not read SHOW CONFIG from the active target.'
+              ? `red-ui could not read ${activePane.id === 'secrets' ? 'SHOW SECRETS' : 'SHOW CONFIG'} from the active target.`
               : 'Connect to a reddb instance to inspect its live configuration.'}
             hint={connected ? loadError ?? activeUrl : 'red serve'}
           />
-        {:else if loading && rows.length === 0}
+        {:else if loading && activeRowCount === 0}
           <div class="grid gap-1 p-2">
             {#each Array(8) as _, i (i)}
               <div class="h-12 rounded-md bg-bg-2 motion-safe:animate-pulse"></div>
             {/each}
           </div>
-        {:else if rows.length === 0}
+        {:else if activeRowCount === 0}
           <EmptyState
             icon={Search}
-            title={query ? 'No config matches' : 'No config reported'}
+            title={query ? `No ${activePane.label.toLowerCase()} match` : `No ${activePane.label.toLowerCase()} reported`}
             message={query
-              ? 'Search checks the config key and curated human label.'
-              : 'SHOW CONFIG returned no rows for this connection.'}
+              ? `Search checks the ${activePane.label.toLowerCase()} key and metadata.`
+              : `${activePane.id === 'secrets' ? 'SHOW SECRETS' : 'SHOW CONFIG'} returned no rows for this connection.`}
           />
+        {:else if activePane.id === 'secrets'}
+          <div class="grid gap-1 p-2">
+            {#each secretRows as entry (entry.key)}
+              {@const control = resolveSecretControl(entry)}
+              <div
+                class={[
+                  'grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-md px-2.5 py-2 transition-colors',
+                  selectedSecret?.key === entry.key
+                    ? 'bg-bg-3 text-fg-0'
+                    : 'text-fg-1 hover:bg-bg-2',
+                ].join(' ')}
+              >
+                <button
+                  type="button"
+                  aria-current={selectedSecret?.key === entry.key ? 'page' : undefined}
+                  onclick={() => (selectedSecretKey = entry.key)}
+                  class="min-w-0 text-left"
+                >
+                  <span class="block truncate text-[13px]">{control.label}</span>
+                  <span class="block truncate font-mono text-[11px] text-fg-3">{entry.key}</span>
+                </button>
+
+                <div class="inline-flex h-6 items-center gap-1.5 rounded border border-line-2 bg-bg-2 px-1.5 font-mono text-[11px] text-fg-2">
+                  <KeyRound class="size-3" />
+                  {entry.value}
+                </div>
+              </div>
+            {/each}
+          </div>
         {:else}
           <div class="grid gap-1 p-2">
-            {#each rows as entry (entry.key)}
+            {#each configRows as entry (entry.key)}
               {@const control = resolveConfigControl(entry)}
               <div
                 class={[
@@ -339,7 +425,7 @@
                 <button
                   type="button"
                   aria-current={selectedEntry?.key === entry.key ? 'page' : undefined}
-                  onclick={() => (selectedKey = entry.key)}
+                  onclick={() => (selectedConfigKey = entry.key)}
                   class="min-w-0 text-left"
                 >
                   <span class="block truncate text-[13px]">{control.label}</span>
@@ -390,15 +476,17 @@
       </div>
 
       <div class="grid gap-2 border-t border-line-1 px-3 py-2.5">
-        <button
-          type="button"
-          onclick={exportConfig}
-          disabled={permissionsLoading || !hasVisiblePane || loading || entries.length === 0}
-          class="inline-flex h-7 items-center justify-center gap-1.5 rounded-md border border-line-2 bg-bg-2 px-2.5 text-[11px] font-mono text-fg-1 transition-colors hover:border-line-3 hover:text-fg-0 disabled:cursor-not-allowed disabled:opacity-40"
-        >
-          <Download class="size-3.5" />
-          export config
-        </button>
+        {#if activePane.id === 'config'}
+          <button
+            type="button"
+            onclick={exportConfig}
+            disabled={permissionsLoading || !hasVisiblePane || loading || configEntries.length === 0}
+            class="inline-flex h-7 items-center justify-center gap-1.5 rounded-md border border-line-2 bg-bg-2 px-2.5 text-[11px] font-mono text-fg-1 transition-colors hover:border-line-3 hover:text-fg-0 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <Download class="size-3.5" />
+            export config
+          </button>
+        {/if}
         <div class="truncate text-[11px] text-fg-3">
           {#if hasVisiblePane}
             Live from <span class="font-mono text-fg-2">{activeUrl}</span>.
@@ -447,12 +535,64 @@
           {#if unreachable}
           <EmptyState
             icon={Unplug}
-            title={connected ? 'Unable to read config' : 'No active connection'}
+            title={connected ? `Unable to read ${activePane.label.toLowerCase()}` : 'No active connection'}
             message={connected
-              ? 'The Config pane is intentionally empty because SHOW CONFIG did not complete.'
+              ? `The ${activePane.label} pane is intentionally empty because ${activePane.id === 'secrets' ? 'SHOW SECRETS' : 'SHOW CONFIG'} did not complete.`
               : 'Start or select a reddb target, then return here to inspect live config.'}
             hint={connected ? loadError ?? activeUrl : 'docker compose -f docker/compose.yml up -d'}
           />
+          {:else if activePane.id === 'secrets'}
+            {#if !selectedSecret || !selectedSecretControl}
+              <EmptyState
+                icon={KeyRound}
+                title="No secret selected"
+                message="Select a live SHOW SECRETS row to inspect its masked metadata."
+              />
+            {:else}
+              <section>
+                <SectionHeading title={selectedSecretControl.label} class="mb-2">
+                  {#snippet icon()}<KeyRound class="size-3.5" />{/snippet}
+                  {#snippet meta()}<Pill>masked</Pill>{/snippet}
+                </SectionHeading>
+
+                <div class="divide-y divide-line-1 overflow-hidden rounded-lg border border-line-1 bg-bg-1">
+                  <ListRow
+                    title={selectedSecretControl.label}
+                    description="Vault metadata row; plaintext is not available in this pane."
+                    hint={selectedSecret.key}
+                    wide
+                  >
+                    {#snippet action()}
+                      <input
+                        readonly
+                        value={selectedSecret.value}
+                        aria-label={selectedSecretControl.label}
+                        class="h-8 w-full rounded-md border border-line-2 bg-bg-2 px-2.5 font-mono text-[12px] text-fg-1 outline-none"
+                      />
+                    {/snippet}
+                  </ListRow>
+
+                  <ListRow title="Key" hint={selectedSecret.key}>
+                    {#snippet action()}
+                      <span class="font-mono text-[12px] text-fg-1">{selectedSecret.key}</span>
+                    {/snippet}
+                  </ListRow>
+
+                  <ListRow title="Metadata">
+                    {#snippet action()}
+                      <div class="flex flex-wrap justify-end gap-1.5">
+                        <Pill>{selectedSecret.status ?? 'status unknown'}</Pill>
+                        <Pill
+                          >version {selectedSecret.version === undefined
+                            ? 'unknown'
+                            : selectedSecret.version}</Pill
+                        >
+                      </div>
+                    {/snippet}
+                  </ListRow>
+                </div>
+              </section>
+            {/if}
           {:else if !selectedEntry || !selectedControl}
           <EmptyState
             icon={FileJson}
@@ -462,7 +602,13 @@
           {:else}
           <section>
             <SectionHeading title={selectedControl.label} class="mb-2">
-              {#snippet icon()}<SlidersHorizontal class="size-3.5" />{/snippet}
+              {#snippet icon()}
+                {#if selectedControl.kind === 'secret-reference'}
+                  <Link2 class="size-3.5" />
+                {:else}
+                  <SlidersHorizontal class="size-3.5" />
+                {/if}
+              {/snippet}
               {#snippet meta()}<Pill>{selectedControl.kind}</Pill>{/snippet}
             </SectionHeading>
 

--- a/packages/ui/src/lib/settings-authoring-client.test.ts
+++ b/packages/ui/src/lib/settings-authoring-client.test.ts
@@ -3,6 +3,7 @@ import type { QueryResult } from "./reddb/client";
 import {
   SettingsAuthoringClient,
   parseShowConfigResult,
+  parseShowSecretsResult,
   type QueryTransport,
 } from "./settings-authoring-client";
 
@@ -86,6 +87,35 @@ describe("parseShowConfigResult", () => {
     ]);
   });
 
+  it("keeps secret references as references instead of resolving values", () => {
+    expect(
+      parseShowConfigResult(
+        result([
+          {
+            key: "red.config.ai.openai.default.api_key",
+            value: "&red.secret.ai.openai.default.api_key",
+          },
+          {
+            key: "red.config.ai.openai.masked_api_key",
+            value: "&***",
+          },
+        ])
+      )
+    ).toEqual([
+      {
+        key: "red.config.ai.openai.default.api_key",
+        value: {
+          type: "secret_ref",
+          key: "red.secret.ai.openai.default.api_key",
+        },
+      },
+      {
+        key: "red.config.ai.openai.masked_api_key",
+        value: { type: "secret_ref", key: "***", masked: true },
+      },
+    ]);
+  });
+
   it("throws the server error when the query envelope is not ok", () => {
     expect(() =>
       parseShowConfigResult({
@@ -96,6 +126,48 @@ describe("parseShowConfigResult", () => {
         error: "permission denied",
       })
     ).toThrow("permission denied");
+  });
+});
+
+describe("parseShowSecretsResult", () => {
+  it("parses metadata-only SHOW SECRETS rows sorted by key", () => {
+    expect(
+      parseShowSecretsResult(
+        result([
+          {
+            key: "legacy.missing.key",
+            value: "***",
+            status: "restore_failed",
+            version: 2,
+          },
+          {
+            key: "mycompany.payments.key",
+            value: "***",
+            status: "active",
+          },
+        ])
+      )
+    ).toEqual([
+      {
+        key: "legacy.missing.key",
+        value: "***",
+        status: "restore_failed",
+        version: 2,
+      },
+      {
+        key: "mycompany.payments.key",
+        value: "***",
+        status: "active",
+      },
+    ]);
+  });
+
+  it("rejects plaintext secret values from SHOW SECRETS", () => {
+    expect(() =>
+      parseShowSecretsResult(
+        result([{ key: "mycompany.payments.key", value: "sk-live-secret" }])
+      )
+    ).toThrow("unmasked secret value");
   });
 });
 
@@ -141,5 +213,35 @@ describe("SettingsAuthoringClient", () => {
       new SettingsAuthoringClient(transport).showConfig("red.ai; DROP TABLE x")
     ).rejects.toThrow("dotted identifier path");
     expect(calls).toEqual([]);
+  });
+
+  it("reads SHOW SECRETS over the query transport", async () => {
+    const calls: string[] = [];
+    const transport: QueryTransport = {
+      async query(sql) {
+        calls.push(sql);
+        return result([{ key: "mycompany.payments.key", value: "***" }]);
+      },
+    };
+
+    await expect(
+      new SettingsAuthoringClient(transport).showSecrets()
+    ).resolves.toEqual([{ key: "mycompany.payments.key", value: "***" }]);
+    expect(calls).toEqual(["SHOW SECRETS"]);
+  });
+
+  it("passes a SHOW SECRETS prefix when requested", async () => {
+    const calls: string[] = [];
+    const transport: QueryTransport = {
+      async query(sql) {
+        calls.push(sql);
+        return result([]);
+      },
+    };
+
+    await new SettingsAuthoringClient(transport).showSecrets(
+      "mycompany.payments"
+    );
+    expect(calls).toEqual(["SHOW SECRETS mycompany.payments"]);
   });
 });

--- a/packages/ui/src/lib/settings-authoring-client.ts
+++ b/packages/ui/src/lib/settings-authoring-client.ts
@@ -25,6 +25,21 @@ export interface ConfigEntry {
   tags?: unknown;
 }
 
+export interface SecretReference {
+  type: "secret_ref";
+  store?: string;
+  collection?: string;
+  key: string;
+  masked?: boolean;
+}
+
+export interface SecretEntry {
+  key: string;
+  value: "***";
+  status?: string;
+  version?: number;
+}
+
 export interface QueryTransport {
   query(sql: string): Promise<QueryResult>;
 }
@@ -59,6 +74,39 @@ function readSchemaVersion(
   );
 }
 
+function readSecretReference(value: unknown): SecretReference | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "&***") {
+      return { type: "secret_ref", key: "***", masked: true };
+    }
+    if (/^&[A-Za-z0-9_.-]+$/.test(trimmed)) {
+      return { type: "secret_ref", key: trimmed.slice(1) };
+    }
+    return undefined;
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const ref = value as Record<string, unknown>;
+  if (ref.type !== "secret_ref") return undefined;
+  const key =
+    optionalString(ref.key) ??
+    optionalString(ref.path) ??
+    optionalString(ref.name);
+  if (!key) return undefined;
+
+  const secretRef: SecretReference = { type: "secret_ref", key };
+  const store = optionalString(ref.store);
+  const collection = optionalString(ref.collection);
+  if (store) secretRef.store = store;
+  if (collection) secretRef.collection = collection;
+  if (key === "***") secretRef.masked = true;
+  return secretRef;
+}
+
 function normalizeConfigPrefix(prefix: string | undefined): string | undefined {
   const suffix = prefix?.trim();
   if (!suffix) return undefined;
@@ -79,7 +127,7 @@ export function parseShowConfigResult(result: QueryResult): ConfigEntry[] {
 
     const entry: ConfigEntry = {
       key,
-      value: values.value,
+      value: readSecretReference(values.value) ?? values.value,
     };
     const collection = optionalString(values.collection);
     const version = optionalNumber(values.version);
@@ -97,6 +145,31 @@ export function parseShowConfigResult(result: QueryResult): ConfigEntry[] {
   return entries.sort((left, right) => left.key.localeCompare(right.key));
 }
 
+export function parseShowSecretsResult(result: QueryResult): SecretEntry[] {
+  if (!result.ok) throw new Error(result.error ?? "SHOW SECRETS failed");
+
+  const entries: SecretEntry[] = [];
+  for (const record of result.result.records) {
+    const values = record.values;
+    const key = optionalString(values.key);
+    if (!key) continue;
+
+    const value = values.value;
+    if (value !== "***") {
+      throw new Error("SHOW SECRETS returned an unmasked secret value");
+    }
+
+    const entry: SecretEntry = { key, value: "***" };
+    const status = optionalString(values.status);
+    const version = optionalNumber(values.version);
+    if (status) entry.status = status;
+    if (version !== undefined) entry.version = version;
+    entries.push(entry);
+  }
+
+  return entries.sort((left, right) => left.key.localeCompare(right.key));
+}
+
 export class SettingsAuthoringClient {
   constructor(private readonly transport: QueryTransport) {}
 
@@ -106,5 +179,13 @@ export class SettingsAuthoringClient {
       suffix ? `SHOW CONFIG ${suffix}` : "SHOW CONFIG"
     );
     return parseShowConfigResult(result);
+  }
+
+  async showSecrets(prefix?: string): Promise<SecretEntry[]> {
+    const suffix = normalizeConfigPrefix(prefix);
+    const result = await this.transport.query(
+      suffix ? `SHOW SECRETS ${suffix}` : "SHOW SECRETS"
+    );
+    return parseShowSecretsResult(result);
   }
 }

--- a/packages/ui/src/lib/settings-sections.test.ts
+++ b/packages/ui/src/lib/settings-sections.test.ts
@@ -1,18 +1,23 @@
 import { describe, expect, it } from "vitest";
-import type { ConfigEntry } from "./settings-authoring-client";
+import type { ConfigEntry, SecretEntry } from "./settings-authoring-client";
 import {
   ENUM_OPTIONS,
   SETTINGS_PANES,
   filterConfigEntries,
+  filterSecretEntries,
   filterSettingsPanesByGrant,
   humanizeKey,
   resolveConfigControl,
   resolvePane,
+  resolveSecretControl,
 } from "./settings-sections";
 
 describe("settings panes registry", () => {
   it("ships only real panes with stable, unique ids", () => {
-    expect(SETTINGS_PANES.map((pane) => pane.id)).toEqual(["config"]);
+    expect(SETTINGS_PANES.map((pane) => pane.id)).toEqual([
+      "config",
+      "secrets",
+    ]);
     const ids = SETTINGS_PANES.map((pane) => pane.id);
     expect(new Set(ids).size).toBe(ids.length);
     for (const pane of SETTINGS_PANES) {
@@ -36,12 +41,12 @@ describe("settings panes registry", () => {
       filterSettingsPanesByGrant(SETTINGS_PANES, { cachedCan: () => true }).map(
         (pane) => pane.id
       )
-    ).toEqual(["config"]);
+    ).toEqual(["config", "secrets"]);
     expect(
       filterSettingsPanesByGrant(SETTINGS_PANES, {
         cachedCan: (check) => check.action !== "config:read",
-      })
-    ).toEqual([]);
+      }).map((pane) => pane.id)
+    ).toEqual(["secrets"]);
   });
 });
 
@@ -92,6 +97,40 @@ describe("resolveConfigControl", () => {
     expect(control.valueType).toBe("bool");
     expect(control.schemaVersion).toBe(2);
   });
+
+  it("renders secret references as references", () => {
+    const control = resolveConfigControl(
+      entry({
+        key: "red.config.ai.openai.default.api_key",
+        value: {
+          type: "secret_ref",
+          key: "red.secret.ai.openai.default.api_key",
+        },
+      })
+    );
+
+    expect(control.kind).toBe("secret-reference");
+    expect(control.secretReference).toEqual({
+      type: "secret_ref",
+      key: "red.secret.ai.openai.default.api_key",
+    });
+  });
+});
+
+describe("resolveSecretControl", () => {
+  it("marks vault rows as masked controls", () => {
+    expect(
+      resolveSecretControl({
+        key: "mycompany.payments.stripe.key",
+        value: "***",
+        status: "active",
+      })
+    ).toMatchObject({
+      key: "mycompany.payments.stripe.key",
+      kind: "text",
+      masked: true,
+    });
+  });
 });
 
 describe("humanizeKey", () => {
@@ -128,5 +167,45 @@ describe("filterConfigEntries (per-pane search)", () => {
     expect(
       filterConfigEntries(entries, "durability").map((entry) => entry.key)
     ).toEqual(["durability.mode"]);
+  });
+
+  it("matches secret reference targets without resolving them", () => {
+    expect(
+      filterConfigEntries(
+        [
+          ...entries,
+          {
+            key: "red.config.ai.openai.default.api_key",
+            value: {
+              type: "secret_ref",
+              key: "red.secret.ai.openai.default.api_key",
+            },
+          },
+        ],
+        "secret.ai"
+      ).map((entry) => entry.key)
+    ).toEqual(["red.config.ai.openai.default.api_key"]);
+  });
+});
+
+describe("filterSecretEntries (per-pane search)", () => {
+  const entries: SecretEntry[] = [
+    { key: "mycompany.payments.stripe.key", value: "***", status: "active" },
+    { key: "legacy.missing.key", value: "***", status: "restore_failed" },
+  ];
+
+  it("returns all entries (a copy) for an empty or whitespace query", () => {
+    expect(filterSecretEntries(entries, "")).toEqual(entries);
+    expect(filterSecretEntries(entries, "   ")).toEqual(entries);
+    expect(filterSecretEntries(entries, "")).not.toBe(entries);
+  });
+
+  it("matches secret keys and metadata case-insensitively", () => {
+    expect(
+      filterSecretEntries(entries, "PAYMENTS").map((entry) => entry.key)
+    ).toEqual(["mycompany.payments.stripe.key"]);
+    expect(
+      filterSecretEntries(entries, "restore").map((entry) => entry.key)
+    ).toEqual(["legacy.missing.key"]);
   });
 });

--- a/packages/ui/src/lib/settings-sections.ts
+++ b/packages/ui/src/lib/settings-sections.ts
@@ -1,12 +1,20 @@
 // Data-driven settings registry + pure schema resolver for the Settings surface.
-// This slice ships only the real Config pane. Secrets and Policies are absent
-// until they have live backing data, keeping the surface "live or empty" rather
-// than rendering placeholders.
-import type { ConfigEntry, ConfigValueType } from "./settings-authoring-client";
+import type {
+  ConfigEntry,
+  ConfigValueType,
+  SecretEntry,
+  SecretReference,
+} from "./settings-authoring-client";
 import type { PermissionCheck } from "./permission-gate";
 
 /** The read-only control a config value is rendered through. */
-export type ControlKind = "text" | "number" | "boolean" | "enum" | "list";
+export type ControlKind =
+  | "text"
+  | "number"
+  | "boolean"
+  | "enum"
+  | "list"
+  | "secret-reference";
 
 /** A resolved control for one config key. */
 export interface ControlDescriptor {
@@ -24,6 +32,10 @@ export interface ControlDescriptor {
   valueType?: ConfigValueType;
   /** Server-reported config schema version, when SHOW CONFIG projects it. */
   schemaVersion?: number;
+  /** True when this row must not render plaintext. */
+  masked?: boolean;
+  /** Vault path referenced by a config value, if this is a secret reference. */
+  secretReference?: SecretReference;
 }
 
 export interface SettingsPane {
@@ -48,6 +60,16 @@ export const SETTINGS_PANES: SettingsPane[] = [
     readGrant: {
       action: "config:read",
       resource: { kind: "config", name: "*" },
+    },
+  },
+  {
+    id: "secrets",
+    label: "Secrets",
+    blurb: "Vault inventory from SHOW SECRETS with values masked.",
+    icon: "key",
+    readGrant: {
+      action: "vault:read_metadata",
+      resource: { kind: "vault", name: "*" },
     },
   },
 ];
@@ -165,11 +187,27 @@ function kindFromRuntimeValue(value: unknown): ControlKind {
   return "text";
 }
 
+export function isSecretReference(value: unknown): value is SecretReference {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    (value as SecretReference).type === "secret_ref" &&
+    typeof (value as SecretReference).key === "string"
+  );
+}
+
 export function resolveConfigControl(entry: ConfigEntry): ControlDescriptor {
   const options = ENUM_OPTIONS[entry.key];
-  const kind: ControlKind = options
-    ? "enum"
-    : (kindFromValueType(entry.valueType) ?? kindFromRuntimeValue(entry.value));
+  const secretReference = isSecretReference(entry.value)
+    ? entry.value
+    : undefined;
+  const kind: ControlKind = secretReference
+    ? "secret-reference"
+    : options
+      ? "enum"
+      : (kindFromValueType(entry.valueType) ??
+        kindFromRuntimeValue(entry.value));
   const descriptor: ControlDescriptor = {
     key: entry.key,
     label: LABELS[entry.key] ?? humanizeKey(entry.key),
@@ -181,7 +219,17 @@ export function resolveConfigControl(entry: ConfigEntry): ControlDescriptor {
   if (entry.valueType) descriptor.valueType = entry.valueType;
   if (entry.schemaVersion !== undefined)
     descriptor.schemaVersion = entry.schemaVersion;
+  if (secretReference) descriptor.secretReference = secretReference;
   return descriptor;
+}
+
+export function resolveSecretControl(entry: SecretEntry): ControlDescriptor {
+  return {
+    key: entry.key,
+    label: humanizeKey(entry.key),
+    kind: "text",
+    masked: true,
+  };
 }
 
 export function resolvePane(
@@ -207,6 +255,22 @@ export function filterConfigEntries(
   return entries.filter(
     (entry) =>
       entry.key.toLowerCase().includes(q) ||
-      resolveConfigControl(entry).label.toLowerCase().includes(q)
+      resolveConfigControl(entry).label.toLowerCase().includes(q) ||
+      (isSecretReference(entry.value) &&
+        entry.value.key.toLowerCase().includes(q))
+  );
+}
+
+export function filterSecretEntries(
+  entries: readonly SecretEntry[],
+  query: string
+): SecretEntry[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [...entries];
+  return entries.filter(
+    (entry) =>
+      entry.key.toLowerCase().includes(q) ||
+      resolveSecretControl(entry).label.toLowerCase().includes(q) ||
+      entry.status?.toLowerCase().includes(q)
   );
 }


### PR DESCRIPTION
Closes #86.

## Summary
- Add a Settings Secrets pane gated by vault:read_metadata.
- Query SHOW SECRETS metadata only and reject unmasked values.
- Render config secret references as references, including &*** masked refs.

## Validation
- pnpm --filter @reddb-io/ui test -- settings-authoring-client settings-sections
- pnpm --filter @reddb-io/ui exec svelte-check --tsconfig ./tsconfig.json
- pnpm --filter @reddb-io/ui build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783169936&installation_id=129708444&pr_number=99&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F99&signature=a23b6784fce1fe5c6ff9a054522e47c2270ebd34152961a8ec563f4f795f543b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Secrets pane to Settings view for browsing and inspecting vault inventory with masked values
  * Support for secret references within config values, properly formatted and searchable
  * Enhanced filtering and search functionality across both config and secrets datasets
  * Improved pane-specific load and error tracking for independent data management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->