### PR TITLE
Loading: per-pane skeletons

### DIFF
--- a/packages/ui/src/lib/ClusterView.svelte
+++ b/packages/ui/src/lib/ClusterView.svelte
@@ -24,6 +24,12 @@
   let known = $state<KnownNode[]>([])
   let loading = $state(true)
   let selectedId = $state<string | null>(null)
+  const clusterSkeletonNodes = [
+    { id: 'primary', x: '50%', y: '38%', role: 'primary', label: 92 },
+    { id: 'replica', x: '68%', y: '54%', role: 'replica', label: 112 },
+    { id: 'embedded', x: '32%', y: '54%', role: 'embedded', label: 104 },
+  ]
+  const clusterSkeletonRows = Array.from({ length: 3 }, (_, i) => i)
   // Per-preset failure tracking. Dead nodes back off to one probe per ~60s
   // instead of one per 5s so unreachable presets (e.g. embedded with no
   // local file-backed reddb running) don't flood DevTools with native
@@ -259,8 +265,55 @@
 </script>
 
 {#if loading}
-  <div class="absolute inset-0 grid place-items-center text-fg-3 font-mono text-[12px]">
-    Probing reachable nodes…
+  <div class="absolute inset-0 overflow-hidden bg-bg-0" aria-busy="true" aria-label="Loading cluster topology">
+    <div class="absolute inset-0 cluster-skeleton-grid"></div>
+
+    <svg class="absolute inset-0 h-full w-full" aria-hidden="true">
+      <line x1="50%" y1="38%" x2="32%" y2="54%" class="cluster-skeleton-edge motion-safe:animate-pulse" />
+      <line x1="50%" y1="38%" x2="68%" y2="54%" class="cluster-skeleton-edge motion-safe:animate-pulse" />
+    </svg>
+
+    {#each clusterSkeletonNodes as node (node.id)}
+      <div
+        class="absolute w-[220px] rounded border border-line-2 bg-bg-1 p-3 shadow-md motion-safe:animate-pulse"
+        style={`left: ${node.x}; top: ${node.y}; transform: translate(-50%, -50%);`}
+      >
+        <div class="mb-3 flex items-center gap-2">
+          <div class={[
+            'h-2 w-2 rounded-full',
+            node.role === 'primary' ? 'bg-role-primary' : node.role === 'replica' ? 'bg-role-replica' : 'bg-role-embedded',
+          ].join(' ')}></div>
+          <div class="h-3 rounded bg-bg-3" style={`width: ${node.label}px`}></div>
+        </div>
+        <div class="grid grid-cols-2 gap-2">
+          <div class="h-9 rounded border border-line-1 bg-bg-2"></div>
+          <div class="h-9 rounded border border-line-1 bg-bg-2"></div>
+        </div>
+      </div>
+    {/each}
+
+    <div class="absolute top-4 left-4 z-10 w-64 rounded border border-line-2 bg-bg-1 p-3 shadow-md">
+      <div class="mb-3 h-3 w-16 rounded bg-bg-2 motion-safe:animate-pulse"></div>
+      <div class="mb-3 grid grid-cols-2 gap-3 border-b border-line-1 pb-3">
+        <div>
+          <div class="mb-2 h-3 w-16 rounded bg-bg-2 motion-safe:animate-pulse"></div>
+          <div class="h-6 w-12 rounded bg-bg-2 motion-safe:animate-pulse"></div>
+        </div>
+        <div>
+          <div class="mb-2 h-3 w-14 rounded bg-bg-2 motion-safe:animate-pulse"></div>
+          <div class="h-6 w-20 rounded bg-bg-2 motion-safe:animate-pulse"></div>
+        </div>
+      </div>
+      <div class="grid gap-1">
+        {#each clusterSkeletonRows as row (row)}
+          <div class="flex h-[30px] items-center gap-2.5 rounded px-2">
+            <div class="h-1.5 w-1.5 rounded-full bg-bg-2 motion-safe:animate-pulse"></div>
+            <div class="h-3 flex-1 rounded bg-bg-2 motion-safe:animate-pulse"></div>
+            <div class="h-3 rounded bg-bg-2 motion-safe:animate-pulse" style={`width: ${row === 0 ? 36 : 24}px`}></div>
+          </div>
+        {/each}
+      </div>
+    </div>
   </div>
 {:else if secureStore.locked}
   <div class="p-6">
@@ -537,5 +590,16 @@
     background: var(--color-bg-2) !important;
     color: var(--color-fg-0) !important;
     fill: var(--color-fg-0) !important;
+  }
+  .cluster-skeleton-grid {
+    background-image: radial-gradient(var(--color-line-2) 1px, transparent 1px);
+    background-size: 32px 32px;
+    opacity: 0.55;
+  }
+  .cluster-skeleton-edge {
+    stroke: var(--color-line-2);
+    stroke-width: 1.5;
+    stroke-linecap: round;
+    opacity: 0.7;
   }
 </style>

--- a/packages/ui/src/lib/ResultsPane.svelte
+++ b/packages/ui/src/lib/ResultsPane.svelte
@@ -38,6 +38,8 @@
     { value: 'document', label: 'Document' },
     { value: 'json', label: 'JSON' },
   ]
+  const resultsSkeletonRows = Array.from({ length: 14 }, (_, i) => i)
+  const resultsSkeletonColumns = Array.from({ length: 6 }, (_, i) => i)
 
   let results = $state<Record<string, QueryResult | null>>({})
   let errors = $state<Record<string, string>>({})
@@ -588,8 +590,71 @@
             <pre class="whitespace-pre-wrap">{err}</pre>
           </div>
         {:else if !result}
-          <div class="h-full grid place-items-center text-fg-3 text-[12px] font-mono">
-            Loading {tab.label}…
+          <div class="h-full flex flex-col" aria-busy="true" aria-label={`Loading ${tab.label} results`}>
+            <div class="border-b border-line-1 bg-bg-1/35 px-3 py-2">
+              <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
+                <div class="min-w-[180px] flex-1">
+                  <div class="flex items-center gap-2">
+                    <div class="h-[21px] w-[78px] rounded border border-line-1 bg-bg-2 motion-safe:animate-pulse"></div>
+                    <div class="h-4 w-44 max-w-[45vw] rounded bg-bg-2 motion-safe:animate-pulse"></div>
+                  </div>
+                  <div class="mt-1 flex flex-wrap gap-1">
+                    <div class="h-[21px] w-24 rounded border border-line-1 bg-bg-0/70 motion-safe:animate-pulse"></div>
+                    <div class="h-[21px] w-32 rounded border border-line-1 bg-bg-0/70 motion-safe:animate-pulse"></div>
+                    <div class="h-[21px] w-20 rounded border border-line-1 bg-bg-0/70 motion-safe:animate-pulse"></div>
+                  </div>
+                </div>
+
+                <div class="flex flex-wrap items-center gap-2">
+                  <div class="h-[30px] w-[94px] rounded border border-line-1 bg-bg-0/70 motion-safe:animate-pulse"></div>
+                  <div class="h-[30px] w-[92px] rounded border border-line-1 bg-bg-0/70 motion-safe:animate-pulse"></div>
+                  <div class="h-[30px] w-[92px] rounded border border-line-1 bg-bg-0/70 motion-safe:animate-pulse"></div>
+                  <div class="h-[30px] w-[78px] rounded border border-line-1 bg-bg-0/70 motion-safe:animate-pulse"></div>
+                  <div class="h-[30px] w-[78px] rounded border border-line-1 bg-bg-0/70 motion-safe:animate-pulse"></div>
+                </div>
+              </div>
+            </div>
+
+            <div class="border-b border-line-1 px-3 py-1.5 flex items-center gap-2 bg-bg-1/40">
+              <div class="h-6 w-[70px] rounded border border-line-1 bg-bg-2 motion-safe:animate-pulse"></div>
+              <div class="h-6 w-[54px] rounded border border-line-1 bg-bg-2 motion-safe:animate-pulse"></div>
+              <div class="h-4 w-px bg-line-1"></div>
+              <div class="h-6 w-[76px] rounded border border-line-1 bg-bg-2 motion-safe:animate-pulse"></div>
+              <div class="ml-auto h-3 w-[58px] rounded bg-bg-2 motion-safe:animate-pulse"></div>
+            </div>
+
+            <div class="flex-1 overflow-hidden">
+              <div class="min-w-[760px]">
+                <div class="grid h-8 grid-cols-[40px_repeat(6,minmax(96px,1fr))] border-b border-line-1 bg-bg-1">
+                  <div class="px-2 py-2">
+                    <div class="ml-auto h-3 w-4 rounded bg-bg-2 motion-safe:animate-pulse"></div>
+                  </div>
+                  {#each resultsSkeletonColumns as col (col)}
+                    <div class="px-2 py-2">
+                      <div class="h-3 rounded bg-bg-2 motion-safe:animate-pulse" style={`width: ${col % 3 === 0 ? 72 : col % 3 === 1 ? 104 : 56}px`}></div>
+                    </div>
+                  {/each}
+                </div>
+                {#each resultsSkeletonRows as row (row)}
+                  <div class="grid h-[29px] grid-cols-[40px_repeat(6,minmax(96px,1fr))] border-b border-line-1/60">
+                    <div class="px-2 py-2">
+                      <div class="ml-auto h-3 w-4 rounded bg-bg-2 motion-safe:animate-pulse"></div>
+                    </div>
+                    {#each resultsSkeletonColumns as col (col)}
+                      <div class="px-2 py-2">
+                        <div class="h-3 rounded bg-bg-2 motion-safe:animate-pulse" style={`width: ${col === 0 ? 48 : 64 + ((row + col) % 4) * 18}px`}></div>
+                      </div>
+                    {/each}
+                  </div>
+                {/each}
+              </div>
+            </div>
+
+            <div class="border-t border-line-1 px-3 py-1.5 flex items-center gap-3">
+              <div class="h-3 w-28 rounded bg-bg-2 motion-safe:animate-pulse"></div>
+              <div class="h-3 w-44 rounded bg-bg-2 motion-safe:animate-pulse"></div>
+              <div class="h-3 w-20 rounded bg-bg-2 motion-safe:animate-pulse"></div>
+            </div>
           </div>
         {:else}
           {@const renderer = pickRenderer(tab, result)}

--- a/packages/ui/src/lib/SchemaTree.svelte
+++ b/packages/ui/src/lib/SchemaTree.svelte
@@ -27,6 +27,8 @@
   let error = $state<string | null>(null)
   let search = $state('')
   let capabilityFilter = $state<Capability | 'all'>('all')
+  const skeletonRows = Array.from({ length: 10 }, (_, i) => i)
+  const skeletonChips = Array.from({ length: 4 }, (_, i) => i)
 
   const connected = $derived(connection.connected)
   const activeUrl = $derived(connection.active.url)
@@ -113,7 +115,29 @@
     <div class="mt-1 break-words">{error}</div>
   </div>
 {:else if loading && items.length === 0}
-  <div class="p-3 text-[12px] text-fg-3 font-mono">Loading…</div>
+  <div class="schema-skeleton" aria-busy="true" aria-label="Loading schema">
+    <div class="p-2 border-b border-line-1 grid gap-2">
+      <div class="flex items-center gap-1.5 h-7 rounded border border-line-1 bg-bg-0 px-2">
+        <Search class="size-3 text-fg-3" />
+        <div class="h-3 w-32 rounded bg-bg-2 motion-safe:animate-pulse"></div>
+      </div>
+
+      <div class="flex flex-wrap gap-1">
+        {#each skeletonChips as chip (chip)}
+          <div class="h-5 rounded border border-line-1 bg-bg-1 px-1.5 motion-safe:animate-pulse" style={`width: ${chip === 0 ? 42 : 28 + chip * 8}px`}></div>
+        {/each}
+      </div>
+    </div>
+
+    <ul class="py-1" role="presentation">
+      {#each skeletonRows as row (row)}
+        <li class="flex h-7 items-center gap-2 px-3">
+          <div class="h-4 w-4 rounded bg-bg-2 motion-safe:animate-pulse"></div>
+          <div class="h-3 rounded bg-bg-2 motion-safe:animate-pulse" style={`width: ${row % 3 === 0 ? 132 : row % 3 === 1 ? 96 : 164}px`}></div>
+        </li>
+      {/each}
+    </ul>
+  </div>
 {:else if items.length === 0}
   <div class="p-3 flex flex-col items-start gap-2 text-[12px] text-fg-3 font-mono leading-relaxed">
     <span class="text-fg-2">No user collections.</span>


### PR DESCRIPTION
Closes #92

## Summary
- add skeleton placeholders for pending query results, schema tree, and cluster topology states
- keep failure/unreachable and empty branches on their existing non-skeleton rendering
- size skeletons to the eventual pane geometry and use `motion-safe:animate-pulse` for reduced-motion compatibility

## Validation
- `pnpm --filter @reddb-io/ui test` (44 files, 460 tests passed)
- `pnpm --filter @reddb-io/ui check` (0 errors, 0 warnings)
- `pnpm --filter @reddb-io/ui build`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783177978&installation_id=129708444&pr_number=105&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F105&signature=f3ee9a6acfee2edf79259d373fdd0cd894109449b70b44dbc3ca40bb778f0be2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->