### PR TITLE
RedWire-WS spike: handshake and one query

### DIFF
--- a/packages/ui/docs/redwire-ws-spike.md
+++ b/packages/ui/docs/redwire-ws-spike.md
@@ -1,0 +1,30 @@
+# RedWire WebSocket Spike
+
+This spike lives at `/redwire-ws-spike`. It is intentionally not wired into the
+production connection provider or transport classifier.
+
+Enable it by either running the SvelteKit dev server or setting:
+
+```bash
+VITE_REDWIRE_WS_SPIKE=1
+```
+
+The reddb endpoint must be reachable over WSS. The server-side RedWire
+WebSocket route is `/redwire` and requires the subprotocol
+`reddb.redwire.v1`. The server mounts the route only when WebSocket allowed
+origins are configured, so include the red-ui dev origin in reddb's Origin
+allowlist.
+
+Local checklist:
+
+1. Start reddb with TLS/WSS enabled for the API origin.
+2. Configure reddb's WebSocket allowed origins to include the red-ui dev
+   origin, for example `https://localhost:5173` or the actual dev origin in
+   use.
+3. Open `/redwire-ws-spike`.
+4. Enter the HTTPS origin or full WSS URL. Origins resolve to `/redwire`.
+5. Enter a bearer token accepted by the reddb instance.
+6. Run one query and inspect the decoded RedWire result.
+
+The browser will reject plain `ws://` for this spike. Use a WSS endpoint with a
+certificate trusted by the browser.

