### PR TITLE
Loading: query running controls

### DIFF
--- a/packages/ui/src/lib/QueryEditor.svelte
+++ b/packages/ui/src/lib/QueryEditor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { Play, Loader2 } from 'lucide-svelte'
+  import { Play, Loader2, X } from 'lucide-svelte'
   import { connection } from '$lib/connections.svelte'
-  import { queryTabs, deriveQueryLabel } from '$lib/query-tabs.svelte'
+  import { queryTabs, deriveQueryLabel, formatElapsed } from '$lib/query-tabs.svelte'
   import { tabs } from '$lib/tabs.svelte'
   import { registry } from '$lib/renderers'
   import type { Capability } from '$lib/renderers'
@@ -23,6 +23,19 @@
   const tab = $derived(tabs.tabs.find((t) => t.id === tabId))
 
   let textareaEl: HTMLTextAreaElement | undefined = $state()
+  let now = $state(Date.now())
+  const elapsed = $derived(
+    qs?.runningStartedAt ? formatElapsed(Math.max(0, now - qs.runningStartedAt)) : '0ms'
+  )
+
+  $effect(() => {
+    if (!qs?.running) return
+    now = Date.now()
+    const id = setInterval(() => {
+      now = Date.now()
+    }, 100)
+    return () => clearInterval(id)
+  })
 
   function setSql(value: string) {
     queryTabs.setSql(tabId, value)
@@ -34,6 +47,10 @@
 
   async function run() {
     await queryTabs.run(tabId)
+  }
+
+  function cancel() {
+    queryTabs.cancel(tabId)
   }
 
   function onKey(e: KeyboardEvent) {
@@ -93,14 +110,38 @@
   </div>
 
   <div class="flex-1 overflow-hidden bg-bg-0">
-    {#if qs?.error}
+    {#if qs?.running}
+      <div class="h-full grid place-items-center p-6" aria-live="polite" aria-busy="true">
+        <div class="w-full max-w-md rounded border border-line-1 bg-bg-1 p-4 font-mono">
+          <div class="flex items-start justify-between gap-4">
+            <div class="min-w-0">
+              <div class="flex items-center gap-2 text-fg-1 text-[13px]">
+                <Loader2 class="size-4 animate-spin text-accent" />
+                <span>Running query</span>
+              </div>
+              <div class="mt-2 text-[11px] text-fg-3">
+                elapsed <span class="tabular-nums text-fg-2">{elapsed}</span>
+              </div>
+            </div>
+            <button
+              type="button"
+              class="inline-flex h-7 items-center gap-1 rounded border border-line-2 px-2 text-[11px] text-fg-2 hover:border-danger/50 hover:text-danger cursor-pointer"
+              onclick={cancel}
+              aria-label="Cancel running query"
+            >
+              <X class="size-3.5" />
+              <span>Cancel</span>
+            </button>
+          </div>
+          <div class="mt-3 max-h-24 overflow-hidden rounded bg-bg-0 px-2 py-1.5 text-[11px] text-fg-3">
+            <pre class="m-0 whitespace-pre-wrap break-words">{qs.sql.trim()}</pre>
+          </div>
+        </div>
+      </div>
+    {:else if qs?.error}
       <div class="p-4 text-[12px] font-mono text-warn">
         <div class="font-semibold mb-1">Query failed</div>
         <pre class="whitespace-pre-wrap">{qs.error}</pre>
-      </div>
-    {:else if qs?.running && !qs.result}
-      <div class="h-full grid place-items-center text-fg-3 text-[12px] font-mono">
-        Running…
       </div>
     {:else if !qs?.result}
       <div class="h-full grid place-items-center text-fg-3 text-[12px] font-mono">

--- a/packages/ui/src/lib/Workspace.svelte
+++ b/packages/ui/src/lib/Workspace.svelte
@@ -113,7 +113,9 @@
       queryTabs.setExecutor(null)
       return
     }
-    queryTabs.setExecutor((sql) => runQueryPreferStream(client, sql))
+    queryTabs.setExecutor((sql, options) =>
+      runQueryPreferStream(client, sql, options)
+    )
     pendingChanges.setExecutor(async (changes) =>
       Promise.all(
         changes.map(async (c): Promise<CommitOutcome> => {

--- a/packages/ui/src/lib/query-tabs.svelte.ts
+++ b/packages/ui/src/lib/query-tabs.svelte.ts
@@ -4,57 +4,99 @@
 // running flag. Stored separately from the tabs store so the Tab type
 // stays a thin identity record and switching tabs preserves state.
 
-import type { QueryResult } from '#reddb'
+import { activity } from "./activity.svelte";
+import type { QueryResult } from "#reddb";
 
 export interface QueryTabState {
-  sql: string
-  result: QueryResult | null
-  error: string | null
-  running: boolean
+  sql: string;
+  result: QueryResult | null;
+  error: string | null;
+  running: boolean;
+  runningStartedAt: number | null;
 }
 
-export type QueryExecutor = (sql: string) => Promise<QueryResult>
+export interface QueryRunOptions {
+  signal?: AbortSignal;
+}
+
+export type QueryExecutor = (
+  sql: string,
+  options?: QueryRunOptions
+) => Promise<QueryResult>;
 
 function emptyState(): QueryTabState {
-  return { sql: '', result: null, error: null, running: false }
+  return {
+    sql: "",
+    result: null,
+    error: null,
+    running: false,
+    runningStartedAt: null,
+  };
+}
+
+function queryActivityLabel(sql: string): string {
+  const oneLine = sql.replace(/\s+/g, " ").trim();
+  if (oneLine.length <= 80) return `query · ${oneLine}`;
+  return `query · ${oneLine.slice(0, 79).trimEnd()}…`;
+}
+
+function isAbortError(e: unknown): boolean {
+  return (
+    (e instanceof DOMException && e.name === "AbortError") ||
+    (e instanceof Error && e.name === "AbortError")
+  );
+}
+
+export function formatElapsed(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const minutes = Math.floor(ms / 60_000);
+  const seconds = Math.floor((ms % 60_000) / 1000);
+  return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
 }
 
 class QueryTabsStore {
   /** Per-tab state keyed by tab id. */
-  states = $state<Record<string, QueryTabState>>({})
+  states = $state<Record<string, QueryTabState>>({});
   /** Monotonic counter for "Query N" labels — survives close so numbers don't reuse. */
-  private counter = 0
-  private executor: QueryExecutor | null = null
+  private counter = 0;
+  private executor: QueryExecutor | null = null;
+  private runSeq = 0;
+  private inFlight = new Map<
+    string,
+    { token: number; controller: AbortController }
+  >();
 
   setExecutor(executor: QueryExecutor | null): void {
-    this.executor = executor
+    this.executor = executor;
   }
 
   nextLabel(): string {
-    this.counter += 1
-    return `Query ${this.counter}`
+    this.counter += 1;
+    return `Query ${this.counter}`;
   }
 
   ensure(id: string): QueryTabState {
-    if (!this.states[id]) this.states[id] = emptyState()
-    return this.states[id]
+    if (!this.states[id]) this.states[id] = emptyState();
+    return this.states[id];
   }
 
   setSql(id: string, sql: string): void {
-    const s = this.ensure(id)
-    s.sql = sql
+    const s = this.ensure(id);
+    s.sql = sql;
   }
 
   get(id: string): QueryTabState | undefined {
-    return this.states[id]
+    return this.states[id];
   }
 
   has(id: string): boolean {
-    return this.states[id] !== undefined
+    return this.states[id] !== undefined;
   }
 
   remove(id: string): void {
-    delete this.states[id]
+    this.cancel(id);
+    delete this.states[id];
   }
 
   /**
@@ -63,9 +105,9 @@ class QueryTabsStore {
    * confirmation.
    */
   isDirty(id: string): boolean {
-    const s = this.states[id]
-    if (!s) return false
-    return s.sql.trim().length > 0
+    const s = this.states[id];
+    if (!s) return false;
+    return s.sql.trim().length > 0;
   }
 
   /**
@@ -74,42 +116,75 @@ class QueryTabsStore {
    * running flag guards against re-entry.
    */
   async run(id: string): Promise<void> {
-    const s = this.ensure(id)
-    if (s.running) return
+    const s = this.ensure(id);
+    if (s.running) return;
     if (!this.executor) {
-      s.error = 'No connection — connect to a reddb instance first.'
-      s.result = null
-      return
+      s.error = "No connection — connect to a reddb instance first.";
+      s.result = null;
+      return;
     }
-    const sql = s.sql.trim()
+    const sql = s.sql.trim();
     if (!sql) {
-      s.error = 'Empty query.'
-      s.result = null
-      return
+      s.error = "Empty query.";
+      s.result = null;
+      return;
     }
-    s.running = true
-    s.error = null
+    const controller = new AbortController();
+    const token = ++this.runSeq;
+    this.inFlight.set(id, { token, controller });
+    s.running = true;
+    s.runningStartedAt = Date.now();
+    s.error = null;
     try {
-      const r = await this.executor(sql)
-      s.result = r
-      s.error = r.ok ? null : (r.error ?? 'Query failed.')
+      const r = await activity.track(queryActivityLabel(sql), () =>
+        this.executor!(sql, { signal: controller.signal })
+      );
+      if (this.inFlight.get(id)?.token !== token) return;
+      s.result = r;
+      s.error = r.ok ? null : (r.error ?? "Query failed.");
     } catch (e) {
-      s.error = (e as Error).message
-      s.result = null
+      if (this.inFlight.get(id)?.token !== token) return;
+      if (controller.signal.aborted || isAbortError(e)) {
+        s.error = null;
+        return;
+      }
+      s.error = (e as Error).message;
+      s.result = null;
     } finally {
-      s.running = false
+      if (this.inFlight.get(id)?.token === token) {
+        this.inFlight.delete(id);
+        s.running = false;
+        s.runningStartedAt = null;
+      }
     }
+  }
+
+  cancel(id: string): boolean {
+    const run = this.inFlight.get(id);
+    if (!run) return false;
+    this.inFlight.delete(id);
+    run.controller.abort();
+    const s = this.states[id];
+    if (s) {
+      s.running = false;
+      s.runningStartedAt = null;
+      s.error = null;
+    }
+    return true;
   }
 
   /** Test-only reset. */
   clear(): void {
-    this.states = {}
-    this.counter = 0
-    this.executor = null
+    for (const run of this.inFlight.values()) run.controller.abort();
+    this.inFlight.clear();
+    this.states = {};
+    this.counter = 0;
+    this.executor = null;
+    this.runSeq = 0;
   }
 }
 
-export const queryTabs = new QueryTabsStore()
+export const queryTabs = new QueryTabsStore();
 
 /**
  * Derive a tab title from the SQL text. Defaults to `fallback` (e.g.
@@ -118,13 +193,17 @@ export const queryTabs = new QueryTabsStore()
  *
  * Kept pure & exported for unit tests.
  */
-export function deriveQueryLabel(sql: string, fallback: string, max = 24): string {
-  const trimmed = sql.trim()
-  if (!trimmed) return fallback
-  const match = trimmed.match(/^\s*select\s+([\s\S]+?)\s+from\b/i)
-  if (!match) return fallback
-  const clause = match[1].replace(/\s+/g, ' ').trim()
-  if (!clause || clause === '*') return fallback
-  if (clause.length <= max) return clause
-  return clause.slice(0, max - 1).trimEnd() + '…'
+export function deriveQueryLabel(
+  sql: string,
+  fallback: string,
+  max = 24
+): string {
+  const trimmed = sql.trim();
+  if (!trimmed) return fallback;
+  const match = trimmed.match(/^\s*select\s+([\s\S]+?)\s+from\b/i);
+  if (!match) return fallback;
+  const clause = match[1].replace(/\s+/g, " ").trim();
+  if (!clause || clause === "*") return fallback;
+  if (clause.length <= max) return clause;
+  return clause.slice(0, max - 1).trimEnd() + "…";
 }

--- a/packages/ui/src/lib/query-tabs.test.ts
+++ b/packages/ui/src/lib/query-tabs.test.ts
@@ -1,155 +1,273 @@
-import { describe, expect, it, beforeEach } from 'vitest'
-import { queryTabs, deriveQueryLabel } from './query-tabs.svelte'
-import type { QueryResult } from '#reddb'
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { activity } from "./activity.svelte";
+import {
+  queryTabs,
+  deriveQueryLabel,
+  formatElapsed,
+} from "./query-tabs.svelte";
+import type { QueryResult } from "#reddb";
 
-beforeEach(() => queryTabs.clear())
+beforeEach(() => {
+  queryTabs.clear();
+  activity.reset();
+});
+
+afterEach(() => {
+  queryTabs.clear();
+  activity.reset();
+});
 
 const okResult = (sql: string): QueryResult => ({
   ok: true,
   query: sql,
   record_count: 1,
-  result: { columns: ['x'], records: [{ values: { x: 1 } }] },
-})
+  result: { columns: ["x"], records: [{ values: { x: 1 } }] },
+});
 
-describe('queryTabs store', () => {
-  it('nextLabel hands out monotonic Query N labels', () => {
-    expect(queryTabs.nextLabel()).toBe('Query 1')
-    expect(queryTabs.nextLabel()).toBe('Query 2')
-    expect(queryTabs.nextLabel()).toBe('Query 3')
-  })
+describe("queryTabs store", () => {
+  it("nextLabel hands out monotonic Query N labels", () => {
+    expect(queryTabs.nextLabel()).toBe("Query 1");
+    expect(queryTabs.nextLabel()).toBe("Query 2");
+    expect(queryTabs.nextLabel()).toBe("Query 3");
+  });
 
-  it('ensure() initialises empty state and is idempotent', () => {
-    const a = queryTabs.ensure('t1')
-    expect(a).toEqual({ sql: '', result: null, error: null, running: false })
-    queryTabs.setSql('t1', 'SELECT 1')
-    const b = queryTabs.ensure('t1')
-    expect(b.sql).toBe('SELECT 1')
-  })
+  it("ensure() initialises empty state and is idempotent", () => {
+    const a = queryTabs.ensure("t1");
+    expect(a).toEqual({
+      sql: "",
+      result: null,
+      error: null,
+      running: false,
+      runningStartedAt: null,
+    });
+    queryTabs.setSql("t1", "SELECT 1");
+    const b = queryTabs.ensure("t1");
+    expect(b.sql).toBe("SELECT 1");
+  });
 
-  it('isDirty is true only when sql has non-whitespace content', () => {
-    queryTabs.ensure('t1')
-    expect(queryTabs.isDirty('t1')).toBe(false)
-    queryTabs.setSql('t1', '   \n\t  ')
-    expect(queryTabs.isDirty('t1')).toBe(false)
-    queryTabs.setSql('t1', 'SELECT 1')
-    expect(queryTabs.isDirty('t1')).toBe(true)
-  })
+  it("isDirty is true only when sql has non-whitespace content", () => {
+    queryTabs.ensure("t1");
+    expect(queryTabs.isDirty("t1")).toBe(false);
+    queryTabs.setSql("t1", "   \n\t  ");
+    expect(queryTabs.isDirty("t1")).toBe(false);
+    queryTabs.setSql("t1", "SELECT 1");
+    expect(queryTabs.isDirty("t1")).toBe(true);
+  });
 
-  it('remove() drops state and isDirty becomes false', () => {
-    queryTabs.setSql('t1', 'SELECT 1')
-    expect(queryTabs.isDirty('t1')).toBe(true)
-    queryTabs.remove('t1')
-    expect(queryTabs.has('t1')).toBe(false)
-    expect(queryTabs.isDirty('t1')).toBe(false)
-  })
+  it("remove() drops state and isDirty becomes false", () => {
+    queryTabs.setSql("t1", "SELECT 1");
+    expect(queryTabs.isDirty("t1")).toBe(true);
+    queryTabs.remove("t1");
+    expect(queryTabs.has("t1")).toBe(false);
+    expect(queryTabs.isDirty("t1")).toBe(false);
+  });
 
-  it('run() without executor reports a no-connection error', async () => {
-    queryTabs.setSql('t1', 'SELECT 1')
-    await queryTabs.run('t1')
-    expect(queryTabs.get('t1')?.error).toMatch(/no connection/i)
-    expect(queryTabs.get('t1')?.result).toBeNull()
-  })
+  it("run() without executor reports a no-connection error", async () => {
+    queryTabs.setSql("t1", "SELECT 1");
+    await queryTabs.run("t1");
+    expect(queryTabs.get("t1")?.error).toMatch(/no connection/i);
+    expect(queryTabs.get("t1")?.result).toBeNull();
+  });
 
-  it('run() with empty sql sets an error without calling the executor', async () => {
-    let called = 0
+  it("run() with empty sql sets an error without calling the executor", async () => {
+    let called = 0;
     queryTabs.setExecutor(async (sql) => {
-      called++
-      return okResult(sql)
-    })
-    queryTabs.ensure('t1')
-    await queryTabs.run('t1')
-    expect(called).toBe(0)
-    expect(queryTabs.get('t1')?.error).toBe('Empty query.')
-  })
+      called++;
+      return okResult(sql);
+    });
+    queryTabs.ensure("t1");
+    await queryTabs.run("t1");
+    expect(called).toBe(0);
+    expect(queryTabs.get("t1")?.error).toBe("Empty query.");
+  });
 
-  it('run() with executor populates result and clears error', async () => {
-    queryTabs.setExecutor(async (sql) => okResult(sql))
-    queryTabs.setSql('t1', 'SELECT 1')
-    await queryTabs.run('t1')
-    const s = queryTabs.get('t1')!
-    expect(s.result?.ok).toBe(true)
-    expect(s.error).toBeNull()
-    expect(s.running).toBe(false)
-  })
+  it("run() with executor populates result and clears error", async () => {
+    queryTabs.setExecutor(async (sql) => okResult(sql));
+    queryTabs.setSql("t1", "SELECT 1");
+    await queryTabs.run("t1");
+    const s = queryTabs.get("t1")!;
+    expect(s.result?.ok).toBe(true);
+    expect(s.error).toBeNull();
+    expect(s.running).toBe(false);
+    expect(s.runningStartedAt).toBeNull();
+  });
 
-  it('run() surfaces executor throws as error string', async () => {
+  it("run() surfaces executor throws as error string", async () => {
     queryTabs.setExecutor(async () => {
-      throw new Error('boom')
-    })
-    queryTabs.setSql('t1', 'SELECT 1')
-    await queryTabs.run('t1')
-    expect(queryTabs.get('t1')?.error).toBe('boom')
-    expect(queryTabs.get('t1')?.result).toBeNull()
-  })
+      throw new Error("boom");
+    });
+    queryTabs.setSql("t1", "SELECT 1");
+    await queryTabs.run("t1");
+    expect(queryTabs.get("t1")?.error).toBe("boom");
+    expect(queryTabs.get("t1")?.result).toBeNull();
+  });
 
-  it('run() surfaces ok=false QueryResult error field', async () => {
-    queryTabs.setExecutor(async (sql): Promise<QueryResult> => ({
-      ok: false,
-      query: sql,
-      record_count: 0,
-      result: { columns: [], records: [] },
-      error: 'parse error',
-    }))
-    queryTabs.setSql('t1', 'SELECT bogus')
-    await queryTabs.run('t1')
-    expect(queryTabs.get('t1')?.error).toBe('parse error')
-  })
+  it("run() surfaces ok=false QueryResult error field", async () => {
+    queryTabs.setExecutor(
+      async (sql): Promise<QueryResult> => ({
+        ok: false,
+        query: sql,
+        record_count: 0,
+        result: { columns: [], records: [] },
+        error: "parse error",
+      })
+    );
+    queryTabs.setSql("t1", "SELECT bogus");
+    await queryTabs.run("t1");
+    expect(queryTabs.get("t1")?.error).toBe("parse error");
+  });
 
-  it('multiple query tabs keep independent state', async () => {
-    queryTabs.setExecutor(async (sql) => okResult(sql))
-    queryTabs.setSql('a', 'SELECT 1')
-    queryTabs.setSql('b', 'SELECT 2')
-    await queryTabs.run('a')
-    await queryTabs.run('b')
-    expect(queryTabs.get('a')?.result?.query).toBe('SELECT 1')
-    expect(queryTabs.get('b')?.result?.query).toBe('SELECT 2')
-    expect(queryTabs.get('a')?.sql).toBe('SELECT 1')
-    expect(queryTabs.get('b')?.sql).toBe('SELECT 2')
-  })
+  it("multiple query tabs keep independent state", async () => {
+    queryTabs.setExecutor(async (sql) => okResult(sql));
+    queryTabs.setSql("a", "SELECT 1");
+    queryTabs.setSql("b", "SELECT 2");
+    await queryTabs.run("a");
+    await queryTabs.run("b");
+    expect(queryTabs.get("a")?.result?.query).toBe("SELECT 1");
+    expect(queryTabs.get("b")?.result?.query).toBe("SELECT 2");
+    expect(queryTabs.get("a")?.sql).toBe("SELECT 1");
+    expect(queryTabs.get("b")?.sql).toBe("SELECT 2");
+  });
 
-  it('run() ignores re-entry while already running', async () => {
-    let resolveOuter: (r: QueryResult) => void = () => {}
+  it("run() ignores re-entry while already running", async () => {
+    let resolveOuter: (r: QueryResult) => void = () => {};
     const pending = new Promise<QueryResult>((res) => {
-      resolveOuter = res
-    })
-    queryTabs.setExecutor(() => pending)
-    queryTabs.setSql('t1', 'SELECT slow')
-    const first = queryTabs.run('t1')
+      resolveOuter = res;
+    });
+    queryTabs.setExecutor(() => pending);
+    queryTabs.setSql("t1", "SELECT slow");
+    const first = queryTabs.run("t1");
     // Second call should bail out (running flag set) and resolve immediately.
-    await queryTabs.run('t1')
-    expect(queryTabs.get('t1')?.running).toBe(true)
-    resolveOuter(okResult('SELECT slow'))
-    await first
-    expect(queryTabs.get('t1')?.running).toBe(false)
-  })
-})
+    await queryTabs.run("t1");
+    expect(queryTabs.get("t1")?.running).toBe(true);
+    expect(queryTabs.get("t1")?.runningStartedAt).toEqual(expect.any(Number));
+    resolveOuter(okResult("SELECT slow"));
+    await first;
+    expect(queryTabs.get("t1")?.running).toBe(false);
+  });
 
-describe('deriveQueryLabel', () => {
-  it('returns the fallback when sql is empty / whitespace', () => {
-    expect(deriveQueryLabel('', 'Query 1')).toBe('Query 1')
-    expect(deriveQueryLabel('   \n  ', 'Query 2')).toBe('Query 2')
-  })
+  it("passes an AbortSignal to the executor", async () => {
+    let signal: AbortSignal | undefined;
+    queryTabs.setExecutor(async (sql, options) => {
+      signal = options?.signal;
+      return okResult(sql);
+    });
+    queryTabs.setSql("t1", "SELECT 1");
+    await queryTabs.run("t1");
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal?.aborted).toBe(false);
+  });
 
-  it('returns the fallback for SELECT *', () => {
-    expect(deriveQueryLabel('SELECT * FROM users', 'Query 3')).toBe('Query 3')
-  })
+  it("cancel() aborts the in-flight query and returns to the previous result", async () => {
+    const existing = queryTabs.ensure("t1");
+    existing.result = okResult("SELECT old");
+    queryTabs.setSql("t1", "SELECT slow");
+    queryTabs.setExecutor(
+      (_sql, options) =>
+        new Promise<QueryResult>((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        })
+    );
 
-  it('returns the fallback when there is no FROM clause', () => {
-    expect(deriveQueryLabel('SELECT 1', 'Query 4')).toBe('Query 4')
-  })
+    const run = queryTabs.run("t1");
+    await Promise.resolve();
 
-  it('returns the column list when short enough', () => {
-    expect(deriveQueryLabel('SELECT id, name FROM users', 'fb')).toBe('id, name')
-  })
+    expect(queryTabs.get("t1")?.running).toBe(true);
+    expect(queryTabs.cancel("t1")).toBe(true);
+    const s = queryTabs.get("t1")!;
+    expect(s.running).toBe(false);
+    expect(s.runningStartedAt).toBeNull();
+    expect(s.error).toBeNull();
+    expect(s.result?.query).toBe("SELECT old");
+    await run;
+  });
 
-  it('truncates long select clauses with an ellipsis', () => {
-    const sql = 'SELECT a, b, c, d, e, f, g, h, i, j FROM t'
-    const label = deriveQueryLabel(sql, 'fb', 10)
-    expect(label.length).toBeLessThanOrEqual(10)
-    expect(label.endsWith('…')).toBe(true)
-  })
+  it("cancel() ignores a late result from an executor that did not abort", async () => {
+    let release!: (r: QueryResult) => void;
+    const existing = queryTabs.ensure("t1");
+    existing.result = okResult("SELECT old");
+    queryTabs.setSql("t1", "SELECT slow");
+    queryTabs.setExecutor(
+      () =>
+        new Promise<QueryResult>((resolve) => {
+          release = resolve;
+        })
+    );
 
-  it('is case-insensitive', () => {
-    expect(deriveQueryLabel('select id from users', 'fb')).toBe('id')
-  })
-})
+    const run = queryTabs.run("t1");
+    await Promise.resolve();
+    expect(queryTabs.cancel("t1")).toBe(true);
+
+    release(okResult("SELECT late"));
+    await run;
+
+    const s = queryTabs.get("t1")!;
+    expect(s.running).toBe(false);
+    expect(s.runningStartedAt).toBeNull();
+    expect(s.error).toBeNull();
+    expect(s.result?.query).toBe("SELECT old");
+  });
+
+  it("query runs are reflected in the global activity tracker", async () => {
+    let release!: (r: QueryResult) => void;
+    queryTabs.setExecutor((sql) =>
+      new Promise<QueryResult>((resolve) => {
+        release = resolve;
+      }).then(() => okResult(sql))
+    );
+    queryTabs.setSql("t1", "SELECT slow");
+    const run = queryTabs.run("t1");
+    await Promise.resolve();
+
+    expect(activity.inflight).toBe(1);
+    expect(activity.active).toBe(true);
+
+    release(okResult("SELECT slow"));
+    await run;
+
+    expect(activity.inflight).toBe(0);
+    expect(activity.active).toBe(false);
+  });
+});
+
+describe("deriveQueryLabel", () => {
+  it("returns the fallback when sql is empty / whitespace", () => {
+    expect(deriveQueryLabel("", "Query 1")).toBe("Query 1");
+    expect(deriveQueryLabel("   \n  ", "Query 2")).toBe("Query 2");
+  });
+
+  it("returns the fallback for SELECT *", () => {
+    expect(deriveQueryLabel("SELECT * FROM users", "Query 3")).toBe("Query 3");
+  });
+
+  it("returns the fallback when there is no FROM clause", () => {
+    expect(deriveQueryLabel("SELECT 1", "Query 4")).toBe("Query 4");
+  });
+
+  it("returns the column list when short enough", () => {
+    expect(deriveQueryLabel("SELECT id, name FROM users", "fb")).toBe(
+      "id, name"
+    );
+  });
+
+  it("truncates long select clauses with an ellipsis", () => {
+    const sql = "SELECT a, b, c, d, e, f, g, h, i, j FROM t";
+    const label = deriveQueryLabel(sql, "fb", 10);
+    expect(label.length).toBeLessThanOrEqual(10);
+    expect(label.endsWith("…")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(deriveQueryLabel("select id from users", "fb")).toBe("id");
+  });
+});
+
+describe("formatElapsed", () => {
+  it("formats milliseconds, seconds, and minute-scale durations", () => {
+    expect(formatElapsed(250)).toBe("250ms");
+    expect(formatElapsed(1250)).toBe("1.3s");
+    expect(formatElapsed(65_000)).toBe("1m 05s");
+  });
+});

--- a/packages/ui/src/lib/reddb/client.ts
+++ b/packages/ui/src/lib/reddb/client.ts
@@ -357,7 +357,9 @@ export async function runQueryPreferStream(
   sql: string,
   opts: { maxRows?: number; signal?: AbortSignal } = {}
 ): Promise<QueryResult> {
-  if (!SELECT_RE.test(sql)) return client.query(sql);
+  const queryOpts = opts.signal ? { signal: opts.signal } : undefined;
+  if (!SELECT_RE.test(sql))
+    return queryOpts ? client.query(sql, queryOpts) : client.query(sql);
   try {
     const s = await client.queryStreamCollect(sql, opts);
     return {
@@ -371,8 +373,14 @@ export async function runQueryPreferStream(
       streamed: true,
       truncated: s.truncated,
     };
-  } catch {
-    return client.query(sql);
+  } catch (e) {
+    if (
+      opts.signal?.aborted ||
+      (e instanceof Error && e.name === "AbortError")
+    ) {
+      throw e;
+    }
+    return queryOpts ? client.query(sql, queryOpts) : client.query(sql);
   }
 }
 
@@ -520,10 +528,14 @@ export class RedClient {
     );
   }
 
-  async query(query: string): Promise<QueryResult> {
+  async query(
+    query: string,
+    opts: { signal?: AbortSignal } = {}
+  ): Promise<QueryResult> {
     return this.json<QueryResult>("/query", {
       method: "POST",
       body: JSON.stringify({ query }),
+      signal: opts.signal,
     });
   }
 

--- a/packages/ui/src/lib/reddb/query-stream.test.ts
+++ b/packages/ui/src/lib/reddb/query-stream.test.ts
@@ -166,6 +166,28 @@ describe("runQueryPreferStream", () => {
     expect(r).toBe(buffered);
   });
 
+  it("passes AbortSignal through to non-SELECT buffered query()", async () => {
+    const controller = new AbortController();
+    const buffered = {
+      ok: true,
+      query: "x",
+      record_count: 0,
+      result: { columns: [], records: [] },
+    };
+    const client = {
+      query: vi.fn(async () => buffered),
+      queryStreamCollect: vi.fn(),
+    };
+
+    await runQueryPreferStream(client, "INSERT INTO t VALUES (1)", {
+      signal: controller.signal,
+    });
+
+    expect(client.query).toHaveBeenCalledWith("INSERT INTO t VALUES (1)", {
+      signal: controller.signal,
+    });
+  });
+
   it("falls back to buffered query() when streaming fails (older server / 404)", async () => {
     const buffered = {
       ok: true,
@@ -183,5 +205,24 @@ describe("runQueryPreferStream", () => {
     expect(client.queryStreamCollect).toHaveBeenCalledOnce();
     expect(client.query).toHaveBeenCalledWith("SELECT * FROM t");
     expect(r).toBe(buffered);
+  });
+
+  it("does not fall back to buffered query() after an abort", async () => {
+    const err = new DOMException("Aborted", "AbortError");
+    const controller = new AbortController();
+    controller.abort();
+    const client = {
+      query: vi.fn(),
+      queryStreamCollect: vi.fn(async () => {
+        throw err;
+      }),
+    };
+
+    await expect(
+      runQueryPreferStream(client, "SELECT * FROM t", {
+        signal: controller.signal,
+      })
+    ).rejects.toBe(err);
+    expect(client.query).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #93

Summary:
- add per-query running state with elapsed timer and cancel support
- pass AbortSignal through streaming and buffered query execution
- surface query runs through the activity tracker
- preserve previous results when a running query is cancelled

Validation:
- pnpm --filter @reddb-io/ui test -- query-tabs query-stream activity
- pnpm --filter @reddb-io/ui check
- pnpm --filter @reddb-io/ui build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783179180&installation_id=129708444&pr_number=106&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F106&signature=a8be0a4967431523de76b86e12bfbbe5dcd2973447198f69974c99753b4d32c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->