### PR TITLE
Policies viewer: effective set and capability matrix

### DIFF
--- a/packages/ui/src/lib/SecurityView.svelte
+++ b/packages/ui/src/lib/SecurityView.svelte
@@ -4,22 +4,33 @@
   import EmptyState from '$lib/EmptyState.svelte'
   import { activity } from '$lib/activity.svelte'
   import { connection } from '$lib/connections.svelte'
+  import type { PermissionDecision } from '$lib/permission-gate'
+  import {
+    POLICY_READ_CHECK,
+    assembleCapabilityMatrix,
+    capabilityMatrixChecksFromPolicies,
+    type CapabilityMatrixRow,
+  } from '$lib/policies'
   import { secureStore } from '$lib/secureStore.svelte'
   import type { AuthPolicy, AuthTenant, AuthUser, Whoami } from '#reddb'
-  import { Building2, Lock, RefreshCw, ScrollText, Shield, ShieldAlert, Users } from 'lucide-svelte'
+  import { Building2, CheckCircle2, Lock, RefreshCw, ScrollText, ShieldAlert, Users, XCircle } from 'lucide-svelte'
 
   let whoami = $state<Whoami | null>(null)
   let tenants = $state<AuthTenant[]>([])
   let users = $state<AuthUser[]>([])
   let policies = $state<AuthPolicy[]>([])
+  let policyReadDecision = $state<PermissionDecision | null>(null)
+  let capabilityRows = $state<CapabilityMatrixRow[]>([])
   let loading = $state(false)
   let whoamiError = $state<string | null>(null)
   let tenantsError = $state<string | null>(null)
   let usersError = $state<string | null>(null)
   let policiesError = $state<string | null>(null)
+  let capabilityError = $state<string | null>(null)
 
   const activeUrl = $derived(connection.active.url)
   const connected = $derived(connection.connected)
+  const showPolicyPane = $derived(policyReadDecision?.allowed === true)
 
   function fmtTime(v: number | undefined): string {
     if (!v) return '-'
@@ -34,6 +45,8 @@
       tenants = []
       users = []
       policies = []
+      policyReadDecision = null
+      capabilityRows = []
       return
     }
     loading = true
@@ -41,6 +54,9 @@
     tenantsError = null
     usersError = null
     policiesError = null
+    capabilityError = null
+    policyReadDecision = null
+    capabilityRows = []
     try {
       whoami = await activity.track('security · whoami', () => client.whoami())
     } catch (e) {
@@ -48,13 +64,51 @@
       whoami = null
     }
     try {
+      tenants = await activity.track('security · tenants', () => client.tenants())
+    } catch (e) {
+      tenantsError = (e as Error).message
+      tenants = []
+    }
+    try {
       users = await activity.track('security · users', () => client.users())
     } catch (e) {
       usersError = (e as Error).message
       users = []
-    } finally {
-      loading = false
     }