--- a/packages/ui/src/lib/reddb/redwire-ws-spike.test.ts
+++ b/packages/ui/src/lib/reddb/redwire-ws-spike.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  REDWIRE_WS_SUBPROTOCOL,
+  MessageKind,
+  decodeFrame,
+  encodeFrame,
+  encodePreamble,
+  redwireWsUrlFromHttp,
+  runRedWireWsSpike,
+} from "./redwire-ws-spike";
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  readyState = 0;
+  binaryType = "blob";
+  sent: Uint8Array[] = [];
+  readonly url: string;
+  readonly protocol: string;
+  readonly listeners = new Map<string, Set<(event?: unknown) => void>>();
+
+  constructor(url: string, protocols?: string | string[]) {
+    this.url = url;
+    this.protocol = Array.isArray(protocols) ? protocols[0] : (protocols ?? "");
+    MockWebSocket.instances.push(this);
+    queueMicrotask(() => {
+      this.readyState = 1;
+      this.emit("open");
+    });
+  }
+
+  addEventListener(type: string, cb: (event?: unknown) => void): void {
+    const set = this.listeners.get(type) ?? new Set();
+    set.add(cb);
+    this.listeners.set(type, set);
+  }
+
+  removeEventListener(type: string, cb: (event?: unknown) => void): void {
+    this.listeners.get(type)?.delete(cb);
+  }
+
+  send(data: Uint8Array | ArrayBuffer): void {
+    const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
+    this.sent.push(bytes);
+    if (bytes.byteLength === 2) return;
+
+    const frame = decodeFrame(bytes);
+    if (!frame) return;
+    if (frame.kind === MessageKind.Hello) {
+      this.deliver(
+        encodeFrame(
+          MessageKind.HelloAck,
+          frame.correlationId,
+          jsonBytes({ auth: "bearer", features: 0 })
+        )
+      );
+    } else if (frame.kind === MessageKind.AuthResponse) {
+      this.deliver(
+        encodeFrame(
+          MessageKind.AuthOk,
+          frame.correlationId,
+          jsonBytes({ session_id: "mock-session", features: 0 })
+        )
+      );
+    } else if (frame.kind === MessageKind.QueryBinary) {
+      const query = new TextDecoder().decode(frame.payload);
+      this.deliver(
+        encodeFrame(
+          MessageKind.Result,
+          frame.correlationId,
+          jsonBytes({
+            ok: true,
+            query,
+            columns: ["x"],
+            rows: [{ x: 1 }],
+          }),
+          0,
+          frame.streamId
+        )
+      );
+    }
+  }
+
+  close(): void {
+    this.readyState = 3;
+    this.emit("close");
+  }
+
+  private deliver(bytes: Uint8Array): void {
+    queueMicrotask(() => {
+      const data = bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength
+      );
+      this.emit("message", { data });
+    });
+  }
+
+  private emit(type: string, event?: unknown): void {
+    for (const cb of this.listeners.get(type) ?? []) cb(event);
+  }
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+});
+
+describe("RedWire WS frame codec", () => {
+  it("encodes the native preamble", () => {
+    expect([...encodePreamble()]).toEqual([0xfe, 0x01]);
+  });
+
+  it("encodes and decodes the 16-byte header with stream and correlation ids", () => {
+    const payload = new TextEncoder().encode("SELECT 1");
+    const encoded = encodeFrame(MessageKind.QueryBinary, 42n, payload, 0b10, 7);
+    const view = new DataView(encoded.buffer);
+
+    expect(view.getUint32(0, true)).toBe(16 + payload.byteLength);
+    expect(encoded[4]).toBe(MessageKind.QueryBinary);
+    expect(encoded[5]).toBe(0b10);
+    expect(view.getUint16(6, true)).toBe(7);
+    expect(view.getBigUint64(8, true)).toBe(42n);
+
+    const decoded = decodeFrame(encoded);
+    expect(decoded?.kind).toBe(MessageKind.QueryBinary);
+    expect(decoded?.flags).toBe(0b10);
+    expect(decoded?.streamId).toBe(7);
+    expect(decoded?.correlationId).toBe(42n);
+    expect(new TextDecoder().decode(decoded?.payload)).toBe("SELECT 1");
+    expect(decoded?.consumed).toBe(encoded.byteLength);
+  });
+
+  it("waits for partial frames", () => {
+    const encoded = encodeFrame(MessageKind.Hello, 1n, jsonBytes({}));
+    expect(decodeFrame(encoded.slice(0, 8))).toBeNull();
+  });
+
+  it("resolves HTTPS origins to the RedWire WSS route", () => {
+    expect(redwireWsUrlFromHttp("https://example.test")).toBe(
+      "wss://example.test/redwire"
+    );
+    expect(redwireWsUrlFromHttp("wss://example.test/redwire")).toBe(
+      "wss://example.test/redwire"
+    );
+  });
+});
+
+describe("runRedWireWsSpike", () => {
+  it("opens with the RedWire subprotocol, handshakes, sends one query, and decodes the result", async () => {
+    const result = await runRedWireWsSpike({
+      url: "wss://example.test/redwire",
+      token: "secret-token",
+      query: "SELECT 1",
+      WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
+    });
+
+    expect(result.endpoint).toBe("wss://example.test/redwire");
+    expect(result.subprotocol).toBe(REDWIRE_WS_SUBPROTOCOL);
+    expect(result.session.session_id).toBe("mock-session");
+    expect(result.query).toMatchObject({
+      ok: true,
+      statement: "SELECT 1",
+      columns: ["x"],
+      rows: [{ x: 1 }],
+    });
+
+    const ws = MockWebSocket.instances[0];
+    expect(ws.url).toBe("wss://example.test/redwire");
+    expect(ws.protocol).toBe(REDWIRE_WS_SUBPROTOCOL);
+    expect([...ws.sent[0]]).toEqual([0xfe, 0x01]);
+
+    const hello = decodeFrame(ws.sent[1]);
+    const auth = decodeFrame(ws.sent[2]);
+    const query = decodeFrame(ws.sent[3]);
+    expect(hello?.kind).toBe(MessageKind.Hello);
+    expect(auth?.kind).toBe(MessageKind.AuthResponse);
+    expect(query?.kind).toBe(MessageKind.QueryBinary);
+    expect(query?.streamId).toBe(1);
+    expect(query?.correlationId).toBe(3n);
+    expect(new TextDecoder().decode(query?.payload)).toBe("SELECT 1");
+  });
+});
+
+function jsonBytes(value: unknown): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(value));
+}

