### PR TITLE
Config pane: add gated editing

### DIFF
--- a/packages/ui/src/lib/SettingsView.svelte
+++ b/packages/ui/src/lib/SettingsView.svelte
@@ -2,15 +2,19 @@
   // Settings surface: a bounded pane shell backed by live SQL introspection.
   import { ListRow, NavItem, Pill, SectionHeading } from '@reddb-io/ui-kit'
   import {
+    AlertCircle,
     Download,
     FileJson,
     KeyRound,
     Link2,
+    Plus,
     RefreshCw,
     Search,
+    Save,
     Settings2,
     ShieldOff,
     SlidersHorizontal,
+    Trash2,
     Unplug,
     type Icon,
   } from 'lucide-svelte'
@@ -30,6 +34,8 @@
     filterConfigEntries,
     filterSecretEntries,
     filterSettingsPanesByGrant,
+    initialConfigEditValue,
+    parseConfigEditValue,
     resolveConfigControl,
     resolvePane,
     resolveSecretControl,
@@ -63,6 +69,13 @@
   let loading = $state(false)
   let configLoadError = $state<string | null>(null)
   let secretsLoadError = $state<string | null>(null)
+  let writing = $state(false)
+  let writeStatus = $state<{ tone: 'ok' | 'error'; message: string } | null>(null)
+  let editingConfigKey = $state<string | null>(null)
+  let editValue = $state('')
+  let newConfigKey = $state('')
+  let newConfigKind = $state<'text' | 'number' | 'boolean' | 'list'>('text')
+  let newConfigValue = $state('')
 
   const connected = $derived(connection.connected)
   const activeUrl = $derived(connection.active.url)
