### PR TITLE
Secrets pane: add gated secret authoring

### DIFF
--- a/packages/ui/src/lib/SettingsView.svelte
+++ b/packages/ui/src/lib/SettingsView.svelte
@@ -70,12 +70,19 @@
   let configLoadError = $state<string | null>(null)
   let secretsLoadError = $state<string | null>(null)
   let writing = $state(false)
-  let writeStatus = $state<{ tone: 'ok' | 'error'; message: string } | null>(null)
+  let writeStatus = $state<{
+    tone: 'ok' | 'error'
+    message: string
+    paneId: string
+  } | null>(null)
   let editingConfigKey = $state<string | null>(null)
   let editValue = $state('')
   let newConfigKey = $state('')
   let newConfigKind = $state<'text' | 'number' | 'boolean' | 'list'>('text')
   let newConfigValue = $state('')
+  let editingSecretSelectionKey = $state<string | null>(null)
+  let secretWriteKey = $state('')
+  let secretWriteValue = $state('')
 
   const connected = $derived(connection.connected)
   const activeUrl = $derived(connection.active.url)
@@ -102,10 +109,19 @@
       !!activePane.writeGrant &&
       permissions?.cachedCan(activePane.writeGrant) === true,
   )
+  const canWriteSecrets = $derived(
+    activePane.id === 'secrets' &&
+      !!activePane.writeGrant &&
+      permissions?.cachedCan(activePane.writeGrant) === true,
+  )
 
   function setQuery(value: string) {
     if (!hasVisiblePane) return
     queries = { ...queries, [activePane.id]: value }
+  }
+
+  function setWriteStatus(paneId: string, tone: 'ok' | 'error', message: string) {
+    writeStatus = { paneId, tone, message }
   }
 
   function onWindowKey(e: KeyboardEvent) {
@@ -128,6 +144,9 @@
     selectedSecretKey = null
     writeStatus = null
     editingConfigKey = null
+    editingSecretSelectionKey = null
+    secretWriteKey = ''
+    secretWriteValue = ''
 
     if (!client || !connected) {
       permissionsLoading = false
@@ -238,7 +257,7 @@
 
     const parsed = parseConfigEditValue(selectedControl, editValue)
     if (!parsed.ok) {
-      writeStatus = { tone: 'error', message: parsed.error ?? 'Invalid config value.' }
+      setWriteStatus('config', 'error', parsed.error ?? 'Invalid config value.')
       return
     }
 
@@ -250,10 +269,10 @@
         authoring.setConfig(selectedEntry.key, parsed.value ?? null),
       )
       selectedConfigKey = selectedEntry.key
-      writeStatus = { tone: 'ok', message: `${selectedEntry.key} saved.` }
+      setWriteStatus('config', 'ok', `${selectedEntry.key} saved.`)
       await refresh()
     } catch (e) {
-      writeStatus = { tone: 'error', message: (e as Error).message }
+      setWriteStatus('config', 'error', (e as Error).message)
     } finally {
       writing = false
     }
@@ -271,10 +290,10 @@
       const authoring = new SettingsAuthoringClient(client)
       await activity.track('settings · delete config', () => authoring.unsetConfig(key))
       selectedConfigKey = key
-      writeStatus = { tone: 'ok', message: `${key} unset.` }
+      setWriteStatus('config', 'ok', `${key} unset.`)
       await refresh()
     } catch (e) {
-      writeStatus = { tone: 'error', message: (e as Error).message }
+      setWriteStatus('config', 'error', (e as Error).message)
     } finally {
       writing = false
     }
@@ -286,7 +305,7 @@
 
     const parsed = parseNewConfigValue()
     if (!parsed.ok) {
-      writeStatus = { tone: 'error', message: parsed.error ?? 'Invalid config value.' }
+      setWriteStatus('config', 'error', parsed.error ?? 'Invalid config value.')
       return
     }
 