--- a/packages/ui/src/lib/reddb/redwire-ws-spike.ts
+++ b/packages/ui/src/lib/reddb/redwire-ws-spike.ts
@@ -1,0 +1,590 @@
+const REDWIRE_MAGIC = 0xfe;
+const REDWIRE_MINOR = 0x01;
+const FRAME_HEADER_SIZE = 16;
+const MAX_FRAME_SIZE = 16 * 1024 * 1024;
+const KNOWN_FLAGS = 0b0000_0011;
+const WS_CONNECTING = 0;
+const WS_OPEN = 1;
+
+export const REDWIRE_WS_PATH = "/redwire";
+export const REDWIRE_WS_SUBPROTOCOL = "reddb.redwire.v1";
+
+export const MessageKind = {
+  Query: 0x01,
+  Result: 0x02,
+  Error: 0x03,
+  QueryBinary: 0x07,
+  Hello: 0x10,
+  HelloAck: 0x11,
+  AuthResponse: 0x13,
+  AuthOk: 0x14,
+  AuthFail: 0x15,
+  Bye: 0x16,
+} as const;
+
+export type RedWireMessageKind = (typeof MessageKind)[keyof typeof MessageKind];
+
+const KIND_NAME = new Map<number, string>(
+  Object.entries(MessageKind).map(([name, value]) => [value, name])
+);
+
+export interface RedWireFrame {
+  kind: RedWireMessageKind | number;
+  flags: number;
+  streamId: number;
+  correlationId: bigint;
+  payload: Uint8Array;
+}
+
+export interface DecodedRedWireFrame extends RedWireFrame {
+  consumed: number;
+}
+
+export interface RedWireQueryResult {
+  ok: boolean;
+  statement?: string;
+  affected?: number;
+  columns: string[];
+  rows: Array<Record<string, unknown>>;
+  raw: unknown;
+}
+
+export interface RedWireWsSpikeResult {
+  endpoint: string;
+  subprotocol: string;
+  session: Record<string, unknown>;
+  helloAck: Record<string, unknown>;
+  query: RedWireQueryResult;
+}
+
+export class RedWireSpikeError extends Error {
+  constructor(
+    readonly code: string,
+    message: string
+  ) {
+    super(message);
+    this.name = "RedWireSpikeError";
+  }
+}
+
+export function redwireWsUrlFromHttp(url: string): string {
+  const parsed = new URL(url);
+  if (parsed.protocol === "wss:") return parsed.toString();
+  if (parsed.protocol === "https:") {
+    parsed.protocol = "wss:";
+  } else if (parsed.protocol === "http:") {
+    parsed.protocol = "ws:";
+  }
+  if (parsed.pathname === "/" || parsed.pathname === "") {
+    parsed.pathname = REDWIRE_WS_PATH;
+  }
+  return parsed.toString();
+}
+
+export function encodeFrame(
+  kind: RedWireMessageKind | number,
+  correlationId: bigint | number,
+  payload: Uint8Array | ArrayBuffer | ArrayLike<number>,
+  flags = 0,
+  streamId = 0
+): Uint8Array {
+  const body =
+    payload instanceof Uint8Array ? payload : new Uint8Array(payload);
+  const length = FRAME_HEADER_SIZE + body.byteLength;
+  if (length > MAX_FRAME_SIZE) {
+    throw new RedWireSpikeError(
+      "FRAME_TOO_LARGE",
+      `frame ${length} exceeds ${MAX_FRAME_SIZE}`
+    );
+  }
+  const bytes = new Uint8Array(length);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(0, length, true);
+  bytes[4] = kind & 0xff;
+  bytes[5] = flags & KNOWN_FLAGS;
+  view.setUint16(6, streamId, true);
+  view.setBigUint64(8, BigInt(correlationId), true);
+  bytes.set(body, FRAME_HEADER_SIZE);
+  return bytes;
+}
+
+export function decodeFrame(bytes: Uint8Array): DecodedRedWireFrame | null {
+  if (bytes.byteLength < FRAME_HEADER_SIZE) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const length = view.getUint32(0, true);
+  if (length < FRAME_HEADER_SIZE || length > MAX_FRAME_SIZE) {
+    throw new RedWireSpikeError("FRAME_INVALID_LENGTH", `length=${length}`);
+  }
+  if (bytes.byteLength < length) return null;
+  const flags = bytes[5];
+  if (flags & ~KNOWN_FLAGS) {
+    throw new RedWireSpikeError(
+      "FRAME_UNKNOWN_FLAGS",
+      `flags=0x${flags.toString(16)}`
+    );
+  }
+  return {
+    kind: bytes[4],
+    flags,
+    streamId: view.getUint16(6, true),
+    correlationId: view.getBigUint64(8, true),
+    payload: bytes.slice(FRAME_HEADER_SIZE, length),
+    consumed: length,
+  };
+}
+
+export function encodePreamble(): Uint8Array {
+  return Uint8Array.from([REDWIRE_MAGIC, REDWIRE_MINOR]);
+}
+
+export function decodeResultPayload(payload: Uint8Array): RedWireQueryResult {
+  const json = parseJson(payload);
+  if (json && typeof json === "object") {
+    const obj = json as Record<string, unknown>;
+    const columns = Array.isArray(obj.columns)
+      ? obj.columns.filter((c): c is string => typeof c === "string")
+      : [];
+    const rows = Array.isArray(obj.rows)
+      ? obj.rows.filter(isRecord)
+      : Array.isArray(
+            (obj.result as Record<string, unknown> | undefined)?.records
+          )
+        ? ((obj.result as Record<string, unknown>).records as unknown[]).filter(
+            isRecord
+          )
+        : [];
+    return {
+      ok: obj.ok !== false,
+      statement: stringField(obj.statement) ?? stringField(obj.query),
+      affected: numberField(obj.affected),
+      columns,
+      rows,
+      raw: json,
+    };
+  }
+  return decodeBinaryResultPayload(payload);
+}
+
+export async function runRedWireWsSpike({
+  url,
+  token,
+  query,
+  timeoutMs = 10_000,
+  WebSocketImpl = globalThis.WebSocket,
+}: {
+  url: string;
+  token: string;
+  query: string;
+  timeoutMs?: number;
+  WebSocketImpl?: typeof WebSocket;
+}): Promise<RedWireWsSpikeResult> {
+  if (typeof WebSocketImpl !== "function") {
+    throw new RedWireSpikeError("NO_WEBSOCKET", "WebSocket is unavailable");
+  }
+  if (!url.startsWith("wss://")) {
+    throw new RedWireSpikeError(
+      "WSS_REQUIRED",
+      `RedWire WS requires wss://, got ${url}`
+    );
+  }
+  if (!token.trim()) {
+    throw new RedWireSpikeError("TOKEN_REQUIRED", "Bearer token is required");
+  }
+
+  const socket = new BrowserWebSocketDuplex(
+    new WebSocketImpl(url, REDWIRE_WS_SUBPROTOCOL)
+  );
+  await socket.open(timeoutMs);
+  const reader = new FrameReader(socket);
+  const enc = new TextEncoder();
+
+  try {
+    socket.write(encodePreamble());
+    socket.write(
+      encodeFrame(
+        MessageKind.Hello,
+        1n,
+        jsonBytes({
+          versions: [REDWIRE_MINOR],
+          auth_methods: ["bearer"],
+          features: 0,
+          client_name: "red-ui/redwire-ws-spike",
+        })
+      )
+    );
+
+    const helloAck = await expectFrame(
+      reader,
+      [MessageKind.HelloAck, MessageKind.AuthFail],
+      "HelloAck"
+    );
+    if (helloAck.kind === MessageKind.AuthFail) {
+      throw new RedWireSpikeError(
+        "AUTH_REFUSED",
+        parseReason(helloAck.payload) ?? "AuthFail at HelloAck"
+      );
+    }
+    const helloAckPayload = expectJsonObject(helloAck.payload, "HelloAck");
+    if (helloAckPayload.auth !== "bearer") {
+      throw new RedWireSpikeError(
+        "AUTH_UNSUPPORTED",
+        `server picked ${String(helloAckPayload.auth)}, expected bearer`
+      );
+    }
+
+    socket.write(
+      encodeFrame(
+        MessageKind.AuthResponse,
+        2n,
+        jsonBytes({ token: token.trim() })
+      )
+    );
+    const authOk = await expectFrame(
+      reader,
+      [MessageKind.AuthOk, MessageKind.AuthFail],
+      "AuthOk"
+    );
+    if (authOk.kind === MessageKind.AuthFail) {
+      throw new RedWireSpikeError(
+        "AUTH_REFUSED",
+        parseReason(authOk.payload) ?? "auth refused"
+      );
+    }
+    const session = expectJsonObject(authOk.payload, "AuthOk");
+
+    const correlationId = 3n;
+    socket.write(
+      encodeFrame(
+        MessageKind.QueryBinary,
+        correlationId,
+        enc.encode(query),
+        0,
+        1
+      )
+    );
+    const reply = await expectFrame(
+      reader,
+      [MessageKind.Result, MessageKind.Error],
+      "query result"
+    );
+    if (reply.correlationId !== correlationId) {
+      throw new RedWireSpikeError(
+        "CORRELATION_MISMATCH",
+        `expected correlation ${correlationId}, got ${reply.correlationId}`
+      );
+    }
+    if (reply.kind === MessageKind.Error) {
+      throw new RedWireSpikeError(
+        "QUERY_FAILED",
+        new TextDecoder().decode(reply.payload)
+      );
+    }
+
+    return {
+      endpoint: url,
+      subprotocol: REDWIRE_WS_SUBPROTOCOL,
+      session,
+      helloAck: helloAckPayload,
+      query: decodeResultPayload(reply.payload),
+    };
+  } finally {
+    socket.close();
+  }
+}
+
+type SocketEvent = "data" | "error" | "close";
+
+class BrowserWebSocketDuplex {
+  readonly #ws: WebSocket;
+  readonly #handlers: Record<SocketEvent, Array<(arg?: unknown) => void>> = {
+    data: [],
+    error: [],
+    close: [],
+  };
+
+  constructor(ws: WebSocket) {
+    this.#ws = ws;
+    this.#ws.binaryType = "arraybuffer";
+    this.#ws.addEventListener("message", (event) => {
+      const bytes = bytesFromMessage(event.data);
+      if (bytes) this.#emit("data", bytes);
+    });
+    this.#ws.addEventListener("error", () => {
+      this.#emit(
+        "error",
+        new RedWireSpikeError("WS_ERROR", "WebSocket transport error")
+      );
+    });
+    this.#ws.addEventListener("close", () => this.#emit("close"));
+  }
+
+  on(event: SocketEvent, cb: (arg?: unknown) => void): void {
+    this.#handlers[event].push(cb);
+  }
+
+  open(timeoutMs: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (this.#ws.readyState === WS_OPEN) {
+        resolve();
+        return;
+      }
+      const timeout = setTimeout(() => {
+        cleanup();
+        reject(new RedWireSpikeError("WS_TIMEOUT", "WebSocket open timed out"));
+      }, timeoutMs);
+      const cleanup = () => {
+        clearTimeout(timeout);
+        this.#ws.removeEventListener("open", onOpen);
+        this.#ws.removeEventListener("error", onError);
+        this.#ws.removeEventListener("close", onClose);
+      };
+      const onOpen = () => {
+        cleanup();
+        resolve();
+      };
+      const onError = () => {
+        cleanup();
+        reject(
+          new RedWireSpikeError("WS_CONNECT_FAILED", "WebSocket failed to open")
+        );
+      };
+      const onClose = () => {
+        cleanup();
+        reject(
+          new RedWireSpikeError(
+            "WS_CONNECT_FAILED",
+            "WebSocket closed before opening"
+          )
+        );
+      };
+      this.#ws.addEventListener("open", onOpen);
+      this.#ws.addEventListener("error", onError);
+      this.#ws.addEventListener("close", onClose);
+    });
+  }
+
+  write(bytes: Uint8Array): void {
+    this.#ws.send(bytes);
+  }
+
+  close(): void {
+    if (
+      this.#ws.readyState === WS_OPEN ||
+      this.#ws.readyState === WS_CONNECTING
+    ) {
+      this.#ws.close();
+    }
+  }
+
+  #emit(event: SocketEvent, arg?: unknown): void {
+    for (const cb of this.#handlers[event]) cb(arg);
+  }
+}
+
+class FrameReader {
+  #buffer = new Uint8Array();
+  #waiters: Array<{
+    resolve: (frame: DecodedRedWireFrame) => void;
+    reject: (err: unknown) => void;
+  }> = [];
+  #error: unknown = null;
+  #closed = false;
+
+  constructor(socket: BrowserWebSocketDuplex) {
+    socket.on("data", (chunk) => {
+      if (!(chunk instanceof Uint8Array)) return;
+      const next = new Uint8Array(this.#buffer.byteLength + chunk.byteLength);
+      next.set(this.#buffer, 0);
+      next.set(chunk, this.#buffer.byteLength);
+      this.#buffer = next;
+      this.#drain();
+    });
+    socket.on("error", (err) => {
+      this.#error = err;
+      this.#flush();
+    });
+    socket.on("close", () => {
+      this.#closed = true;
+      this.#flush();
+    });
+  }
+
+  next(): Promise<DecodedRedWireFrame> {
+    if (this.#error) return Promise.reject(this.#error);
+    return new Promise((resolve, reject) => {
+      this.#waiters.push({ resolve, reject });
+      this.#drain();
+    });
+  }
+
+  #drain(): void {
+    while (this.#waiters.length > 0 && this.#buffer.byteLength > 0) {
+      const frame = decodeFrame(this.#buffer);
+      if (!frame) return;
+      this.#buffer = this.#buffer.slice(frame.consumed);
+      this.#waiters.shift()?.resolve(frame);
+    }
+    this.#flush();
+  }
+
+  #flush(): void {
+    if (!this.#error && (!this.#closed || this.#buffer.byteLength > 0)) return;
+    const err =
+      this.#error ??
+      new RedWireSpikeError("CONNECTION_CLOSED", "RedWire WS closed");
+    while (this.#waiters.length > 0) this.#waiters.shift()?.reject(err);
+  }
+}
+
+async function expectFrame(
+  reader: FrameReader,
+  kinds: number[],
+  label: string
+): Promise<DecodedRedWireFrame> {
+  const frame = await reader.next();
+  if (!kinds.includes(frame.kind)) {
+    throw new RedWireSpikeError(
+      "UNEXPECTED_FRAME",
+      `expected ${label}, got ${KIND_NAME.get(frame.kind) ?? frame.kind}`
+    );
+  }
+  return frame;
+}
+
+function jsonBytes(value: unknown): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(value));
+}
+
+function parseJson(bytes: Uint8Array): unknown {
+  if (bytes.byteLength === 0) return null;
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    return null;
+  }
+}
+
+function expectJsonObject(
+  bytes: Uint8Array,
+  label: string
+): Record<string, unknown> {
+  const parsed = parseJson(bytes);
+  if (!isRecord(parsed)) {
+    throw new RedWireSpikeError("PROTOCOL", `${label} payload is not JSON`);
+  }
+  return parsed;
+}
+
+function parseReason(payload: Uint8Array): string | null {
+  const parsed = parseJson(payload);
+  if (!isRecord(parsed)) return null;
+  return stringField(parsed.reason) ?? null;
+}
+
+function decodeBinaryResultPayload(payload: Uint8Array): RedWireQueryResult {
+  const view = new DataView(
+    payload.buffer,
+    payload.byteOffset,
+    payload.byteLength
+  );
+  const dec = new TextDecoder();
+  let pos = 0;
+  const read = (n: number, label: string): number => {
+    if (pos + n > payload.byteLength) {
+      throw new RedWireSpikeError(
+        "RESULT_TRUNCATED",
+        `Result payload truncated while reading ${label}`
+      );
+    }
+    const start = pos;
+    pos += n;
+    return start;
+  };
+  const readU16 = (label: string) => view.getUint16(read(2, label), true);
+  const readU32 = (label: string) => view.getUint32(read(4, label), true);
+  const readText = (n: number, label: string) =>
+    dec.decode(payload.subarray(read(n, label), pos));
+  const readI64 = (label: string) =>
+    jsNumberOrBigInt(view.getBigInt64(read(8, label), true));
+  const readU64 = (label: string) =>
+    jsNumberOrBigInt(view.getBigUint64(read(8, label), true));
+
+  const columnCount = readU16("column count");
+  const columns: string[] = [];
+  for (let i = 0; i < columnCount; i += 1) {
+    const length = readU16(`column ${i} length`);
+    columns.push(readText(length, `column ${i} name`));
+  }
+  const rowCount = readU32("row count");
+  const rows: Array<Record<string, unknown>> = [];
+  for (let r = 0; r < rowCount; r += 1) {
+    const row: Record<string, unknown> = {};
+    for (const column of columns) row[column] = readBinaryValue();
+    rows.push(row);
+  }
+  return {
+    ok: true,
+    statement: "SELECT",
+    affected: 0,
+    columns,
+    rows,
+    raw: { columns, rows },
+  };
+
+  function readBinaryValue(): unknown {
+    const tag = payload[read(1, "value tag")];
+    switch (tag) {
+      case 0:
+        return null;
+      case 1:
+        return readI64("i64 value");
+      case 2:
+        return view.getFloat64(read(8, "f64 value"), true);
+      case 3: {
+        const length = readU32("text length");
+        return readText(length, "text value");
+      }
+      case 4:
+        return payload[read(1, "bool value")] !== 0;
+      case 5:
+        return readU64("u64 value");
+      default:
+        throw new RedWireSpikeError(
+          "RESULT_UNKNOWN_TAG",
+          `Result payload has unknown value tag ${tag}`
+        );
+    }
+  }
+}
+
+function bytesFromMessage(data: unknown): Uint8Array | null {
+  if (data instanceof ArrayBuffer) return new Uint8Array(data);
+  if (ArrayBuffer.isView(data)) {
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  }
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function numberField(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function jsNumberOrBigInt(value: bigint): number | bigint {
+  if (
+    value >= BigInt(Number.MIN_SAFE_INTEGER) &&
+    value <= BigInt(Number.MAX_SAFE_INTEGER)
+  ) {
+    return Number(value);
+  }
+  return value;
+}

--- a/packages/ui/src/routes/+layout.svelte
+++ b/packages/ui/src/routes/+layout.svelte
@@ -15,7 +15,9 @@
 
   const router = createKitRouter()
   const path = $derived(page.url.pathname.slice(base.length) || '/')
-  const renderRouteContent = $derived(path === '/graph' || path === '/shadow-dom-spike')
+  const renderRouteContent = $derived(
+    path === '/graph' || path === '/shadow-dom-spike' || path === '/redwire-ws-spike',
+  )
 </script>
 
 {#if renderRouteContent}

--- a/packages/ui/src/routes/redwire-ws-spike/+page.svelte
+++ b/packages/ui/src/routes/redwire-ws-spike/+page.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+  import { dev } from '$app/environment'
+  import {
+    RedWireSpikeError,
+    redwireWsUrlFromHttp,
+    runRedWireWsSpike,
+    type RedWireWsSpikeResult,
+  } from '$lib/reddb/redwire-ws-spike'
+
+  const enabled = dev || import.meta.env.VITE_REDWIRE_WS_SPIKE === '1'
+
+  let endpoint = $state('https://localhost:5055')
+  let token = $state('')
+  let query = $state('SELECT 1')
+  let running = $state(false)
+  let result = $state<RedWireWsSpikeResult | null>(null)
+  let error = $state<string | null>(null)
+
+  const resolvedEndpoint = $derived(endpoint.trim() ? redwireWsUrlFromHttp(endpoint.trim()) : '')
+
+  async function runSpike() {
+    if (!enabled || running) return
+    running = true
+    result = null
+    error = null
+    try {
+      result = await runRedWireWsSpike({
+        url: resolvedEndpoint,
+        token,
+        query,
+      })
+    } catch (e) {
+      if (e instanceof RedWireSpikeError) {
+        error = `${e.code}: ${e.message}`
+      } else {
+        error = e instanceof Error ? e.message : String(e)
+      }
+    } finally {
+      running = false
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>RedWire WS spike</title>
+</svelte:head>
+
+<main class="min-h-screen bg-bg-0 text-fg-1">
+  <div class="mx-auto flex max-w-5xl flex-col gap-5 px-5 py-6 font-mono">
+    <header class="flex flex-col gap-2 border-b border-line-1 pb-4">
+      <div class="text-[11px] uppercase tracking-wide text-fg-3">Dev spike</div>
+      <h1 class="text-xl font-semibold">RedWire over WebSocket</h1>
+      <p class="max-w-3xl text-[12px] leading-5 text-fg-3">
+        Opens a WSS RedWire endpoint, negotiates the versioned subprotocol, completes bearer auth,
+        sends one binary framed query, and decodes the result. This route is isolated from the
+        production transport path.
+      </p>
+    </header>
+
+    {#if !enabled}
+      <section class="rounded border border-line-1 bg-bg-1 p-4 text-[12px] text-fg-3">
+        Enable with <span class="text-fg-1">VITE_REDWIRE_WS_SPIKE=1</span> or run in dev mode.
+      </section>
+    {/if}
+
+    <section class="grid gap-4 md:grid-cols-[1fr_1fr]">
+      <label class="flex flex-col gap-1 text-[12px] text-fg-2">
+        Endpoint origin or WSS URL
+        <input
+          class="h-9 rounded border border-line-2 bg-bg-1 px-2 text-fg-1 outline-none focus:border-accent"
+          bind:value={endpoint}
+          disabled={!enabled || running}
+        />
+      </label>
+      <label class="flex flex-col gap-1 text-[12px] text-fg-2">
+        Bearer token
+        <input
+          class="h-9 rounded border border-line-2 bg-bg-1 px-2 text-fg-1 outline-none focus:border-accent"
+          bind:value={token}
+          type="password"
+          disabled={!enabled || running}
+        />
+      </label>
+    </section>
+
+    <label class="flex flex-col gap-1 text-[12px] text-fg-2">
+      Query
+      <textarea
+        class="min-h-28 rounded border border-line-2 bg-bg-1 p-2 text-fg-1 outline-none focus:border-accent"
+        bind:value={query}
+        disabled={!enabled || running}
+      ></textarea>
+    </label>
+
+    <div class="flex flex-wrap items-center gap-3">
+      <button
+        type="button"
+        class="h-9 rounded border border-accent bg-accent px-3 text-[12px] font-semibold text-bg-0 disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={!enabled || running || !resolvedEndpoint || !token.trim() || !query.trim()}
+        onclick={runSpike}
+      >
+        {running ? 'Running' : 'Run WSS query'}
+      </button>
+      <div class="text-[11px] text-fg-3">
+        Resolved endpoint: <span class="text-fg-2">{resolvedEndpoint || 'n/a'}</span>
+      </div>
+    </div>
+
+    {#if error}
+      <section class="rounded border border-danger/50 bg-bg-1 p-4 text-[12px] text-danger">
+        <pre class="m-0 whitespace-pre-wrap">{error}</pre>
+      </section>
+    {/if}
+
+    {#if result}
+      <section class="rounded border border-line-1 bg-bg-1 p-4">
+        <div class="mb-2 text-[12px] font-semibold text-fg-2">Decoded result</div>
+        <pre class="m-0 max-h-[520px] overflow-auto text-[11px] leading-5 text-fg-2">{JSON.stringify(result, null, 2)}</pre>
+      </section>
+    {/if}
+  </div>
+</main>


### PR DESCRIPTION
Refs #94

Summary:
- add an isolated /redwire-ws-spike dev route, gated by dev mode or VITE_REDWIRE_WS_SPIKE=1
- add a browser-safe RedWire-over-WSS spike client with native preamble, versioned subprotocol, bearer handshake, binary frame encode/decode, one QueryBinary request, and result decoding
- document WSS and Origin allowlist setup for local validation
- add synthetic WebSocket tests for preamble, 16-byte frame header, stream_id, correlation_id, handshake, one query, and decoded result

Validation:
- pnpm --filter @reddb-io/ui test -- redwire-ws-spike: 45 files, 472 tests passed
- pnpm --filter @reddb-io/ui check: 0 errors, 0 warnings
- pnpm --filter @reddb-io/ui build: passed
- live WSS validation was not run: no local WSS reddb endpoint was reachable at localhost:5055

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783180543&installation_id=129708444&pr_number=107&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F107&signature=a1f4b4c58286ada35f88585d21e9a9b841d8db4cf451a8316de40408b7639689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RedWire WebSocket spike protocol implementation with client-side support.
  * Added documentation page describing spike configuration and usage requirements.
  * Added developer interface for testing RedWire WebSocket connections and queries.

* **Tests**
  * Added comprehensive test suite for protocol frame encoding/decoding and handshake logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->