@@ -83,6 +96,11 @@
   )
   const selectedSecretControl = $derived(
     selectedSecret ? resolveSecretControl(selectedSecret) : null,
+  )
+  const canWriteConfig = $derived(
+    activePane.id === 'config' &&
+      !!activePane.writeGrant &&
+      permissions?.cachedCan(activePane.writeGrant) === true,
   )
 
   function setQuery(value: string) {
@@ -108,6 +126,8 @@
     secretEntries = []
     selectedConfigKey = null
     selectedSecretKey = null
+    writeStatus = null
+    editingConfigKey = null
 
     if (!client || !connected) {
       permissionsLoading = false
@@ -118,7 +138,11 @@
     const gate = new PermissionGate(client)
     try {
       await activity.track('settings · auth.can panes', () =>
-        gate.preload(SETTINGS_PANES.map((pane) => pane.readGrant)),
+        gate.preload(
+          SETTINGS_PANES.flatMap((pane) =>
+            pane.writeGrant ? [pane.readGrant, pane.writeGrant] : [pane.readGrant],
+          ),
+        ),
       )
       if (run !== permissionRun) return
 
@@ -197,6 +221,95 @@
     }
   }
 
+  function parseNewConfigValue() {
+    return parseConfigEditValue(
+      {
+        key: newConfigKey,
+        label: newConfigKey,
+        kind: newConfigKind,
+      },
+      newConfigKind === 'boolean' && !newConfigValue.trim() ? 'false' : newConfigValue,
+    )
+  }
+
+  async function saveSelectedConfig() {
+    const client = connection.client
+    if (!client || !selectedEntry || !selectedControl || !canWriteConfig || writing) return
+
+    const parsed = parseConfigEditValue(selectedControl, editValue)
+    if (!parsed.ok) {
+      writeStatus = { tone: 'error', message: parsed.error ?? 'Invalid config value.' }
+      return
+    }
+
+    writing = true
+    writeStatus = null
+    try {
+      const authoring = new SettingsAuthoringClient(client)
+      await activity.track('settings · set config', () =>
+        authoring.setConfig(selectedEntry.key, parsed.value ?? null),
+      )
+      selectedConfigKey = selectedEntry.key
+      writeStatus = { tone: 'ok', message: `${selectedEntry.key} saved.` }
+      await refresh()
+    } catch (e) {
+      writeStatus = { tone: 'error', message: (e as Error).message }
+    } finally {
+      writing = false
+    }
+  }
+
+  async function unsetSelectedConfig() {
+    const client = connection.client
+    if (!client || !selectedEntry || !canWriteConfig || writing) return
+    if (!window.confirm(`Unset ${selectedEntry.key}?`)) return
+
+    const key = selectedEntry.key
+    writing = true
+    writeStatus = null
+    try {
+      const authoring = new SettingsAuthoringClient(client)
+      await activity.track('settings · delete config', () => authoring.unsetConfig(key))
+      selectedConfigKey = key
+      writeStatus = { tone: 'ok', message: `${key} unset.` }
+      await refresh()
+    } catch (e) {
+      writeStatus = { tone: 'error', message: (e as Error).message }
+    } finally {
+      writing = false
+    }
+  }
+
+  async function setNewConfig() {
+    const client = connection.client
+    if (!client || !canWriteConfig || writing) return
+
+    const parsed = parseNewConfigValue()
+    if (!parsed.ok) {
+      writeStatus = { tone: 'error', message: parsed.error ?? 'Invalid config value.' }
+      return
+    }
+
+    const key = newConfigKey.trim()
+    writing = true
+    writeStatus = null
+    try {
+      const authoring = new SettingsAuthoringClient(client)
+      await activity.track('settings · set config', () =>
+        authoring.setConfig(key, parsed.value ?? null),
+      )
+      selectedConfigKey = key
+      newConfigKey = ''
+      newConfigValue = ''
+      writeStatus = { tone: 'ok', message: `${key} set.` }
+      await refresh()
+    } catch (e) {
+      writeStatus = { tone: 'error', message: (e as Error).message }
+    } finally {
+      writing = false
+    }
+  }
+
   $effect(() => {
     void activeUrl
     void connected
@@ -210,6 +323,19 @@
     void permissions
     void visiblePanes
     refresh()
+  })
+
+  $effect(() => {
+    if (!selectedEntry) {
+      editingConfigKey = null
+      editValue = ''
+      return
+    }
+    if (editingConfigKey !== selectedEntry.key) {
+      editingConfigKey = selectedEntry.key
+      editValue = initialConfigEditValue(selectedEntry)
+      writeStatus = null
+    }
   })
 
   function formatBytes(n: number): string {
@@ -626,16 +752,18 @@
                     >
                       <input
                         type="checkbox"
-                        checked={selectedEntry.value === true}
-                        disabled
+                        checked={canWriteConfig ? editValue === 'true' : selectedEntry.value === true}
+                        disabled={!canWriteConfig || writing}
+                        onchange={(e) => (editValue = e.currentTarget.checked ? 'true' : 'false')}
                         class="size-3 accent-current"
                       />
-                      {selectedEntry.value ? 'true' : 'false'}
+                      {canWriteConfig ? editValue : selectedEntry.value ? 'true' : 'false'}
                     </label>
                   {:else if selectedControl.kind === 'enum'}
                     <select
-                      disabled
-                      value={String(selectedEntry.value)}
+                      disabled={!canWriteConfig || writing}
+                      value={canWriteConfig ? editValue : String(selectedEntry.value)}
+                      onchange={(e) => (editValue = e.currentTarget.value)}
                       class="h-8 min-w-[12rem] rounded-md border border-line-2 bg-bg-2 px-2.5 font-mono text-[12px] text-fg-1 disabled:opacity-100"
                     >
                       {#if !selectedControl.options?.includes(String(selectedEntry.value))}
@@ -647,16 +775,27 @@
                     </select>
                   {:else if selectedControl.kind === 'list'}
                     <textarea
-                      readonly
+                      readonly={!canWriteConfig}
+                      disabled={writing}
                       rows="5"
-                      value={formatLongValue(selectedEntry.value)}
+                      value={canWriteConfig ? editValue : formatLongValue(selectedEntry.value)}
+                      oninput={(e) => (editValue = e.currentTarget.value)}
                       class="min-h-24 w-full resize-y rounded-md border border-line-2 bg-bg-2 px-2.5 py-2 font-mono text-[12px] text-fg-1 outline-none"
                     ></textarea>
-                  {:else}
+                  {:else if selectedControl.kind === 'secret-reference'}
                     <input
                       readonly
-                      type={selectedControl.kind === 'number' ? 'text' : 'text'}
+                      type="text"
                       value={formatValue(selectedEntry)}
+                      class="h-8 w-full rounded-md border border-line-2 bg-bg-2 px-2.5 font-mono text-[12px] text-fg-1 outline-none"
+                    />
+                  {:else}
+                    <input
+                      readonly={!canWriteConfig}
+                      disabled={writing}
+                      type={selectedControl.kind === 'number' ? 'text' : 'text'}
+                      value={canWriteConfig ? editValue : formatValue(selectedEntry)}
+                      oninput={(e) => (editValue = e.currentTarget.value)}
                       class="h-8 w-full rounded-md border border-line-2 bg-bg-2 px-2.5 font-mono text-[12px] text-fg-1 outline-none"
                     />
                   {/if}
@@ -681,7 +820,130 @@
                   </div>
                 {/snippet}
               </ListRow>
+
+              {#if canWriteConfig}
+                <ListRow title="Authoring" description="Submit changes through SET CONFIG or unset through DELETE CONFIG.">
+                  {#snippet action()}
+                    <div class="flex flex-wrap justify-end gap-2">
+                      <button
+                        type="button"
+                        onclick={saveSelectedConfig}
+                        disabled={writing || selectedControl.kind === 'secret-reference'}
+                        title={selectedControl.kind === 'secret-reference'
+                          ? 'Secret references can be unset, but not edited as plaintext config.'
+                          : 'Save config value'}
+                        class="inline-flex h-8 items-center gap-1.5 rounded-md border border-line-2 bg-bg-2 px-2.5 text-[11px] font-mono text-fg-1 hover:border-line-3 hover:text-fg-0 disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        <Save class="size-3.5" />
+                        save
+                      </button>
+                      <button
+                        type="button"
+                        onclick={unsetSelectedConfig}
+                        disabled={writing}
+                        class="inline-flex h-8 items-center gap-1.5 rounded-md border border-danger/30 bg-danger/5 px-2.5 text-[11px] font-mono text-danger hover:border-danger/60 disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        <Trash2 class="size-3.5" />
+                        unset
+                      </button>
+                    </div>
+                  {/snippet}
+                </ListRow>
+              {/if}
             </div>
+
+            {#if canWriteConfig}
+              {#if writeStatus}
+                <div
+                  class={[
+                    'mt-3 inline-flex max-w-full items-center gap-1.5 rounded-md border px-2.5 py-1.5 font-mono text-[11px]',
+                    writeStatus.tone === 'ok'
+                      ? 'border-ok/30 bg-ok/5 text-ok'
+                      : 'border-danger/30 bg-danger/5 text-danger',
+                  ].join(' ')}
+                  role="status"
+                >
+                  <AlertCircle class="size-3 shrink-0" />
+                  <span class="truncate">{writeStatus.message}</span>
+                </div>
+              {/if}
+
+              <section class="mt-4 border-t border-line-1 pt-4">
+                <SectionHeading title="Set config key" class="mb-2">
+                  {#snippet icon()}<Plus class="size-3.5" />{/snippet}
+                </SectionHeading>
+                <div class="grid gap-2 rounded-lg border border-line-1 bg-bg-1 p-3">
+                  <div class="grid gap-2 @min-[42rem]:grid-cols-[minmax(0,1fr)_8rem]">
+                    <input
+                      type="text"
+                      value={newConfigKey}
+                      oninput={(e) => (newConfigKey = e.currentTarget.value)}
+                      placeholder="red.example.key"
+                      disabled={writing}
+                      aria-label="New config key"
+                      class="h-8 rounded-md border border-line-2 bg-bg-2 px-2.5 font-mono text-[12px] text-fg-1 outline-none placeholder:text-fg-3 disabled:cursor-not-allowed disabled:opacity-50"
+                    />
+                    <select
+                      value={newConfigKind}
+                      onchange={(e) => (newConfigKind = e.currentTarget.value as typeof newConfigKind)}
+                      disabled={writing}
+                      aria-label="New config value type"
+                      class="h-8 rounded-md border border-line-2 bg-bg-2 px-2.5 font-mono text-[12px] text-fg-1 outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      <option value="text">text</option>
+                      <option value="number">number</option>
+                      <option value="boolean">boolean</option>
+                      <option value="list">list</option>
+                    </select>
+                  </div>
+
+                  {#if newConfigKind === 'boolean'}
+                    <label class="inline-flex h-8 w-fit items-center gap-2 rounded-md border border-line-2 bg-bg-2 px-2.5 font-mono text-[12px] text-fg-1">
+                      <input
+                        type="checkbox"
+                        checked={newConfigValue === 'true'}
+                        disabled={writing}
+                        onchange={(e) => (newConfigValue = e.currentTarget.checked ? 'true' : 'false')}
+                        class="size-3 accent-current"
+                      />
+                      {newConfigValue === 'true' ? 'true' : 'false'}
+                    </label>
+                  {:else if newConfigKind === 'list'}
+                    <textarea
+                      rows="4"
+                      value={newConfigValue}
+                      oninput={(e) => (newConfigValue = e.currentTarget.value)}
+                      placeholder='["main", "release"]'
+                      disabled={writing}
+                      aria-label="New config value"
+                      class="min-h-20 resize-y rounded-md border border-line-2 bg-bg-2 px-2.5 py-2 font-mono text-[12px] text-fg-1 outline-none placeholder:text-fg-3 disabled:cursor-not-allowed disabled:opacity-50"
+                    ></textarea>
+                  {:else}
+                    <input
+                      type="text"
+                      value={newConfigValue}
+                      oninput={(e) => (newConfigValue = e.currentTarget.value)}
+                      placeholder={newConfigKind === 'number' ? '1000' : 'value'}
+                      disabled={writing}
+                      aria-label="New config value"
+                      class="h-8 rounded-md border border-line-2 bg-bg-2 px-2.5 font-mono text-[12px] text-fg-1 outline-none placeholder:text-fg-3 disabled:cursor-not-allowed disabled:opacity-50"
+                    />
+                  {/if}
+
+                  <div class="flex justify-end">
+                    <button
+                      type="button"
+                      onclick={setNewConfig}
+                      disabled={writing || !newConfigKey.trim()}
+                      class="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md border border-line-2 bg-bg-2 px-2.5 text-[11px] font-mono text-fg-1 hover:border-line-3 hover:text-fg-0 disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      <Plus class="size-3.5" />
+                      set
+                    </button>
+                  </div>
+                </div>
+              </section>
+            {/if}
           </section>
           {/if}
         {/if}

--- a/packages/ui/src/lib/settings-authoring-client.test.ts
+++ b/packages/ui/src/lib/settings-authoring-client.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import type { QueryResult } from "./reddb/client";
 import {
   SettingsAuthoringClient,
+  buildDeleteConfigStatement,
+  buildSetConfigStatement,
+  configValueToSqlLiteral,
   parseShowConfigResult,
+  parseConfigMutationResult,
   parseShowSecretsResult,
   type QueryTransport,
 } from "./settings-authoring-client";
@@ -243,5 +247,107 @@ describe("SettingsAuthoringClient", () => {
       "mycompany.payments"
     );
     expect(calls).toEqual(["SHOW SECRETS mycompany.payments"]);
+  });
+
+  it("sets config through SET CONFIG with typed literals", async () => {
+    const calls: string[] = [];
+    const transport: QueryTransport = {
+      async query(sql) {
+        calls.push(sql);
+        return result([{ message: "config set" }]);
+      },
+    };
+
+    await new SettingsAuthoringClient(transport).setConfig(
+      "red.auth.enabled",
+      true
+    );
+    await new SettingsAuthoringClient(transport).setConfig(
+      "red.ai.default.provider",
+      "o'hara"
+    );
+    await new SettingsAuthoringClient(transport).setConfig(
+      "red.vcs.protected_branches",
+      ["main", "release"]
+    );
+
+    expect(calls).toEqual([
+      "SET CONFIG red.auth.enabled = true",
+      "SET CONFIG red.ai.default.provider = 'o''hara'",
+      'SET CONFIG red.vcs.protected_branches = ["main","release"]',
+    ]);
+  });
+
+  it("unsets config through DELETE CONFIG collection key", async () => {
+    const calls: string[] = [];
+    const transport: QueryTransport = {
+      async query(sql) {
+        calls.push(sql);
+        return result([{ message: "config deleted" }]);
+      },
+    };
+
+    await new SettingsAuthoringClient(transport).unsetConfig(
+      "red.server.max_scan_limit"
+    );
+
+    expect(calls).toEqual(["DELETE CONFIG red.server max_scan_limit"]);
+  });
+
+  it("rejects unsafe config mutation keys before calling the transport", async () => {
+    const calls: string[] = [];
+    const transport: QueryTransport = {
+      async query(sql) {
+        calls.push(sql);
+        return result([]);
+      },
+    };
+    const client = new SettingsAuthoringClient(transport);
+
+    await expect(
+      client.setConfig("red.auth.enabled; DROP TABLE x", false)
+    ).rejects.toThrow("dotted identifier path");
+    await expect(client.unsetConfig("single")).rejects.toThrow(
+      "collection and key"
+    );
+    expect(calls).toEqual([]);
+  });
+});
+
+describe("config mutation SQL helpers", () => {
+  it("builds SET/DELETE CONFIG statements without transport side effects", () => {
+    expect(buildSetConfigStatement("red.auth.enabled", false)).toBe(
+      "SET CONFIG red.auth.enabled = false"
+    );
+    expect(buildSetConfigStatement("red.server.max_scan_limit", 2500)).toBe(
+      "SET CONFIG red.server.max_scan_limit = 2500"
+    );
+    expect(buildDeleteConfigStatement("durability.mode")).toBe(
+      "DELETE CONFIG durability mode"
+    );
+  });
+
+  it("serializes supported config literals", () => {
+    expect(configValueToSqlLiteral(null)).toBe("NULL");
+    expect(configValueToSqlLiteral({ a: 1, b: true })).toBe('{"a":1,"b":true}');
+    expect(() => configValueToSqlLiteral(Number.NaN)).toThrow("finite");
+  });
+
+  it("parses config mutation envelopes and surfaces server failures", () => {
+    expect(
+      parseConfigMutationResult(result([{ message: "ok" }]), "SET CONFIG").ok
+    ).toBe(true);
+    expect(() =>
+      parseConfigMutationResult(
+        {
+          ok: false,
+          query: "DELETE CONFIG red.auth enabled",
+          record_count: 0,
+          result: { columns: [], records: [] },
+          error: "permission denied",
+        },
+        "DELETE CONFIG"
+      )
+    ).toThrow("permission denied");
   });
 });

--- a/packages/ui/src/lib/settings-authoring-client.ts
+++ b/packages/ui/src/lib/settings-authoring-client.ts
@@ -44,6 +44,14 @@ export interface QueryTransport {
   query(sql: string): Promise<QueryResult>;
 }
 
+export type ConfigMutationValue =
+  | string
+  | number
+  | boolean
+  | null
+  | unknown[]
+  | Record<string, unknown>;
+
 function optionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined;
 }
@@ -110,10 +118,61 @@ function readSecretReference(value: unknown): SecretReference | undefined {
 function normalizeConfigPrefix(prefix: string | undefined): string | undefined {
   const suffix = prefix?.trim();
   if (!suffix) return undefined;
-  if (!/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/.test(suffix)) {
-    throw new Error("SHOW CONFIG prefix must be a dotted identifier path");
+  return normalizeConfigPath(suffix, "SHOW CONFIG prefix");
+}
+
+function normalizeConfigPath(path: string, label: string): string {
+  const trimmed = path.trim();
+  if (!/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/.test(trimmed)) {
+    throw new Error(`${label} must be a dotted identifier path`);
   }
-  return suffix;
+  return trimmed;
+}
+
+function quoteSqlString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+export function configValueToSqlLiteral(value: ConfigMutationValue): string {
+  if (value === null) return "NULL";
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new Error("Config number value must be finite");
+    }
+    return String(value);
+  }
+  if (typeof value === "string") return quoteSqlString(value);
+  return JSON.stringify(value);
+}
+
+export function buildSetConfigStatement(
+  key: string,
+  value: ConfigMutationValue
+): string {
+  return `SET CONFIG ${normalizeConfigPath(
+    key,
+    "SET CONFIG key"
+  )} = ${configValueToSqlLiteral(value)}`;
+}
+
+export function buildDeleteConfigStatement(key: string): string {
+  const normalized = normalizeConfigPath(key, "DELETE CONFIG key");
+  const splitAt = normalized.lastIndexOf(".");
+  if (splitAt <= 0 || splitAt === normalized.length - 1) {
+    throw new Error("DELETE CONFIG key must include a collection and key");
+  }
+  return `DELETE CONFIG ${normalized.slice(0, splitAt)} ${normalized.slice(
+    splitAt + 1
+  )}`;
+}
+
+export function parseConfigMutationResult(
+  result: QueryResult,
+  operation: "SET CONFIG" | "DELETE CONFIG"
+): QueryResult {
+  if (!result.ok) throw new Error(result.error ?? `${operation} failed`);
+  return result;
 }
 
 export function parseShowConfigResult(result: QueryResult): ConfigEntry[] {
@@ -187,5 +246,20 @@ export class SettingsAuthoringClient {
       suffix ? `SHOW SECRETS ${suffix}` : "SHOW SECRETS"
     );
     return parseShowSecretsResult(result);
+  }
+
+  async setConfig(
+    key: string,
+    value: ConfigMutationValue
+  ): Promise<QueryResult> {
+    const result = await this.transport.query(
+      buildSetConfigStatement(key, value)
+    );
+    return parseConfigMutationResult(result, "SET CONFIG");
+  }
+
+  async unsetConfig(key: string): Promise<QueryResult> {
+    const result = await this.transport.query(buildDeleteConfigStatement(key));
+    return parseConfigMutationResult(result, "DELETE CONFIG");
   }
 }

--- a/packages/ui/src/lib/settings-sections.test.ts
+++ b/packages/ui/src/lib/settings-sections.test.ts
@@ -7,6 +7,8 @@ import {
   filterSecretEntries,
   filterSettingsPanesByGrant,
   humanizeKey,
+  initialConfigEditValue,
+  parseConfigEditValue,
   resolveConfigControl,
   resolvePane,
   resolveSecretControl,
@@ -28,6 +30,11 @@ describe("settings panes registry", () => {
       expect(pane.readGrant.resource.kind).not.toBe("");
       expect(pane.readGrant.resource.name).not.toBe("");
     }
+    expect(SETTINGS_PANES[0].writeGrant).toEqual({
+      action: "config:write",
+      resource: { kind: "config", name: "*" },
+    });
+    expect(SETTINGS_PANES[1].writeGrant).toBeUndefined();
   });
 
   it("resolves a pane by id and falls back to Config", () => {
@@ -130,6 +137,66 @@ describe("resolveSecretControl", () => {
       kind: "text",
       masked: true,
     });
+  });
+});
+
+describe("config edit value validation", () => {
+  const control = (
+    overrides: Partial<ConfigEntry>
+  ): ReturnType<typeof resolveConfigControl> =>
+    resolveConfigControl({
+      key: "red.auth.enabled",
+      value: false,
+      ...overrides,
+    });
+
+  it("prepares existing values for editable controls", () => {
+    expect(initialConfigEditValue({ key: "x", value: true })).toBe("true");
+    expect(initialConfigEditValue({ key: "x", value: ["main"] })).toBe(
+      '[\n  "main"\n]'
+    );
+  });
+
+  it("validates boolean, number, enum, list, and text values before submit", () => {
+    expect(parseConfigEditValue(control({ value: false }), "true")).toEqual({
+      ok: true,
+      value: true,
+    });
+    expect(
+      parseConfigEditValue(control({ value: 10, valueType: "int" }), "12.5")
+    ).toEqual({ ok: true, value: 12.5 });
+    expect(
+      parseConfigEditValue(
+        control({ key: "durability.mode", value: "sync" }),
+        "async"
+      )
+    ).toEqual({ ok: true, value: "async" });
+    expect(
+      parseConfigEditValue(control({ value: ["main"] }), '["main","release"]')
+    ).toEqual({ ok: true, value: ["main", "release"] });
+    expect(parseConfigEditValue(control({ value: "reddb" }), " red ")).toEqual({
+      ok: true,
+      value: " red ",
+    });
+  });
+
+  it("rejects invalid values by control kind", () => {
+    expect(
+      parseConfigEditValue(control({ value: false }), "yes").error
+    ).toMatch(/true or false/);
+    expect(
+      parseConfigEditValue(control({ value: 10, valueType: "int" }), "nan")
+        .error
+    ).toMatch(/finite/);
+    expect(
+      parseConfigEditValue(
+        control({ key: "durability.mode", value: "sync" }),
+        "eventual"
+      ).error
+    ).toMatch(/allowed/);
+    expect(
+      parseConfigEditValue(control({ value: ["main"] }), "{}").error
+    ).toMatch(/array/);
   });
 });
 

--- a/packages/ui/src/lib/settings-sections.ts
+++ b/packages/ui/src/lib/settings-sections.ts
@@ -1,6 +1,7 @@
 // Data-driven settings registry + pure schema resolver for the Settings surface.
 import type {
   ConfigEntry,
+  ConfigMutationValue,
   ConfigValueType,
   SecretEntry,
   SecretReference,
@@ -49,6 +50,8 @@ export interface SettingsPane {
   icon: string;
   /** Pane-level grant that must be allowed before this pane is rendered. */
   readGrant: PermissionCheck;
+  /** Pane-level grant that enables authoring controls when present. */
+  writeGrant?: PermissionCheck;
 }
 
 export const SETTINGS_PANES: SettingsPane[] = [
@@ -59,6 +62,10 @@ export const SETTINGS_PANES: SettingsPane[] = [
     icon: "settings",
     readGrant: {
       action: "config:read",
+      resource: { kind: "config", name: "*" },
+    },
+    writeGrant: {
+      action: "config:write",
       resource: { kind: "config", name: "*" },
     },
   },
@@ -273,4 +280,74 @@ export function filterSecretEntries(
       resolveSecretControl(entry).label.toLowerCase().includes(q) ||
       entry.status?.toLowerCase().includes(q)
   );
+}
+
+export interface ParsedConfigEditValue {
+  ok: boolean;
+  value?: ConfigMutationValue;
+  error?: string;
+}
+
+export function initialConfigEditValue(entry: ConfigEntry): string {
+  if (
+    Array.isArray(entry.value) ||
+    (entry.value && typeof entry.value === "object")
+  ) {
+    return JSON.stringify(entry.value, null, 2);
+  }
+  if (entry.value === null || entry.value === undefined) return "";
+  return String(entry.value);
+}
+
+export function parseConfigEditValue(
+  control: ControlDescriptor,
+  raw: string
+): ParsedConfigEditValue {
+  const value = raw.trim();
+  switch (control.kind) {
+    case "boolean":
+      if (value === "true") return { ok: true, value: true };
+      if (value === "false") return { ok: true, value: false };
+      return {
+        ok: false,
+        error: "Boolean config values must be true or false.",
+      };
+    case "number": {
+      if (!value)
+        return { ok: false, error: "Number config values cannot be empty." };
+      const parsed = Number(value);
+      if (!Number.isFinite(parsed)) {
+        return { ok: false, error: "Number config values must be finite." };
+      }
+      return { ok: true, value: parsed };
+    }
+    case "enum":
+      if (!control.options?.includes(raw)) {
+        return { ok: false, error: "Choose one of the allowed config values." };
+      }
+      return { ok: true, value: raw };
+    case "list": {
+      try {
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) {
+          return {
+            ok: false,
+            error: "List config values must be a JSON array.",
+          };
+        }
+        return { ok: true, value: parsed };
+      } catch {
+        return { ok: false, error: "List config values must be valid JSON." };
+      }
+    }
+    case "secret-reference":
+      return {
+        ok: false,
+        error:
+          "Secret references can be unset, but not edited as plaintext config.",
+      };
+    case "text":
+    default:
+      return { ok: true, value: raw };
+  }
 }


### PR DESCRIPTION
Closes #87.

## Summary
- Add SET CONFIG / DELETE CONFIG helpers on the Settings authoring query path.
- Gate config edit controls behind config:write while preserving read-only rendering.
- Add type-aware config edit parsing, set-new-key flow, unset confirmation, and write feedback.

## Validation
- pnpm --filter @reddb-io/ui test -- settings-authoring-client.test.ts settings-sections.test.ts permission-gate.test.ts
- pnpm --filter @reddb-io/ui exec svelte-check --tsconfig ./tsconfig.json
- pnpm --filter @reddb-io/ui build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783171217&installation_id=129708444&pr_number=100&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F100&signature=701a104336e072743fd0314c58f38cdd6c6632a334133b4be544f0c8868ff0dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users with appropriate write permissions can now edit existing configuration settings, create new config entries, and delete configurations from the UI.
  * Configuration value inputs include type-aware validation with specific error messages for invalid entries.
  * Write status feedback displays the success or error state of configuration changes in real time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->