@@ -301,10 +320,65 @@
       selectedConfigKey = key
       newConfigKey = ''
       newConfigValue = ''
-      writeStatus = { tone: 'ok', message: `${key} set.` }
+      setWriteStatus('config', 'ok', `${key} set.`)
       await refresh()
     } catch (e) {
-      writeStatus = { tone: 'error', message: (e as Error).message }
+      setWriteStatus('config', 'error', (e as Error).message)
+    } finally {
+      writing = false
+    }
+  }
+
+  async function setSecretValue() {
+    const client = connection.client
+    if (!client || !canWriteSecrets || writing) return
+
+    const key = secretWriteKey.trim()
+    const value = secretWriteValue
+    if (!key) {
+      setWriteStatus('secrets', 'error', 'Secret key is required.')
+      return
+    }
+    if (!value) {
+      setWriteStatus('secrets', 'error', 'Secret value is required.')
+      return
+    }
+
+    writing = true
+    writeStatus = null
+    try {
+      const authoring = new SettingsAuthoringClient(client)
+      await activity.track('settings · set secret', () => authoring.setSecret(key, value))
+      selectedSecretKey = key
+      secretWriteValue = ''
+      setWriteStatus('secrets', 'ok', `${key} set.`)
+      await refresh()
+    } catch (e) {
+      secretWriteValue = ''
+      setWriteStatus('secrets', 'error', (e as Error).message)
+    } finally {
+      writing = false
+    }
+  }
+
+  async function deleteSelectedSecret() {
+    const client = connection.client
+    if (!client || !selectedSecret || !canWriteSecrets || writing) return
+    if (!window.confirm(`Delete secret ${selectedSecret.key}?`)) return
+
+    const key = selectedSecret.key
+    writing = true
+    writeStatus = null
+    try {
+      const authoring = new SettingsAuthoringClient(client)
+      await activity.track('settings · delete secret', () => authoring.deleteSecret(key))
+      secretWriteValue = ''
+      selectedSecretKey = key
+      setWriteStatus('secrets', 'ok', `${key} deleted.`)
+      await refresh()
+    } catch (e) {
+      secretWriteValue = ''
+      setWriteStatus('secrets', 'error', (e as Error).message)
     } finally {
       writing = false
     }
@@ -334,6 +408,18 @@
     if (editingConfigKey !== selectedEntry.key) {
       editingConfigKey = selectedEntry.key
       editValue = initialConfigEditValue(selectedEntry)
+      writeStatus = null
+    }
+  })
+
+  $effect(() => {
+    if (activePane.id !== 'secrets' || !selectedSecret) return
+    if (
+      editingSecretSelectionKey !== selectedSecret.key &&
+      (!secretWriteKey.trim() || secretWriteKey === editingSecretSelectionKey)
+    ) {
+      secretWriteKey = selectedSecret.key
+      editingSecretSelectionKey = selectedSecret.key
       writeStatus = null
     }
   })
@@ -668,57 +754,130 @@
             hint={connected ? loadError ?? activeUrl : 'docker compose -f docker/compose.yml up -d'}
           />
           {:else if activePane.id === 'secrets'}