+    try {
+      const [decision] = await activity.track('security · auth.can policy read', () => client.authCan([POLICY_READ_CHECK]))
+      policyReadDecision = decision ?? {
+        ...POLICY_READ_CHECK,
+        allowed: false,
+        reason: 'auth.can omitted policy-read decision',
+      }
+    } catch (e) {
+      policyReadDecision = {
+        ...POLICY_READ_CHECK,
+        allowed: false,
+        reason: (e as Error).message || 'auth.can failed',
+      }
+    }
+    if (policyReadDecision.allowed) {
+      try {
+        policies = await activity.track('security · policies', () => client.policies())
+      } catch (e) {
+        policiesError = (e as Error).message
+        policies = []
+      }
+      try {
+        const checks = capabilityMatrixChecksFromPolicies(policies)
+        const decisions = await activity.track('security · auth.can capability matrix', () => client.authCan(checks))
+        capabilityRows = assembleCapabilityMatrix(policies, decisions)
+      } catch (e) {
+        capabilityError = (e as Error).message
+        capabilityRows = []
+      }
+    } else {
+      policies = []
+      capabilityRows = []
+    }
+    loading = false
   }
 
   $effect(() => {
@@ -142,38 +196,40 @@
           {/if}
         </Card>
 
-        <Card title="policies">
-          {#if policiesError}
-            <div class="mb-2 inline-flex items-center gap-1.5 rounded border border-warn/40 bg-bg-0 px-2 py-1 text-[11px] font-mono text-warn">
-              <ShieldAlert class="size-3.5" />
-              policies endpoint denied or unavailable
-            </div>
-            <pre class="whitespace-pre-wrap break-words text-[12px] font-mono text-fg-3">{policiesError}</pre>
-          {:else if policies.length === 0}
-            <div class="flex items-center gap-2 text-[12px] font-mono text-fg-3">
-              <ScrollText class="size-4" />
-              <span>No policies returned for this principal.</span>
-            </div>
-          {:else}
-            <div class="grid gap-1 text-[12px] font-mono">
-              {#each policies.slice(0, 6) as policy, i (`${policy.id ?? policy.name ?? i}`)}
-                <div class="rounded border border-line-1 bg-bg-0 px-2 py-1.5">
-                  <div class="flex items-center gap-2">
-                    <span class="text-fg-0">{policy.name ?? policy.id ?? 'policy'}</span>
-                    {#if policy.effect}<Badge tone={policy.effect === 'deny' ? 'danger' : 'ok'}>{policy.effect}</Badge>{/if}
+        {#if showPolicyPane}
+          <Card title="policies">
+            {#if policiesError}
+              <div class="mb-2 inline-flex items-center gap-1.5 rounded border border-warn/40 bg-bg-0 px-2 py-1 text-[11px] font-mono text-warn">
+                <ShieldAlert class="size-3.5" />
+                policies endpoint denied or unavailable
+              </div>
+              <pre class="whitespace-pre-wrap break-words text-[12px] font-mono text-fg-3">{policiesError}</pre>
+            {:else if policies.length === 0}
+              <div class="flex items-center gap-2 text-[12px] font-mono text-fg-3">
+                <ScrollText class="size-4" />
+                <span>No policies returned for this principal.</span>
+              </div>
+            {:else}
+              <div class="grid gap-1 text-[12px] font-mono">
+                {#each policies.slice(0, 6) as policy, i (`${policy.id ?? policy.name ?? i}`)}
+                  <div class="rounded border border-line-1 bg-bg-0 px-2 py-1.5">
+                    <div class="flex items-center gap-2">
+                      <span class="text-fg-0">{policy.name ?? policy.id ?? 'policy'}</span>
+                      {#if policy.effect}<Badge tone={policy.effect === 'deny' ? 'danger' : 'ok'}>{policy.effect}</Badge>{/if}
+                    </div>
+                    <div class="mt-1 text-fg-3">
+                      {policy.action ?? '*'} · {policy.resource ?? '*'}
+                      {#if policy.tenant} · tenant {policy.tenant}{/if}
+                    </div>
                   </div>
-                  <div class="mt-1 text-fg-3">
-                    {policy.action ?? '*'} · {policy.resource ?? '*'}
-                    {#if policy.tenant} · tenant {policy.tenant}{/if}
-                  </div>
-                </div>
-              {/each}
-              {#if policies.length > 6}
-                <div class="text-[11px] text-fg-3">{policies.length - 6} more policies in the table.</div>
-              {/if}
-            </div>
-          {/if}
-        </Card>
+                {/each}
+                {#if policies.length > 6}
+                  <div class="text-[11px] text-fg-3">{policies.length - 6} more policies in the table.</div>
+                {/if}
+              </div>
+            {/if}
+          </Card>
+        {/if}
       </div>
 
       <div class="grid gap-3 content-start">
@@ -217,38 +273,93 @@
           {/if}
         </Card>
 
-        <Card title="policy table">
-          {#if policiesError}
-            <div class="text-[12px] font-mono text-fg-3">Policy table unavailable for this principal.</div>
-          {:else if policies.length === 0}
-            <div class="text-[12px] font-mono text-fg-3">No policies to tabulate.</div>
-          {:else}
-            <div class="overflow-auto">
-              <table class="w-full border-collapse text-[12px] font-mono">
-                <thead class="sticky top-0 bg-bg-1">
-                  <tr class="border-b border-line-1 text-fg-3">
-                    <th class="px-2 py-1.5 text-left font-normal">effect</th>
-                    <th class="px-2 py-1.5 text-left font-normal">principal</th>
-                    <th class="px-2 py-1.5 text-left font-normal">action</th>
-                    <th class="px-2 py-1.5 text-left font-normal">resource</th>
-                    <th class="px-2 py-1.5 text-left font-normal">tenant</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {#each policies as policy, i (`${policy.id ?? policy.name ?? i}`)}
-                    <tr class="border-b border-line-1/60 hover:bg-bg-1/40">
-                      <td class="px-2 py-1">{#if policy.effect}<Badge tone={policy.effect === 'deny' ? 'danger' : 'ok'}>{policy.effect}</Badge>{:else}<span class="text-fg-3">-</span>{/if}</td>
-                      <td class="px-2 py-1 text-fg-1">{policy.principal ?? '-'}</td>
-                      <td class="px-2 py-1 text-accent">{policy.action ?? '*'}</td>
-                      <td class="px-2 py-1 text-fg-1">{policy.resource ?? '*'}</td>
-                      <td class="px-2 py-1 text-fg-2">{policy.tenant ?? '-'}</td>
+        {#if showPolicyPane}
+          <Card title="policy table">
+            {#if policiesError}
+              <div class="text-[12px] font-mono text-fg-3">Policy table unavailable for this principal.</div>
+            {:else if policies.length === 0}
+              <div class="text-[12px] font-mono text-fg-3">No policies to tabulate.</div>
+            {:else}
+              <div class="overflow-auto">
+                <table class="w-full border-collapse text-[12px] font-mono">
+                  <thead class="sticky top-0 bg-bg-1">
+                    <tr class="border-b border-line-1 text-fg-3">
+                      <th class="px-2 py-1.5 text-left font-normal">effect</th>
+                      <th class="px-2 py-1.5 text-left font-normal">principal</th>
+                      <th class="px-2 py-1.5 text-left font-normal">action</th>
+                      <th class="px-2 py-1.5 text-left font-normal">resource</th>
+                      <th class="px-2 py-1.5 text-left font-normal">tenant</th>
                     </tr>
-                  {/each}
-                </tbody>
-              </table>
-            </div>
-          {/if}
-        </Card>
+                  </thead>
+                  <tbody>
+                    {#each policies as policy, i (`${policy.id ?? policy.name ?? i}`)}
+                      <tr class="border-b border-line-1/60 hover:bg-bg-1/40">
+                        <td class="px-2 py-1">{#if policy.effect}<Badge tone={policy.effect === 'deny' ? 'danger' : 'ok'}>{policy.effect}</Badge>{:else}<span class="text-fg-3">-</span>{/if}</td>
+                        <td class="px-2 py-1 text-fg-1">{policy.principal ?? '-'}</td>
+                        <td class="px-2 py-1 text-accent">{policy.action ?? '*'}</td>
+                        <td class="px-2 py-1 text-fg-1">{policy.resource ?? '*'}</td>
+                        <td class="px-2 py-1 text-fg-2">{policy.tenant ?? '-'}</td>
+                      </tr>
+                    {/each}
+                  </tbody>
+                </table>
+              </div>
+            {/if}
+          </Card>
+
+          <Card title="my capabilities">
+            {#if capabilityError}
+              <div class="mb-2 inline-flex items-center gap-1.5 rounded border border-warn/40 bg-bg-0 px-2 py-1 text-[11px] font-mono text-warn">
+                <ShieldAlert class="size-3.5" />
+                capability matrix unavailable
+              </div>
+              <pre class="whitespace-pre-wrap break-words text-[12px] font-mono text-fg-3">{capabilityError}</pre>
+            {:else if capabilityRows.length === 0}
+              <div class="text-[12px] font-mono text-fg-3">No capability checks returned.</div>
+            {:else}
+              <div class="overflow-auto">
+                <table class="w-full border-collapse text-[12px] font-mono">
+                  <thead class="sticky top-0 bg-bg-1">
+                    <tr class="border-b border-line-1 text-fg-3">
+                      <th class="px-2 py-1.5 text-left font-normal">can</th>
+                      <th class="px-2 py-1.5 text-left font-normal">action</th>
+                      <th class="px-2 py-1.5 text-left font-normal">resource</th>
+                      <th class="px-2 py-1.5 text-left font-normal">policy effect</th>
+                      <th class="px-2 py-1.5 text-left font-normal">reason</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {#each capabilityRows as row (row.id)}
+                      <tr class="border-b border-line-1/60 hover:bg-bg-1/40">
+                        <td class="px-2 py-1">
+                          {#if row.allowed}
+                            <span class="inline-flex items-center gap-1 text-ok"><CheckCircle2 class="size-3.5" /> yes</span>
+                          {:else}
+                            <span class="inline-flex items-center gap-1 text-danger"><XCircle class="size-3.5" /> no</span>
+                          {/if}
+                        </td>
+                        <td class="px-2 py-1 text-accent">{row.action}</td>
+                        <td class="px-2 py-1 text-fg-1">{row.resourceLabel}</td>
+                        <td class="px-2 py-1">
+                          {#if row.effects.length === 0}
+                            <span class="text-fg-3">-</span>
+                          {:else}
+                            <span class="inline-flex flex-wrap gap-1">
+                              {#each row.effects as effect}
+                                <Badge tone={effect === 'deny' ? 'danger' : 'ok'}>{effect}</Badge>
+                              {/each}
+                            </span>
+                          {/if}
+                        </td>
+                        <td class="max-w-[320px] px-2 py-1 text-fg-3">{row.reason ?? '-'}</td>
+                      </tr>
+                    {/each}
+                  </tbody>
+                </table>
+              </div>
+            {/if}
+          </Card>
+        {/if}
       </div>
     </div>
   {/if}

--- a/packages/ui/src/lib/policies.test.ts
+++ b/packages/ui/src/lib/policies.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import type { AuthPolicy } from "#reddb";
+import type { PermissionDecision } from "./permission-gate";
+import {
+  POLICY_READ_CHECK,
+  assembleCapabilityMatrix,
+  capabilityMatrixChecksFromPolicies,
+  parsePolicyResource,
+} from "./policies";
+
+const policies: AuthPolicy[] = [
+  {
+    id: "p1",
+    name: "collection readers",
+    principal: "role:analyst",
+    action: "collection:read",
+    resource: "collection:orders",
+    effect: "allow",
+  },
+  {
+    id: "p2",
+    name: "collection readers duplicate",
+    principal: "role:analyst",
+    action: "collection:read",
+    resource: "collection:orders",
+    effect: "allow",
+  },
+  {
+    id: "p3",
+    name: "tenant secret deny",
+    principal: "user:me",
+    action: "vault:read",
+    resource: "vault/*",
+    tenant: "acme",
+    effect: "deny",
+  },
+];
+
+describe("policy capability matrix", () => {
+  it("parses policy resource strings into auth.can resources", () => {
+    expect(parsePolicyResource("collection:orders")).toEqual({
+      kind: "collection",
+      name: "orders",
+      tenant: undefined,
+    });
+    expect(parsePolicyResource("vault/*", "acme")).toEqual({
+      kind: "vault",
+      name: "*",
+      tenant: "acme",
+    });
+    expect(parsePolicyResource("*")).toEqual({
+      kind: "resource",
+      name: "*",
+      tenant: undefined,
+    });
+  });
+
+  it("builds a de-duplicated auth.can batch from the effective policy set", () => {
+    expect(capabilityMatrixChecksFromPolicies(policies)).toEqual([
+      POLICY_READ_CHECK,
+      {
+        action: "collection:read",
+        resource: { kind: "collection", name: "orders", tenant: undefined },
+      },
+      {
+        action: "vault:read",
+        resource: { kind: "vault", name: "*", tenant: "acme" },
+      },
+    ]);
+  });
+
+  it("assembles readable allowed and denied rows from auth.can decisions", () => {
+    const decisions: PermissionDecision[] = [
+      { ...POLICY_READ_CHECK, allowed: true, reason: "policy-read grant" },
+      {
+        action: "collection:read",
+        resource: { kind: "collection", name: "orders" },
+        allowed: true,
+        reason: "allow at p1.statement[0]",
+      },
+      {
+        action: "vault:read",
+        resource: { kind: "vault", name: "*", tenant: "acme" },
+        allowed: false,
+        reason: "explicit deny at p3.statement[0]",
+      },
+    ];
+
+    expect(assembleCapabilityMatrix(policies, decisions)).toMatchObject([
+      {
+        action: "policy:read",
+        resourceLabel: "policy:*",
+        allowed: true,
+        reason: "policy-read grant",
+        effects: [],
+      },
+      {
+        action: "collection:read",
+        resourceLabel: "collection:orders",
+        allowed: true,
+        effects: ["allow"],
+        principals: ["role:analyst"],
+        policies: ["collection readers", "collection readers duplicate"],
+      },
+      {
+        action: "vault:read",
+        resourceLabel: "vault:* @ acme",
+        allowed: false,
+        reason: "explicit deny at p3.statement[0]",
+        effects: ["deny"],
+        principals: ["user:me"],
+        policies: ["tenant secret deny"],
+      },
+    ]);
+  });
+});

--- a/packages/ui/src/lib/policies.ts
+++ b/packages/ui/src/lib/policies.ts
@@ -1,0 +1,136 @@
+import type { AuthPolicy } from "#reddb";
+import type {
+  PermissionCheck,
+  PermissionDecision,
+  PermissionResource,
+} from "./permission-gate";
+
+export const POLICY_READ_CHECK: PermissionCheck = {
+  action: "policy:read",
+  resource: { kind: "policy", name: "*" },
+};
+
+export interface CapabilityMatrixRow {
+  id: string;
+  action: string;
+  resource: PermissionResource;
+  resourceLabel: string;
+  allowed: boolean;
+  reason?: string;
+  effects: string[];
+  principals: string[];
+  policies: string[];
+}
+
+function matrixKey(check: PermissionCheck): string {
+  return [
+    check.action,
+    check.resource.kind,
+    check.resource.name,
+    check.resource.tenant ?? "",
+    check.current_tenant ?? "",
+  ].join("\u001f");
+}
+
+function resourceLabel(resource: PermissionResource): string {
+  const base = `${resource.kind}:${resource.name}`;
+  return resource.tenant ? `${base} @ ${resource.tenant}` : base;
+}
+
+export function parsePolicyResource(
+  value: string | undefined,
+  tenant?: string
+): PermissionResource {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed === "*")
+    return { kind: "resource", name: "*", tenant };
+
+  const separator = trimmed.includes(":")
+    ? ":"
+    : trimmed.includes("/")
+      ? "/"
+      : null;
+  if (!separator) return { kind: "resource", name: trimmed, tenant };
+
+  const [kind, ...rest] = trimmed.split(separator);
+  const name = rest.join(separator) || "*";
+  return {
+    kind: kind || "resource",
+    name,
+    tenant,
+  };
+}
+
+export function capabilityMatrixChecksFromPolicies(
+  policies: readonly AuthPolicy[]
+): PermissionCheck[] {
+  const checks = [POLICY_READ_CHECK];
+  const seen = new Set(checks.map(matrixKey));
+
+  for (const policy of policies) {
+    const check: PermissionCheck = {
+      action: policy.action?.trim() || "*",
+      resource: parsePolicyResource(policy.resource, policy.tenant),
+    };
+    const key = matrixKey(check);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    checks.push(check);
+  }
+
+  return checks;
+}
+
+export function assembleCapabilityMatrix(
+  policies: readonly AuthPolicy[],
+  decisions: readonly PermissionDecision[]
+): CapabilityMatrixRow[] {
+  const policyChecks = capabilityMatrixChecksFromPolicies(policies);
+  const decisionsByKey = new Map(
+    decisions.map((decision) => [matrixKey(decision), decision] as const)
+  );
+
+  return policyChecks.map((check) => {
+    const decision = decisionsByKey.get(matrixKey(check));
+    const related = policies.filter((policy) => {
+      const policyCheck: PermissionCheck = {
+        action: policy.action?.trim() || "*",
+        resource: parsePolicyResource(policy.resource, policy.tenant),
+      };
+      return matrixKey(policyCheck) === matrixKey(check);
+    });
+
+    return {
+      id: matrixKey(check),
+      action: check.action,
+      resource: check.resource,
+      resourceLabel: resourceLabel(check.resource),
+      allowed: decision?.allowed === true,
+      reason: decision?.reason,
+      effects: [
+        ...new Set(
+          related
+            .map((policy) => policy.effect)
+            .filter((effect): effect is string => !!effect)
+        ),
+      ],
+      principals: [
+        ...new Set(
+          related
+            .map((policy) => policy.principal)
+            .filter((principal): principal is string => !!principal)
+        ),
+      ],
+      policies: [
+        ...new Set(
+          related
+            .map(
+              (policy, index) =>
+                policy.name ?? policy.id ?? `policy ${index + 1}`
+            )
+            .filter((name): name is string => !!name)
+        ),
+      ],
+    };
+  });
+}


### PR DESCRIPTION
Closes #90

## Summary
- gate the Security policies surface with `POST /auth/can` for `policy:read`
- fetch and render the read-only effective policy set only when policy-read is allowed
- add a read-only current-principal capability matrix assembled from policies plus `POST /auth/can`
- add fixture tests for policy resource parsing, matrix check de-duplication, and allowed/denied rows

## Validation
- `pnpm --filter @reddb-io/ui test -- policies.test.ts` (43 files, 457 tests passed)
- `pnpm --filter @reddb-io/ui check` (0 errors, 0 warnings)
- `pnpm --filter @reddb-io/ui build`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783175270&installation_id=129708444&pr_number=103&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F103&signature=2b1e081c359a9d3716e96d2a137c13ff003dbd55c772e182e49e24d66207ec8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a capabilities table displaying user permissions with allow/deny status, actions, resources, and rationale.
  * Policy-related UI now only displays when the user has the necessary permissions.

* **Tests**
  * Added comprehensive test suite for policy-related utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->