### PR TITLE
Secret reveal: gated audited break-glass plaintext

### DIFF
--- a/packages/ui/src/lib/SettingsView.svelte
+++ b/packages/ui/src/lib/SettingsView.svelte
@@ -6,6 +6,8 @@
     Download,
     FileJson,
     KeyRound,
+    Eye,
+    EyeOff,
     Link2,
     Plus,
     RefreshCw,
@@ -83,6 +85,17 @@
   let editingSecretSelectionKey = $state<string | null>(null)
   let secretWriteKey = $state('')
   let secretWriteValue = $state('')
+  let revealing = $state(false)
+  let revealStatus = $state<{
+    tone: 'ok' | 'error'
+    message: string
+    key: string
+  } | null>(null)
+  let revealedSecret = $state<{
+    key: string
+    value: string
+  } | null>(null)
+  let revealTimer: ReturnType<typeof setTimeout> | null = null
 
   const connected = $derived(connection.connected)
   const activeUrl = $derived(connection.active.url)
@@ -114,6 +127,14 @@
       !!activePane.writeGrant &&
       permissions?.cachedCan(activePane.writeGrant) === true,
   )
+  const canRevealSecrets = $derived(
+    activePane.id === 'secrets' &&
+      !!activePane.revealGrant &&
+      permissions?.cachedCan(activePane.revealGrant) === true,
+  )
+  const selectedSecretPlaintext = $derived(
+    selectedSecret && revealedSecret?.key === selectedSecret.key ? revealedSecret.value : null,
+  )
 
   function setQuery(value: string) {
     if (!hasVisiblePane) return
@@ -122,6 +143,28 @@
 
   function setWriteStatus(paneId: string, tone: 'ok' | 'error', message: string) {
     writeStatus = { paneId, tone, message }
+  }
+
+  function clearRevealedSecret() {
+    if (revealTimer) {
+      clearTimeout(revealTimer)
+      revealTimer = null
+    }
+    revealedSecret = null
+  }
+
+  function showRevealedSecret(key: string, value: string) {
+    clearRevealedSecret()
+    revealedSecret = { key, value }
+    revealTimer = setTimeout(() => {
+      revealedSecret = null
+      revealTimer = null
+    }, 30_000)
+  }
+
+  function selectSecretKey(key: string) {
+    if (selectedSecretKey !== key) clearRevealedSecret()
+    selectedSecretKey = key
   }
 
   function onWindowKey(e: KeyboardEvent) {
@@ -147,6 +190,8 @@
     editingSecretSelectionKey = null
     secretWriteKey = ''
     secretWriteValue = ''
+    revealStatus = null
+    clearRevealedSecret()
 
     if (!client || !connected) {
       permissionsLoading = false
@@ -159,7 +204,9 @@
       await activity.track('settings · auth.can panes', () =>
         gate.preload(
           SETTINGS_PANES.flatMap((pane) =>
-            pane.writeGrant ? [pane.readGrant, pane.writeGrant] : [pane.readGrant],
+            [pane.readGrant, pane.writeGrant, pane.revealGrant].filter(
+              (check): check is NonNullable<typeof check> => !!check,
+            ),
           ),
         ),
       )
@@ -203,6 +250,8 @@
     loading = true
     if (activePane.id === 'secrets') {
       secretsLoadError = null
+      revealStatus = null
+      clearRevealedSecret()
     } else {
       configLoadError = null
     }
@@ -381,6 +430,36 @@
       setWriteStatus('secrets', 'error', (e as Error).message)
     } finally {
       writing = false
+    }
+  }
+
+  async function revealSelectedSecret() {
+    const client = connection.client
+    if (!client || !selectedSecret || !canRevealSecrets || revealing) return
+
+    const key = selectedSecret.key
+    revealing = true
+    revealStatus = null
+    clearRevealedSecret()
+    try {
+      const authoring = new SettingsAuthoringClient(client)
+      const revealed = await activity.track('settings · reveal secret', () =>
+        authoring.revealSecret(key),
+      )
+      showRevealedSecret(revealed.key, revealed.value)
+      revealStatus = {
+        tone: 'ok',
+        key,
+        message: 'Plaintext revealed temporarily.',
+      }
+    } catch (e) {
+      revealStatus = {
+        tone: 'error',
+        key,
+        message: (e as Error).message,
+      }
+    } finally {
+      revealing = false
     }
   }
 
@@ -608,7 +687,7 @@
                 <button
                   type="button"
                   aria-current={selectedSecret?.key === entry.key ? 'page' : undefined}
-                  onclick={() => (selectedSecretKey = entry.key)}
+                  onclick={() => selectSecretKey(entry.key)}
                   class="min-w-0 text-left"
                 >
                   <span class="block truncate text-[13px]">{control.label}</span>
@@ -771,14 +850,14 @@
                   <div class="divide-y divide-line-1 overflow-hidden rounded-lg border border-line-1 bg-bg-1">
                     <ListRow
                       title={selectedSecretControl.label}
-                      description="Vault metadata row; plaintext is not available in this pane."
+                      description="Vault metadata row; plaintext is masked unless break-glass reveal is granted."
                       hint={selectedSecret.key}
                       wide
                     >
                       {#snippet action()}
                         <input
                           readonly
-                          value={selectedSecret.value}
+                          value={selectedSecretPlaintext ?? selectedSecret.value}
                           aria-label={selectedSecretControl.label}
                           class="h-8 w-full rounded-md border border-line-2 bg-bg-2 px-2.5 font-mono text-[12px] text-fg-1 outline-none"
                         />
@@ -804,6 +883,33 @@
                       {/snippet}
                     </ListRow>
 
+                    {#if canRevealSecrets}
+                      <ListRow title="Break-glass reveal" description="Calls reddb's audited UNSEAL VAULT path and clears plaintext after 30 seconds.">
+                        {#snippet action()}
+                          {#if selectedSecretPlaintext !== null}
+                            <button
+                              type="button"
+                              onclick={clearRevealedSecret}
+                              class="inline-flex h-8 items-center gap-1.5 rounded-md border border-line-2 bg-bg-2 px-2.5 text-[11px] font-mono text-fg-1 hover:border-line-3 hover:text-fg-0"
+                            >
+                              <EyeOff class="size-3.5" />
+                              hide
+                            </button>
+                          {:else}
+                            <button
+                              type="button"
+                              onclick={revealSelectedSecret}
+                              disabled={revealing}
+                              class="inline-flex h-8 items-center gap-1.5 rounded-md border border-warn/40 bg-warn/5 px-2.5 text-[11px] font-mono text-warn hover:border-warn/70 disabled:cursor-not-allowed disabled:opacity-40"
+                            >
+                              <Eye class={revealing ? 'size-3.5 animate-pulse' : 'size-3.5'} />
+                              reveal
+                            </button>
+                          {/if}
+                        {/snippet}
+                      </ListRow>
+                    {/if}
+
                     {#if canWriteSecrets}
                       <ListRow title="Authoring" description="Delete the selected vault secret through DELETE SECRET.">
                         {#snippet action()}
@@ -821,6 +927,21 @@
                     {/if}
                   </div>
                 </section>
+              {/if}
+
+              {#if revealStatus && revealStatus.key === selectedSecret?.key}
+                <div
+                  class={[
+                    'inline-flex max-w-full items-center gap-1.5 rounded-md border px-2.5 py-1.5 font-mono text-[11px]',
+                    revealStatus.tone === 'ok'
+                      ? 'border-ok/30 bg-ok/5 text-ok'
+                      : 'border-danger/30 bg-danger/5 text-danger',
+                  ].join(' ')}
+                  role="status"
+                >
+                  <AlertCircle class="size-3 shrink-0" />
+                  <span class="truncate">{revealStatus.message}</span>
+                </div>
               {/if}
 
               {#if canWriteSecrets}

--- a/packages/ui/src/lib/settings-authoring-client.test.ts
+++ b/packages/ui/src/lib/settings-authoring-client.test.ts
@@ -4,11 +4,13 @@ import {
   SettingsAuthoringClient,
   buildDeleteConfigStatement,
   buildDeleteSecretStatement,
+  buildRevealSecretStatement,
   buildSetConfigStatement,
   buildSetSecretStatement,
   configValueToSqlLiteral,
   parseShowConfigResult,
   parseConfigMutationResult,
+  parseRevealSecretResult,
   parseSecretMutationResult,
   parseShowSecretsResult,
   type QueryTransport,
@@ -291,6 +293,45 @@ describe("SettingsAuthoringClient", () => {
     expect(JSON.stringify(deleteResult)).not.toContain("sk_live_secret");
   });
 
+  it("reveals a secret through UNSEAL VAULT without using SHOW SECRETS", async () => {
+    const calls: string[] = [];
+    const transport: QueryTransport = {
+      async query(sql) {
+        calls.push(sql);
+        return result([
+          { key: "mycompany.payments.key", value: "sk_live_secret" },
+        ]);
+      },
+    };
+
+    await expect(
+      new SettingsAuthoringClient(transport).revealSecret(
+        "mycompany.payments.key"
+      )
+    ).resolves.toEqual({
+      key: "mycompany.payments.key",
+      value: "sk_live_secret",
+    });
+    expect(calls).toEqual(["UNSEAL VAULT mycompany.payments.key"]);
+  });
+
+  it("rejects unsafe reveal keys before calling the transport", async () => {
+    const calls: string[] = [];
+    const transport: QueryTransport = {
+      async query(sql) {
+        calls.push(sql);
+        return result([]);
+      },
+    };
+
+    await expect(
+      new SettingsAuthoringClient(transport).revealSecret(
+        "mycompany.payments.key; SHOW SECRETS"
+      )
+    ).rejects.toThrow("dotted identifier path");
+    expect(calls).toEqual([]);
+  });
+
   it("sets config through SET CONFIG with typed literals", async () => {
     const calls: string[] = [];
     const transport: QueryTransport = {
@@ -459,5 +500,60 @@ describe("secret mutation SQL helpers", () => {
         "DELETE SECRET"
       )
     ).toThrow("permission denied");
+  });
+});
+
+describe("secret reveal SQL helpers", () => {
+  it("builds UNSEAL VAULT statements", () => {
+    expect(buildRevealSecretStatement("mycompany.payments.key")).toBe(
+      "UNSEAL VAULT mycompany.payments.key"
+    );
+  });
+
+  it("parses plaintext from supported UNSEAL VAULT result columns", () => {
+    expect(
+      parseRevealSecretResult(
+        result([{ key: "mycompany.payments.value", value: "from-value" }]),
+        "mycompany.payments.value"
+      )
+    ).toEqual({ key: "mycompany.payments.value", value: "from-value" });
+    expect(
+      parseRevealSecretResult(
+        result([
+          { key: "mycompany.payments.plaintext", plaintext: "from-plaintext" },
+        ]),
+        "mycompany.payments.plaintext"
+      )
+    ).toEqual({
+      key: "mycompany.payments.plaintext",
+      value: "from-plaintext",
+    });
+    expect(
+      parseRevealSecretResult(
+        result([{ key: "mycompany.payments.secret", secret: "from-secret" }]),
+        "mycompany.payments.secret"
+      )
+    ).toEqual({ key: "mycompany.payments.secret", value: "from-secret" });
+  });
+
+  it("surfaces UNSEAL VAULT failures and missing plaintext", () => {
+    expect(() =>
+      parseRevealSecretResult(
+        {
+          ok: false,
+          query: "UNSEAL VAULT mycompany.payments.key",
+          record_count: 0,
+          result: { columns: [], records: [] },
+          error: "permission denied",
+        },
+        "mycompany.payments.key"
+      )
+    ).toThrow("permission denied");
+    expect(() =>
+      parseRevealSecretResult(
+        result([{ key: "mycompany.payments.key" }]),
+        "mycompany.payments.key"
+      )
+    ).toThrow("UNSEAL VAULT returned no plaintext value");
   });
 });

--- a/packages/ui/src/lib/settings-authoring-client.ts
+++ b/packages/ui/src/lib/settings-authoring-client.ts
@@ -40,6 +40,11 @@ export interface SecretEntry {
   version?: number;
 }
 
+export interface RevealedSecret {
+  key: string;
+  value: string;
+}
+
 export interface QueryTransport {
   query(sql: string): Promise<QueryResult>;
 }
@@ -178,6 +183,10 @@ export function buildDeleteSecretStatement(key: string): string {
   return `DELETE SECRET ${normalizeConfigPath(key, "DELETE SECRET key")}`;
 }
 
+export function buildRevealSecretStatement(key: string): string {
+  return `UNSEAL VAULT ${normalizeConfigPath(key, "UNSEAL VAULT key")}`;
+}
+
 export function parseConfigMutationResult(
   result: QueryResult,
   operation: "SET CONFIG" | "DELETE CONFIG"
@@ -197,6 +206,24 @@ export function parseSecretMutationResult(
     record_count: 0,
     result: { columns: [], records: [] },
   };
+}
+
+export function parseRevealSecretResult(
+  result: QueryResult,
+  key: string
+): RevealedSecret {
+  if (!result.ok) throw new Error(result.error ?? "UNSEAL VAULT failed");
+
+  for (const record of result.result.records) {
+    const values = record.values;
+    const rowKey = optionalString(values.key);
+    if (rowKey && rowKey !== key) continue;
+
+    const value = values.value ?? values.plaintext ?? values.secret;
+    if (typeof value === "string") return { key, value };
+  }
+
+  throw new Error("UNSEAL VAULT returned no plaintext value");
 }
 
 export function parseShowConfigResult(result: QueryResult): ConfigEntry[] {
@@ -297,5 +324,13 @@ export class SettingsAuthoringClient {
   async deleteSecret(key: string): Promise<QueryResult> {
     const result = await this.transport.query(buildDeleteSecretStatement(key));
     return parseSecretMutationResult(result, "DELETE SECRET");
+  }
+
+  async revealSecret(key: string): Promise<RevealedSecret> {
+    const normalized = normalizeConfigPath(key, "UNSEAL VAULT key");
+    const result = await this.transport.query(
+      buildRevealSecretStatement(normalized)
+    );
+    return parseRevealSecretResult(result, normalized);
   }
 }

--- a/packages/ui/src/lib/settings-sections.test.ts
+++ b/packages/ui/src/lib/settings-sections.test.ts
@@ -38,6 +38,10 @@ describe("settings panes registry", () => {
       action: "vault:write",
       resource: { kind: "vault", name: "*" },
     });
+    expect(SETTINGS_PANES[1].revealGrant).toEqual({
+      action: "vault:read",
+      resource: { kind: "vault", name: "*" },
+    });
   });
 
   it("resolves a pane by id and falls back to Config", () => {

--- a/packages/ui/src/lib/settings-sections.ts
+++ b/packages/ui/src/lib/settings-sections.ts
@@ -52,6 +52,8 @@ export interface SettingsPane {
   readGrant: PermissionCheck;
   /** Pane-level grant that enables authoring controls when present. */
   writeGrant?: PermissionCheck;
+  /** Pane-level grant that enables break-glass secret reveal controls. */
+  revealGrant?: PermissionCheck;
 }
 
 export const SETTINGS_PANES: SettingsPane[] = [
@@ -80,6 +82,10 @@ export const SETTINGS_PANES: SettingsPane[] = [
     },
     writeGrant: {
       action: "vault:write",
+      resource: { kind: "vault", name: "*" },
+    },
+    revealGrant: {
+      action: "vault:read",
       resource: { kind: "vault", name: "*" },
     },
   },


### PR DESCRIPTION
Closes #89

## Summary
- add a break-glass reveal control for Secrets, visible only when the permission cache allows the reveal grant
- call the backend audited `UNSEAL VAULT <key>` path through `SettingsAuthoringClient.revealSecret()`
- show plaintext transiently and clear it on hide, pane changes, reloads, or after 30 seconds
- cover reveal SQL, parsing, unsafe key rejection, and the `vault:read` gate in unit tests

## Validation
- `pnpm --filter @reddb-io/ui test -- settings-authoring-client settings-sections permission-gate`
- `pnpm --filter @reddb-io/ui check`
- `pnpm --filter @reddb-io/ui build`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783173863&installation_id=129708444&pr_number=102&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F102&signature=389a61c7f110bdc4cdfae565754f55bfb22328b9414c468e9bf10814bba07dd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "break-glass reveal" functionality allowing users to temporarily view masked secrets. Revealed secrets automatically clear after 30 seconds. Feature availability is controlled by permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->