-            {#if !selectedSecret || !selectedSecretControl}
-              <EmptyState
-                icon={KeyRound}
-                title="No secret selected"
-                message="Select a live SHOW SECRETS row to inspect its masked metadata."
-              />
-            {:else}
-              <section>
-                <SectionHeading title={selectedSecretControl.label} class="mb-2">
-                  {#snippet icon()}<KeyRound class="size-3.5" />{/snippet}
-                  {#snippet meta()}<Pill>masked</Pill>{/snippet}
-                </SectionHeading>
+            <section class="grid gap-4">
+              {#if !selectedSecret || !selectedSecretControl}
+                <EmptyState
+                  icon={KeyRound}
+                  title="No secret selected"
+                  message="Select a live SHOW SECRETS row to inspect its masked metadata."
+                />
+              {:else}
+                <section>
+                  <SectionHeading title={selectedSecretControl.label} class="mb-2">
+                    {#snippet icon()}<KeyRound class="size-3.5" />{/snippet}
+                    {#snippet meta()}<Pill>masked</Pill>{/snippet}
+                  </SectionHeading>
 
-                <div class="divide-y divide-line-1 overflow-hidden rounded-lg border border-line-1 bg-bg-1">
-                  <ListRow
-                    title={selectedSecretControl.label}
-                    description="Vault metadata row; plaintext is not available in this pane."
-                    hint={selectedSecret.key}
-                    wide
+                  <div class="divide-y divide-line-1 overflow-hidden rounded-lg border border-line-1 bg-bg-1">
+                    <ListRow
+                      title={selectedSecretControl.label}
+                      description="Vault metadata row; plaintext is not available in this pane."
+                      hint={selectedSecret.key}
+                      wide
+                    >
+                      {#snippet action()}
+                        <input
+                          readonly
+                          value={selectedSecret.value}
+                          aria-label={selectedSecretControl.label}
+                          class="h-8 w-full rounded-md border border-line-2 bg-bg-2 px-2.5 font-mono text-[12px] text-fg-1 outline-none"
+                        />
+                      {/snippet}
+                    </ListRow>
+
+                    <ListRow title="Key" hint={selectedSecret.key}>
+                      {#snippet action()}
+                        <span class="font-mono text-[12px] text-fg-1">{selectedSecret.key}</span>
+                      {/snippet}
+                    </ListRow>
+
+                    <ListRow title="Metadata">
+                      {#snippet action()}
+                        <div class="flex flex-wrap justify-end gap-1.5">
+                          <Pill>{selectedSecret.status ?? 'status unknown'}</Pill>
+                          <Pill
+                            >version {selectedSecret.version === undefined
+                              ? 'unknown'
+                              : selectedSecret.version}</Pill
+                          >
+                        </div>
+                      {/snippet}
+                    </ListRow>
+
+                    {#if canWriteSecrets}
+                      <ListRow title="Authoring" description="Delete the selected vault secret through DELETE SECRET.">
+                        {#snippet action()}
+                          <button
+                            type="button"
+                            onclick={deleteSelectedSecret}
+                            disabled={writing}
+                            class="inline-flex h-8 items-center gap-1.5 rounded-md border border-danger/30 bg-danger/5 px-2.5 text-[11px] font-mono text-danger hover:border-danger/60 disabled:cursor-not-allowed disabled:opacity-40"
+                          >
+                            <Trash2 class="size-3.5" />
+                            delete
+                          </button>
+                        {/snippet}
+                      </ListRow>
+                    {/if}
+                  </div>
+                </section>
+              {/if}
+
+              {#if canWriteSecrets}
+                {#if writeStatus?.paneId === 'secrets'}
+                  <div
+                    class={[
+                      'inline-flex max-w-full items-center gap-1.5 rounded-md border px-2.5 py-1.5 font-mono text-[11px]',
+                      writeStatus.tone === 'ok'
+                        ? 'border-ok/30 bg-ok/5 text-ok'
+                        : 'border-danger/30 bg-danger/5 text-danger',
+                    ].join(' ')}
+                    role="status"
                   >
-                    {#snippet action()}
-                      <input
-                        readonly
-                        value={selectedSecret.value}
-                        aria-label={selectedSecretControl.label}
-                        class="h-8 w-full rounded-md border border-line-2 bg-bg-2 px-2.5 font-mono text-[12px] text-fg-1 outline-none"
-                      />
-                    {/snippet}
-                  </ListRow>
+                    <AlertCircle class="size-3 shrink-0" />
+                    <span class="truncate">{writeStatus.message}</span>
+                  </div>
+                {/if}
 
-                  <ListRow title="Key" hint={selectedSecret.key}>
-                    {#snippet action()}
-                      <span class="font-mono text-[12px] text-fg-1">{selectedSecret.key}</span>
-                    {/snippet}
-                  </ListRow>
-
-                  <ListRow title="Metadata">
-                    {#snippet action()}
-                      <div class="flex flex-wrap justify-end gap-1.5">
-                        <Pill>{selectedSecret.status ?? 'status unknown'}</Pill>
-                        <Pill
-                          >version {selectedSecret.version === undefined
-                            ? 'unknown'
-                            : selectedSecret.version}</Pill
-                        >
-                      </div>
-                    {/snippet}
-                  </ListRow>
-                </div>
-              </section>
-            {/if}
+                <section>
+                  <SectionHeading title="Set secret" class="mb-2">
+                    {#snippet icon()}<Plus class="size-3.5" />{/snippet}
+                  </SectionHeading>
+                  <div class="grid gap-2 rounded-lg border border-line-1 bg-bg-1 p-3">
+                    <input
+                      type="text"
+                      value={secretWriteKey}
+                      oninput={(e) => (secretWriteKey = e.currentTarget.value)}
+                      placeholder="mycompany.payments.key"
+                      disabled={writing}
+                      aria-label="Secret key"
+                      class="h-8 rounded-md border border-line-2 bg-bg-2 px-2.5 font-mono text-[12px] text-fg-1 outline-none placeholder:text-fg-3 disabled:cursor-not-allowed disabled:opacity-50"
+                    />
+                    <input
+                      type="password"
+                      value={secretWriteValue}
+                      oninput={(e) => (secretWriteValue = e.currentTarget.value)}
+                      placeholder="New secret value"
+                      disabled={writing}
+                      autocomplete="new-password"
+                      aria-label="New secret value"
+                      class="h-8 rounded-md border border-line-2 bg-bg-2 px-2.5 font-mono text-[12px] text-fg-1 outline-none placeholder:text-fg-3 disabled:cursor-not-allowed disabled:opacity-50"
+                    />
+                    <div class="flex justify-end">
+                      <button
+                        type="button"
+                        onclick={setSecretValue}
+                        disabled={writing || !secretWriteKey.trim() || !secretWriteValue}
+                        class="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md border border-line-2 bg-bg-2 px-2.5 text-[11px] font-mono text-fg-1 hover:border-line-3 hover:text-fg-0 disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        <Save class="size-3.5" />
+                        set
+                      </button>
+                    </div>
+                  </div>
+                </section>
+              {/if}
+            </section>
           {:else if !selectedEntry || !selectedControl}
           <EmptyState
             icon={FileJson}
@@ -853,7 +1012,7 @@
             </div>
 
             {#if canWriteConfig}
-              {#if writeStatus}
+              {#if writeStatus?.paneId === 'config'}
                 <div
                   class={[
                     'mt-3 inline-flex max-w-full items-center gap-1.5 rounded-md border px-2.5 py-1.5 font-mono text-[11px]',

--- a/packages/ui/src/lib/settings-authoring-client.test.ts
+++ b/packages/ui/src/lib/settings-authoring-client.test.ts
@@ -3,10 +3,13 @@ import type { QueryResult } from "./reddb/client";
 import {
   SettingsAuthoringClient,
   buildDeleteConfigStatement,
+  buildDeleteSecretStatement,
   buildSetConfigStatement,
+  buildSetSecretStatement,
   configValueToSqlLiteral,
   parseShowConfigResult,
   parseConfigMutationResult,
+  parseSecretMutationResult,
   parseShowSecretsResult,
   type QueryTransport,
 } from "./settings-authoring-client";
@@ -249,6 +252,45 @@ describe("SettingsAuthoringClient", () => {
     expect(calls).toEqual(["SHOW SECRETS mycompany.payments"]);
   });
 
+  it("sets and deletes secrets through SET/DELETE SECRET without echoing the value", async () => {
+    const calls: string[] = [];
+    const transport: QueryTransport = {
+      async query(sql) {
+        calls.push(sql);
+        return {
+          ok: true,
+          query: sql,
+          record_count: 1,
+          result: {
+            columns: ["message", "value"],
+            records: [
+              {
+                values: {
+                  message: "secret set",
+                  value: "sk_live_secret",
+                },
+              },
+            ],
+          },
+        };
+      },
+    };
+    const client = new SettingsAuthoringClient(transport);
+
+    const setResult = await client.setSecret(
+      "mycompany.payments.key",
+      "sk_live_secret"
+    );
+    const deleteResult = await client.deleteSecret("mycompany.payments.key");
+
+    expect(calls).toEqual([
+      "SET SECRET mycompany.payments.key = 'sk_live_secret'",
+      "DELETE SECRET mycompany.payments.key",
+    ]);
+    expect(JSON.stringify(setResult)).not.toContain("sk_live_secret");
+    expect(JSON.stringify(deleteResult)).not.toContain("sk_live_secret");
+  });
+
   it("sets config through SET CONFIG with typed literals", async () => {
     const calls: string[] = [];
     const transport: QueryTransport = {
@@ -347,6 +389,74 @@ describe("config mutation SQL helpers", () => {
           error: "permission denied",
         },
         "DELETE CONFIG"
+      )
+    ).toThrow("permission denied");
+  });
+});
+
+describe("secret mutation SQL helpers", () => {
+  it("builds SET/DELETE SECRET statements and escapes literal values", () => {
+    expect(buildSetSecretStatement("mycompany.payments.key", "sk_live")).toBe(
+      "SET SECRET mycompany.payments.key = 'sk_live'"
+    );
+    expect(buildSetSecretStatement("mycompany.payments.key", "o'hara")).toBe(
+      "SET SECRET mycompany.payments.key = 'o''hara'"
+    );
+    expect(buildDeleteSecretStatement("mycompany.payments.key")).toBe(
+      "DELETE SECRET mycompany.payments.key"
+    );
+  });
+
+  it("rejects unsafe secret keys before query transport sees them", async () => {
+    const calls: string[] = [];
+    const transport: QueryTransport = {
+      async query(sql) {
+        calls.push(sql);
+        return result([]);
+      },
+    };
+    const client = new SettingsAuthoringClient(transport);
+
+    await expect(
+      client.setSecret("mycompany.payments.key; DROP TABLE x", "sk")
+    ).rejects.toThrow("dotted identifier path");
+    await expect(
+      client.deleteSecret("mycompany.payments.key; DROP TABLE x")
+    ).rejects.toThrow("dotted identifier path");
+    expect(calls).toEqual([]);
+  });
+
+  it("redacts successful secret mutation envelopes and surfaces failures", () => {
+    const parsed = parseSecretMutationResult(
+      {
+        ok: true,
+        query: "SET SECRET mycompany.payments.key = 'sk_live_secret'",
+        record_count: 1,
+        result: {
+          columns: ["value"],
+          records: [{ values: { value: "sk_live_secret" } }],
+        },
+      },
+      "SET SECRET"
+    );
+
+    expect(parsed).toEqual({
+      ok: true,
+      query: "SET SECRET",
+      record_count: 0,
+      result: { columns: [], records: [] },
+    });
+    expect(JSON.stringify(parsed)).not.toContain("sk_live_secret");
+    expect(() =>
+      parseSecretMutationResult(
+        {
+          ok: false,
+          query: "DELETE SECRET mycompany.payments.key",
+          record_count: 0,
+          result: { columns: [], records: [] },
+          error: "permission denied",
+        },
+        "DELETE SECRET"
       )
     ).toThrow("permission denied");
   });

--- a/packages/ui/src/lib/settings-authoring-client.ts
+++ b/packages/ui/src/lib/settings-authoring-client.ts
@@ -167,12 +167,36 @@ export function buildDeleteConfigStatement(key: string): string {
   )}`;
 }
 
+export function buildSetSecretStatement(key: string, value: string): string {
+  return `SET SECRET ${normalizeConfigPath(
+    key,
+    "SET SECRET key"
+  )} = ${quoteSqlString(value)}`;
+}
+
+export function buildDeleteSecretStatement(key: string): string {
+  return `DELETE SECRET ${normalizeConfigPath(key, "DELETE SECRET key")}`;
+}
+
 export function parseConfigMutationResult(
   result: QueryResult,
   operation: "SET CONFIG" | "DELETE CONFIG"
 ): QueryResult {
   if (!result.ok) throw new Error(result.error ?? `${operation} failed`);
   return result;
+}
+
+export function parseSecretMutationResult(
+  result: QueryResult,
+  operation: "SET SECRET" | "DELETE SECRET"
+): QueryResult {
+  if (!result.ok) throw new Error(result.error ?? `${operation} failed`);
+  return {
+    ...result,
+    query: operation,
+    record_count: 0,
+    result: { columns: [], records: [] },
+  };
 }
 
 export function parseShowConfigResult(result: QueryResult): ConfigEntry[] {
@@ -261,5 +285,17 @@ export class SettingsAuthoringClient {
   async unsetConfig(key: string): Promise<QueryResult> {
     const result = await this.transport.query(buildDeleteConfigStatement(key));
     return parseConfigMutationResult(result, "DELETE CONFIG");
+  }
+
+  async setSecret(key: string, value: string): Promise<QueryResult> {
+    const result = await this.transport.query(
+      buildSetSecretStatement(key, value)
+    );
+    return parseSecretMutationResult(result, "SET SECRET");
+  }
+
+  async deleteSecret(key: string): Promise<QueryResult> {
+    const result = await this.transport.query(buildDeleteSecretStatement(key));
+    return parseSecretMutationResult(result, "DELETE SECRET");
   }
 }

--- a/packages/ui/src/lib/settings-sections.test.ts
+++ b/packages/ui/src/lib/settings-sections.test.ts
@@ -34,7 +34,10 @@ describe("settings panes registry", () => {
       action: "config:write",
       resource: { kind: "config", name: "*" },
     });
-    expect(SETTINGS_PANES[1].writeGrant).toBeUndefined();
+    expect(SETTINGS_PANES[1].writeGrant).toEqual({
+      action: "vault:write",
+      resource: { kind: "vault", name: "*" },
+    });
   });
 
   it("resolves a pane by id and falls back to Config", () => {

--- a/packages/ui/src/lib/settings-sections.ts
+++ b/packages/ui/src/lib/settings-sections.ts
@@ -78,6 +78,10 @@ export const SETTINGS_PANES: SettingsPane[] = [
       action: "vault:read_metadata",
       resource: { kind: "vault", name: "*" },
     },
+    writeGrant: {
+      action: "vault:write",
+      resource: { kind: "vault", name: "*" },
+    },
   },
 ];
 


### PR DESCRIPTION
Closes #88.

## Summary
- Add SET SECRET / DELETE SECRET statement helpers that redact mutation results.
- Gate Secrets pane authoring controls behind vault:write.
- Add write-only set/rotate form, confirm-before-delete, and success/failure feedback without echoing secret values.

## Validation
- pnpm --filter @reddb-io/ui test -- settings-authoring-client settings-sections permission-gate
- pnpm --filter @reddb-io/ui check
- pnpm --filter @reddb-io/ui build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783172449&installation_id=129708444&pr_number=101&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F101&signature=2963a7ed98230b631594dbc3d3d9b4c449353daef061dd51c5dec868a41156fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to set and delete secrets directly from the settings interface.
  * Implemented permission-based access control for secret management operations.
  * Per-pane write status tracking provides clearer feedback on operation results.

* **Tests**
  * Expanded test coverage for secret mutation operations and authorization checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->