### PR TITLE
fix(ci): build frontend before tauri cargo check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,16 @@ jobs:
       RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 22, cache: pnpm }
+      - run: pnpm install --frozen-lockfile
+      # `generate_context!()` validates `frontendDist` (packages/ui/build) at
+      # compile time, so the SvelteKit bundle must exist before `cargo check`
+      # — otherwise the proc macro panics with "this path doesn't exist".
+      # release.yml builds the frontend ahead of the tauri step for the same
+      # reason; mirror it here.
+      - run: pnpm --filter @reddb-io/ui build
       - uses: dtolnay/rust-toolchain@1.95.0
       - uses: rui314/setup-mold@v1
       - uses: mozilla-actions/sccache-action@v0.0.10

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use tauri::{Emitter, Manager};
+use tauri::Emitter;
 use tauri_plugin_deep_link::DeepLinkExt;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;


### PR DESCRIPTION
## Problem
The `tauri` CI job failed on **every** PR (including before this work). It runs `cargo check` on the desktop crate, and `tauri::generate_context!()` validates `frontendDist` (`packages/ui/build`) **at compile time** — but the job never built the SvelteKit bundle, so the proc macro panicked:

```
error: proc macro panicked
  = help: message: The `frontendDist` configuration is set to "../../../packages/ui/build" but this path doesn't exist
```

A misleading red check, unrelated to whatever the PR changed.

## Fix
`release.yml` already builds the frontend ahead of its tauri step for exactly this reason (see its inline comment). Mirror it in `ci.yml`'s tauri job: set up pnpm/node, `pnpm install`, then `pnpm --filter @reddb-io/ui build` before `cargo check`.

Also drop the unused `Manager` import in `apps/desktop/src-tauri/src/lib.rs` (the one warning the job emitted).

## Verification
- `packages/ui/build/index.html` is produced by the build step, satisfying `generate_context!`.
- Toolchain matches CI (rustc 1.95.0). The webkit-dependent compile is exercised by this job itself (deps via `tauri-linux-deps`); watch the `tauri` check on this PR go green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784416730&installation_id=129708444&pr_number=109&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F109&signature=638922430eae300edb241fbaccf19378d222abd7beb17f839a4aa338d7d49f0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to set up Node/pnpm and build frontend assets earlier in the pipeline.

* **Refactor**
  * Simplified imports in Tauri configuration by removing unused dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->