### PR TITLE
feat(desktop): open file:// databases via a bundled red sidecar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,13 @@ jobs:
           shared-key: tauri-${{ runner.os }}-rust-1.95.0
           cache-on-failure: "true"
       - uses: ./.github/actions/tauri-linux-deps
+      # The `red` sidecar (Tauri externalBin) is a ~15MB binary, gitignored
+      # rather than committed. tauri-build validates `binaries/red-<triple>`
+      # exists at compile time, so provision it before `cargo check`.
+      - name: provision red sidecar
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/reddb-io/reddb/main/install.sh | bash
+          bash scripts/sync-desktop-sidecar.sh "$HOME/.local/bin/red"
       - run: cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml
       - name: sccache stats
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,13 @@ jobs:
       - name: verify frontend bundle
         run: ls -la packages/ui/build/ && test -f packages/ui/build/index.html
 
+      # Provision the `red` sidecar (Tauri externalBin) — gitignored, not
+      # committed. Must exist before tauri-action bundles the app.
+      - name: provision red sidecar
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/reddb-io/reddb/main/install.sh | bash
+          bash scripts/sync-desktop-sidecar.sh "$HOME/.local/bin/red"
+
       - name: build tauri
         uses: tauri-apps/tauri-action@v0
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ apps/desktop/src-tauri/WixTools/
 # needed because ${CLAUDE_PLUGIN_ROOT} doesn't resolve at project scope.
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+
+# Tauri sidecar binaries — ~15MB platform blobs, provisioned per-machine via
+# scripts/sync-desktop-sidecar.sh (and in CI before the tauri job).
+apps/desktop/src-tauri/binaries/*
+!apps/desktop/src-tauri/binaries/.gitkeep

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -758,6 +758,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,7 +790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1568,6 +1577,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,6 +2167,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "open"
+version = "5.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,6 +2192,16 @@ checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
 dependencies = [
  "dlv-list",
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2201,6 +2251,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -2443,7 +2499,7 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "red-ui"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "keyring",
@@ -2452,6 +2508,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",
+ "tauri-plugin-shell",
  "tokio",
 ]
 
@@ -2890,10 +2947,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_child"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
+dependencies = [
+ "libc",
+ "sigchld",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sigchld"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
+dependencies = [
+ "libc",
+ "os_pipe",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -3293,6 +3382,27 @@ dependencies = [
  "url",
  "windows-registry",
  "windows-result 0.3.4",
+]
+
+[[package]]
+name = "tauri-plugin-shell"
+version = "2.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8457dbf9e2bab1edd8df22bb2c20857a59a9868e79cb3eac5ed639eec4d0c73b"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "open",
+ "os_pipe",
+ "regex",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "shared_child",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -310,6 +310,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,8 +363,27 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -534,6 +559,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +700,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1075,8 +1115,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1086,9 +1128,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1253,6 +1297,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,6 +1419,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1364,6 +1428,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1384,9 +1464,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1810,6 +1892,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,6 +1911,12 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markup5ever"
@@ -2088,6 +2182,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2384,6 +2479,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2462,12 +2566,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2492,6 +2667,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2508,6 +2712,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",
+ "tauri-plugin-http",
  "tauri-plugin-shell",
  "tokio",
 ]
@@ -2583,6 +2788,49 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "cookie",
+ "cookie_store",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -2616,6 +2864,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2641,10 +2903,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2870,6 +3173,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3113,6 +3428,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3162,6 +3483,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3264,7 +3606,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3382,6 +3724,54 @@ dependencies = [
  "url",
  "windows-registry",
  "windows-result 0.3.4",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-http"
+version = "2.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5bd512048e1985b7ec78f96d99083e2ddaf7e0d906b2b63c44ce5bb8b894067"
+dependencies = [
+ "bytes",
+ "cookie_store",
+ "data-url",
+ "http",
+ "regex",
+ "reqwest 0.12.28",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+ "urlpattern",
 ]
 
 [[package]]
@@ -3645,6 +4035,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3956,6 +4356,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4192,6 +4598,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4245,6 +4661,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4486,6 +4911,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4939,6 +5373,26 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -17,6 +17,9 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 tauri-plugin-deep-link = "2"
 tauri-plugin-shell = "2"
+# Rust-side HTTP so the webview can reach a file-backed/local reddb that emits
+# no CORS headers (the cross-origin webview fetch would be blocked otherwise).
+tauri-plugin-http = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["net", "io-util", "rt-multi-thread", "macros", "process", "time"] }

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -16,9 +16,10 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-deep-link = "2"
+tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["net", "io-util", "rt-multi-thread", "macros", "process"] }
+tokio = { version = "1", features = ["net", "io-util", "rt-multi-thread", "macros", "process", "time"] }
 anyhow = "1"
 # OS keychain bridge for the EncryptedStore. macOS → Keychain Services,
 # Windows → Credential Manager, Linux → libsecret via the Secret Service API.

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -8,7 +8,12 @@
     "deep-link:default",
     {
       "identifier": "http:default",
-      "allow": [{ "url": "http://**" }, { "url": "https://**" }]
+      "allow": [
+        { "url": "http://localhost:*/*" },
+        { "url": "http://127.0.0.1:*/*" },
+        { "url": "https://localhost:*/*" },
+        { "url": "https://127.0.0.1:*/*" }
+      ]
     }
   ]
 }

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -5,6 +5,10 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "deep-link:default"
+    "deep-link:default",
+    {
+      "identifier": "http:default",
+      "allow": [{ "url": "http://**" }, { "url": "https://**" }]
+    }
   ]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
-use tauri::Emitter;
+use std::collections::HashMap;
+use std::sync::Mutex;
+use tauri::{Emitter, Manager};
 use tauri_plugin_deep_link::DeepLinkExt;
+use tauri_plugin_shell::process::CommandChild;
+use tauri_plugin_shell::ShellExt;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
@@ -95,10 +99,143 @@ async fn docker_exec(container: String, cmd: Vec<String>) -> Result<String, Stri
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
+// Embedded file-backed reddb (the desktop-only "open a .rdb file" capability).
+// The webview can't open a database file directly, so the Tauri shell spawns
+// the bundled `red` sidecar as a local server pointed at the file, and the UI
+// connects to it over plain HTTP on 127.0.0.1 — reusing the entire HTTP client
+// unchanged. One process per canonical path; reused on reconnect; all killed
+// on app exit.
+struct Embedded {
+    url: String,
+    child: CommandChild,
+}
+
+#[derive(Default)]
+struct EmbeddedRegistry(Mutex<HashMap<String, Embedded>>);
+
+/// Resolve a user-typed path (from a `file://` URL) to an absolute path. `~`
+/// and relative paths resolve against `$HOME`, so `file://./test.rdb` opens
+/// `~/test.rdb` — a predictable base for a GUI app whose cwd is unspecified.
+fn resolve_embedded_path(input: &str) -> Result<String, String> {
+    let raw = input.trim();
+    let raw = raw.strip_prefix("file://").unwrap_or(raw);
+    let home = || std::env::var("HOME").map_err(|_| "HOME not set".to_string());
+    let expanded = if let Some(rest) = raw.strip_prefix("~/") {
+        format!("{}/{}", home()?, rest)
+    } else {
+        raw.to_string()
+    };
+    let path = std::path::Path::new(&expanded);
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::path::Path::new(&home()?).join(expanded.trim_start_matches("./"))
+    };
+    Ok(abs.to_string_lossy().to_string())
+}
+
+/// Grab an ephemeral local port by binding `:0` and reading it back.
+fn free_local_port() -> Result<u16, String> {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .and_then(|l| l.local_addr())
+        .map(|a| a.port())
+        .map_err(|e| e.to_string())
+}
+
+/// Poll `GET /stats` on the embedded server until it answers 200 (it is the
+/// canonical proof-of-life for reddb) or the deadline passes.
+async fn wait_until_ready(bind: &str) -> Result<(), String> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    loop {
+        if std::time::Instant::now() > deadline {
+            return Err("embedded reddb did not become ready within 20s".to_string());
+        }
+        if let Ok(mut stream) = TcpStream::connect(bind).await {
+            let req =
+                format!("GET /stats HTTP/1.0\r\nHost: {bind}\r\nConnection: close\r\n\r\n");
+            if stream.write_all(req.as_bytes()).await.is_ok() {
+                let mut buf = [0u8; 32];
+                if let Ok(n) = stream.read(&mut buf).await {
+                    if String::from_utf8_lossy(&buf[..n]).contains(" 200") {
+                        return Ok(());
+                    }
+                }
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+}
+
+/// Open (or reuse) an embedded file-backed reddb and return its local HTTP URL.
+#[tauri::command]
+async fn open_embedded(app: tauri::AppHandle, path: String) -> Result<String, String> {
+    let abs = resolve_embedded_path(&path)?;
+
+    // Reuse an already-running server for the same file.
+    if let Some(existing) = app
+        .state::<EmbeddedRegistry>()
+        .0
+        .lock()
+        .map_err(|e| e.to_string())?
+        .get(&abs)
+        .map(|e| e.url.clone())
+    {
+        return Ok(existing);
+    }
+
+    let port = free_local_port()?;
+    let bind = format!("127.0.0.1:{port}");
+    let url = format!("http://{bind}");
+
+    let (mut rx, child) = app
+        .shell()
+        .sidecar("red")
+        .map_err(|e| format!("sidecar `red` unavailable: {e}"))?
+        .args(["server", "--path", abs.as_str(), "--http-bind", bind.as_str()])
+        // reddb refuses plain HTTP without this in dev (it otherwise wants a
+        // TLS cert); the local client speaks plain http on 127.0.0.1.
+        .env("RED_HTTP_TLS_DEV", "1")
+        .spawn()
+        .map_err(|e| format!("failed to spawn embedded reddb: {e}"))?;
+
+    // Drain the sidecar's output channel so its pipe never fills and blocks.
+    tauri::async_runtime::spawn(async move { while rx.recv().await.is_some() {} });
+
+    if let Err(e) = wait_until_ready(&bind).await {
+        let _ = child.kill();
+        return Err(e);
+    }
+
+    app.state::<EmbeddedRegistry>()
+        .0
+        .lock()
+        .map_err(|e| e.to_string())?
+        .insert(abs, Embedded { url: url.clone(), child });
+    Ok(url)
+}
+
+/// Stop the embedded server backing `path`, if one is running.
+#[tauri::command]
+fn close_embedded(app: tauri::AppHandle, path: String) -> Result<(), String> {
+    let abs = resolve_embedded_path(&path)?;
+    if let Some(embedded) = app
+        .state::<EmbeddedRegistry>()
+        .0
+        .lock()
+        .map_err(|e| e.to_string())?
+        .remove(&abs)
+    {
+        let _ = embedded.child.kill();
+    }
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_deep_link::init())
+        .plugin(tauri_plugin_shell::init())
+        .manage(EmbeddedRegistry::default())
         .setup(|app| {
             let handle = app.handle().clone();
             app.deep_link().on_open_url(move |event| {
@@ -114,7 +251,22 @@ pub fn run() {
             keychain_set,
             keychain_get,
             keychain_delete,
+            open_embedded,
+            close_embedded,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app_handle, event| {
+            // Reap any embedded reddb sidecars when the app exits so we never
+            // leak a file-backed server holding the database open.
+            if let tauri::RunEvent::Exit = event {
+                if let Some(registry) = app_handle.try_state::<EmbeddedRegistry>() {
+                    if let Ok(mut map) = registry.0.lock() {
+                        for (_, embedded) in map.drain() {
+                            let _ = embedded.child.kill();
+                        }
+                    }
+                }
+            }
+        });
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -235,6 +235,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_http::init())
         .manage(EmbeddedRegistry::default())
         .setup(|app| {
             let handle = app.handle().clone();

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -187,16 +187,26 @@ async fn open_embedded(app: tauri::AppHandle, path: String) -> Result<String, St
     let bind = format!("127.0.0.1:{port}");
     let url = format!("http://{bind}");
 
-    let (mut rx, child) = app
-        .shell()
+    let args = ["server", "--path", abs.as_str(), "--http-bind", bind.as_str()];
+    let shell = app.shell();
+    // Prefer the bundled sidecar (production). In `tauri dev` the sidecar binary
+    // isn't copied next to the dev executable, so fall back to `red` on PATH.
+    // `RED_HTTP_TLS_DEV=1` lets reddb serve plain HTTP on 127.0.0.1.
+    let sidecar_spawn = shell
         .sidecar("red")
-        .map_err(|e| format!("sidecar `red` unavailable: {e}"))?
-        .args(["server", "--path", abs.as_str(), "--http-bind", bind.as_str()])
-        // reddb refuses plain HTTP without this in dev (it otherwise wants a
-        // TLS cert); the local client speaks plain http on 127.0.0.1.
-        .env("RED_HTTP_TLS_DEV", "1")
-        .spawn()
-        .map_err(|e| format!("failed to spawn embedded reddb: {e}"))?;
+        .ok()
+        .map(|cmd| cmd.args(args).env("RED_HTTP_TLS_DEV", "1").spawn());
+    let (mut rx, child) = match sidecar_spawn {
+        Some(Ok(pair)) => pair,
+        _ => shell
+            .command("red")
+            .args(args)
+            .env("RED_HTTP_TLS_DEV", "1")
+            .spawn()
+            .map_err(|e| {
+                format!("failed to spawn `red` (bundled sidecar and PATH both unavailable): {e}")
+            })?,
+    };
 
     // Drain the sidecar's output channel so its pipe never fills and blocks.
     tauri::async_runtime::spawn(async move { while rx.recv().await.is_some() {} });

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -28,6 +28,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "externalBin": ["binaries/red"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -61,6 +61,7 @@
     "@sigma/edge-curve": "^3.1.0",
     "@sigma/node-border": "^3.0.0",
     "@tauri-apps/api": "^2.5.0",
+    "@tauri-apps/plugin-http": "^2.5.9",
     "@xyflow/svelte": "^1.2.0",
     "bits-ui": "^2.18.1",
     "clsx": "^2.1.1",

--- a/packages/ui/src/lib/connections.svelte.ts
+++ b/packages/ui/src/lib/connections.svelte.ts
@@ -173,11 +173,27 @@ export function makeCustomConnection(input: string): ConnectionPreset {
 // Transport reachability is a Surface property (#34, ADR-0003): a Tauri shell
 // can open native unix/embedded connections the browser can't. Detect the
 // Surface here so the default provider declares the right reachable set.
-function surfaceTransports(): Transport[] {
-  const tauri =
+function isTauriSurface(): boolean {
+  return (
     typeof window !== "undefined" &&
-    ("__TAURI_INTERNALS__" in window || "__TAURI__" in window);
-  return [...(tauri ? DESKTOP_TRANSPORTS : BROWSER_TRANSPORTS)];
+    ("__TAURI_INTERNALS__" in window || "__TAURI__" in window)
+  );
+}
+
+function surfaceTransports(): Transport[] {
+  return [...(isTauriSurface() ? DESKTOP_TRANSPORTS : BROWSER_TRANSPORTS)];
+}
+
+/**
+ * Open a `file://` connection by asking the Tauri shell to spawn a local
+ * file-backed reddb sidecar; returns the `http://127.0.0.1:<port>` URL the
+ * HTTP client then talks to. Only wired on a Tauri Surface — the browser has
+ * no filesystem/process access, so `file://` stays unreachable there.
+ */
+async function tauriOpenEmbedded(fileUrl: string): Promise<string> {
+  const path = fileUrl.replace(/^file:\/\//i, "");
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<string>("open_embedded", { path });
 }
 
 function isHandoffTokenConsumer(
@@ -198,6 +214,7 @@ export const provider: ConnectionProvider & {
   presets: PRESETS,
   history: historyStore,
   transports: surfaceTransports(),
+  embeddedResolver: isTauriSurface() ? tauriOpenEmbedded : undefined,
   // Boot-params pre-configuration (#36, ADR-0005): a Surface (the MCP App)
   // seeds the endpoint + initial route in the app URL; the Core reads it
   // through the provider. Query tokens are ignored and hash tokens are not

--- a/packages/ui/src/lib/connections.svelte.ts
+++ b/packages/ui/src/lib/connections.svelte.ts
@@ -187,14 +187,49 @@ function surfaceTransports(): Transport[] {
 /**
  * Open a `file://` connection by asking the Tauri shell to spawn a local
  * file-backed reddb sidecar; returns the `http://127.0.0.1:<port>` URL the
- * HTTP client then talks to. Only wired on a Tauri Surface — the browser has
- * no filesystem/process access, so `file://` stays unreachable there.
+ * HTTP client then talks to.
+ *
+ * Tauri-ness is checked HERE, at call time — not when the provider is built.
+ * In `tauri dev` this module can evaluate before Tauri injects its globals, so
+ * gating the resolver at construction left it unwired and `file://` fell
+ * through to a raw fetch ("Load failed"). At connect time the IPC bridge is
+ * always present. The browser has no filesystem/process access, so we fail
+ * with a clear message there instead.
  */
 async function tauriOpenEmbedded(fileUrl: string): Promise<string> {
+  if (!isTauriSurface()) {
+    throw new Error("file:// databases can only be opened in the desktop app");
+  }
   const path = fileUrl.replace(/^file:\/\//i, "");
   const { invoke } = await import("@tauri-apps/api/core");
   return invoke<string>("open_embedded", { path });
 }
+
+/**
+ * Desktop HTTP for loopback targets goes through Tauri's rust-side fetch.
+ *
+ * An embedded file-backed reddb (and the bundled `red` generally) emits no CORS
+ * headers, so a cross-origin webview fetch from the app/dev origin to
+ * `127.0.0.1:<port>` is blocked ("Load failed"). Tauri's HTTP plugin issues the
+ * request from Rust, bypassing the webview's same-origin policy. Only loopback
+ * targets are rerouted; remote servers keep the plain webview fetch. In the
+ * browser this is always the plain fetch.
+ */
+const desktopFetch: typeof fetch = async (input, init) => {
+  const url =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.href
+        : input.url;
+  const isLoopback =
+    /^https?:\/\/(127\.0\.0\.1|localhost|\[::1\])(:\d+)?(\/|$)/i.test(url);
+  if (isTauriSurface() && isLoopback) {
+    const { fetch: tauriFetch } = await import("@tauri-apps/plugin-http");
+    return tauriFetch(input as URL | Request | string, init as RequestInit);
+  }
+  return fetch(input, init);
+};
 
 function isHandoffTokenConsumer(
   candidate: ConnectionProvider
@@ -214,7 +249,13 @@ export const provider: ConnectionProvider & {
   presets: PRESETS,
   history: historyStore,
   transports: surfaceTransports(),
-  embeddedResolver: isTauriSurface() ? tauriOpenEmbedded : undefined,
+  // Always wired: the resolver itself decides (at call time) whether it's on a
+  // Tauri Surface, so a not-yet-injected global at module load can't disable it.
+  embeddedResolver: tauriOpenEmbedded,
+  // Route loopback HTTP through Tauri's rust-side fetch (CORS bypass for the
+  // embedded/local reddb); plain webview fetch everywhere else.
+  clientFactory: (url, opts) =>
+    new RedClient(url, { ...opts, fetch: desktopFetch }),
   // Boot-params pre-configuration (#36, ADR-0005): a Surface (the MCP App)
   // seeds the endpoint + initial route in the app URL; the Core reads it
   // through the provider. Query tokens are ignored and hash tokens are not

--- a/packages/ui/src/lib/connections.svelte.ts
+++ b/packages/ui/src/lib/connections.svelte.ts
@@ -225,8 +225,19 @@ const desktopFetch: typeof fetch = async (input, init) => {
   const isLoopback =
     /^https?:\/\/(127\.0\.0\.1|localhost|\[::1\])(:\d+)?(\/|$)/i.test(url);
   if (isTauriSurface() && isLoopback) {
-    const { fetch: tauriFetch } = await import("@tauri-apps/plugin-http");
-    return tauriFetch(input as URL | Request | string, init as RequestInit);
+    try {
+      const { fetch: tauriFetch } = await import("@tauri-apps/plugin-http");
+      return await tauriFetch(
+        input as URL | Request | string,
+        init as RequestInit
+      );
+    } catch (e) {
+      // Surface the real reason — the http plugin can reject with a bare
+      // string/object that would otherwise read as "undefined" upstream.
+      const reason =
+        e instanceof Error ? e.message : typeof e === "string" ? e : String(e);
+      throw new Error(`rust-side fetch failed for ${url}: ${reason}`);
+    }
   }
   return fetch(input, init);
 };

--- a/packages/ui/src/lib/reddb/client.ts
+++ b/packages/ui/src/lib/reddb/client.ts
@@ -294,6 +294,27 @@ async function* parseNdjsonFrames(
 const SELECT_RE = /^\s*select\b/i;
 
 /**
+ * Extract a human-readable message from any thrown value. Tauri's `invoke` and
+ * the HTTP plugin reject with plain strings or bare objects (not `Error`), so
+ * `(e as Error).message` is often `undefined` — this never returns that.
+ */
+export function errorText(e: unknown): string {
+  if (e instanceof Error) return e.message || String(e);
+  if (typeof e === "string") return e;
+  if (e && typeof e === "object") {
+    const m = (e as { message?: unknown }).message;
+    if (typeof m === "string" && m) return m;
+    try {
+      const s = JSON.stringify(e);
+      if (s && s !== "{}") return s;
+    } catch {
+      /* circular — fall through */
+    }
+  }
+  return String(e);
+}
+
+/**
  * Run a query, preferring the bounded-memory NDJSON stream for a plain SELECT
  * and falling back to the buffered `POST /query` for everything else — and for
  * any streaming failure (network, a non-SELECT 400, or an older server with no
@@ -433,7 +454,7 @@ export class RedClient {
       await this.json("/stats");
       return { ok: true, rtt_ms: Math.round(performance.now() - start) };
     } catch (e) {
-      return { ok: false, error: (e as Error).message };
+      return { ok: false, error: errorText(e) };
     }
   }
 

--- a/packages/ui/src/lib/reddb/local-url-provider.test.ts
+++ b/packages/ui/src/lib/reddb/local-url-provider.test.ts
@@ -175,6 +175,61 @@ describe("LocalUrlProvider — implementation-specific", () => {
     expect(JSON.stringify(history.load())).not.toContain("mock-handoff-token");
   });
 
+  it("resolves a file:// target through the embedded resolver, keeping file:// for display", async () => {
+    const clientFactory = vi.fn(fakeClient);
+    const embeddedResolver = vi
+      .fn<(u: string) => Promise<string>>()
+      .mockResolvedValue("http://127.0.0.1:48211");
+    const p = new LocalUrlProvider({
+      presets: [],
+      history: memoryHistory(),
+      clientFactory,
+      embeddedResolver,
+    });
+
+    const active = await p.connect("file://./test.rdb");
+
+    // The resolver saw the original file:// string…
+    expect(embeddedResolver).toHaveBeenCalledWith("file://./test.rdb");
+    // …the client was built against the resolved local URL…
+    expect(clientFactory).toHaveBeenCalledWith(
+      "http://127.0.0.1:48211",
+      undefined
+    );
+    // …but the connection's identity stays the file path the user typed.
+    expect(active.connection.url).toBe("file://./test.rdb");
+  });
+
+  it("surfaces a failed embedded resolve as UnreachableConnectionError", async () => {
+    const p = new LocalUrlProvider({
+      presets: [],
+      history: memoryHistory(),
+      clientFactory: fakeClient,
+      embeddedResolver: vi
+        .fn<(u: string) => Promise<string>>()
+        .mockRejectedValue(new Error("sidecar `red` unavailable")),
+    });
+    await expect(p.connect("file://./missing.rdb")).rejects.toBeInstanceOf(
+      UnreachableConnectionError
+    );
+  });
+
+  it("leaves http targets untouched even when an embedded resolver is present", async () => {
+    const clientFactory = vi.fn(fakeClient);
+    const embeddedResolver = vi
+      .fn<(u: string) => Promise<string>>()
+      .mockResolvedValue("http://127.0.0.1:1");
+    const p = new LocalUrlProvider({
+      presets: [],
+      history: memoryHistory(),
+      clientFactory,
+      embeddedResolver,
+    });
+    await p.connect("http://host:5055");
+    expect(embeddedResolver).not.toHaveBeenCalled();
+    expect(clientFactory).toHaveBeenCalledWith("http://host:5055", undefined);
+  });
+
   it("history is capped at historyMax", async () => {
     const history = memoryHistory();
     const p = new LocalUrlProvider({

--- a/packages/ui/src/lib/reddb/local-url-provider.ts
+++ b/packages/ui/src/lib/reddb/local-url-provider.ts
@@ -181,7 +181,15 @@ export class LocalUrlProvider implements ConnectionProvider {
       try {
         clientUrl = await this.embeddedResolver(target.url);
       } catch (e) {
-        throw new UnreachableConnectionError(target.id, (e as Error).message);
+        // Tauri's `invoke` rejects with a plain string (the Rust `Err`), not an
+        // Error — so read the message defensively instead of assuming `.message`.
+        const reason =
+          e instanceof Error
+            ? e.message
+            : typeof e === "string"
+              ? e
+              : String(e);
+        throw new UnreachableConnectionError(target.id, reason);
       }
     }
 

--- a/packages/ui/src/lib/reddb/local-url-provider.ts
+++ b/packages/ui/src/lib/reddb/local-url-provider.ts
@@ -50,6 +50,14 @@ export interface LocalUrlProviderOptions {
    * auto-connect without the Connect flow. Tokens must never be placed here.
    */
   bootParams?: BootParams;
+  /**
+   * Resolve a `file://` connection to a reachable URL (#embedded-file). Only a
+   * Tauri Surface supplies this: it spawns a local file-backed reddb sidecar
+   * and returns its `http://127.0.0.1:<port>` URL, which the HTTP client then
+   * talks to. Absent on the browser Surface, where `file://` is unreachable by
+   * design. Receives the original `file://…` string, returns the client URL.
+   */
+  embeddedResolver?: (fileUrl: string) => Promise<string>;
 }
 
 export interface HandoffTokenConsumer {
@@ -102,6 +110,7 @@ export class LocalUrlProvider implements ConnectionProvider {
   private readonly historyMax: number;
   private readonly supportedTransports: Transport[];
   private readonly boot: BootParams | null;
+  private readonly embeddedResolver?: (fileUrl: string) => Promise<string>;
   private readonly handoffTokens = new Map<string, string>();
   private active: ActiveConnection | null = null;
 
@@ -120,6 +129,7 @@ export class LocalUrlProvider implements ConnectionProvider {
       (hasBootEndpoint(opts.bootParams) || hasBootRoute(opts.bootParams))
         ? { ...opts.bootParams }
         : null;
+    this.embeddedResolver = opts.embeddedResolver;
   }
 
   transports(): Transport[] {
@@ -162,9 +172,22 @@ export class LocalUrlProvider implements ConnectionProvider {
     const target = this.resolve(id);
     if (!target) throw new UnknownConnectionError(id);
 
+    // A `file://` target is opened by the Surface's embedded resolver (Tauri
+    // spawns a local file-backed reddb and hands back its http URL). The
+    // displayed connection keeps the `file://` identity; only the client talks
+    // to the resolved local URL.
+    let clientUrl = target.url;
+    if (this.embeddedResolver && /^file:\/\//i.test(target.url)) {
+      try {
+        clientUrl = await this.embeddedResolver(target.url);
+      } catch (e) {
+        throw new UnreachableConnectionError(target.id, (e as Error).message);
+      }
+    }
+
     const token = this.consumeHandoffToken(target.url);
     const client = this.clientFactory(
-      target.url,
+      clientUrl,
       token ? { headers: { Authorization: `Bearer ${token}` } } : undefined
     );
     const ping = await client.ping();

--- a/packages/ui/vite-tailwind-svelte.ts
+++ b/packages/ui/vite-tailwind-svelte.ts
@@ -1,0 +1,52 @@
+import tailwindcssPlugin from "@tailwindcss/vite";
+import type { PluginOption } from "vite";
+
+/**
+ * `@tailwindcss/vite` that skips Svelte `<style>` virtual modules.
+ *
+ * Tailwind's transform compiles every module whose id contains `&lang.css`,
+ * which includes svelte-plugin's `Foo.svelte?svelte&type=style&lang.css`
+ * modules. On a *cold* `vite dev` request (the style fetched before svelte has
+ * transformed its parent), Tailwind reads the raw `.svelte` file off disk and
+ * parses the `<script>` as CSS — crashing the dev server with
+ * `Invalid declaration: ...`. It only bites in dev (`tauri dev`); `vite build`
+ * resolves parent-first.
+ *
+ * Our component `<style>` blocks are plain CSS (no `@apply`/`@reference`/
+ * `theme()`), so Tailwind has no reason to touch them. Skipping them removes
+ * the crash without losing any functionality.
+ */
+export function tailwindcss(): PluginOption[] {
+  const plugins = tailwindcssPlugin() as PluginOption[];
+  const isSvelteStyle = (id: string) =>
+    id.includes(".svelte?") && id.includes("type=style");
+  for (const plugin of plugins) {
+    if (!plugin || typeof plugin !== "object") continue;
+    const slot = plugin as { transform?: unknown };
+    const t = slot.transform;
+    if (!t) continue;
+    const handler =
+      typeof t === "function" ? t : (t as { handler?: unknown }).handler;
+    if (typeof handler !== "function") continue;
+    const fn = handler as (
+      this: unknown,
+      code: string,
+      id: string,
+      opts?: unknown
+    ) => unknown;
+    const wrapped = function (
+      this: unknown,
+      code: string,
+      id: string,
+      opts?: unknown
+    ) {
+      if (isSvelteStyle(id)) return null;
+      return fn.call(this, code, id, opts);
+    };
+    slot.transform =
+      typeof t === "function"
+        ? wrapped
+        : { ...(t as object), handler: wrapped };
+  }
+  return plugins;
+}

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -1,5 +1,5 @@
 import { sveltekit } from "@sveltejs/kit/vite";
-import { defineConfig } from "vite";
+import { defineConfig, searchForWorkspaceRoot } from "vite";
 import { tailwindcss } from "./vite-tailwind-svelte";
 import { versionDefines } from "./version.config";
 
@@ -10,6 +10,9 @@ export default defineConfig({
   server: {
     port: 1420,
     strictPort: true,
+    // Allow serving workspace-sibling sources (e.g. @reddb-io/ui-kit) in dev —
+    // they live outside packages/ui, so default fs.allow rejects them.
+    fs: { allow: [searchForWorkspaceRoot(process.cwd())] },
     watch: { ignored: ["**/src-tauri/**"] },
   },
 });

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -1,6 +1,6 @@
 import { sveltekit } from "@sveltejs/kit/vite";
-import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
+import { tailwindcss } from "./vite-tailwind-svelte";
 import { versionDefines } from "./version.config";
 
 export default defineConfig({

--- a/packages/ui/vite.embed.config.ts
+++ b/packages/ui/vite.embed.config.ts
@@ -1,7 +1,7 @@
 import { svelte } from "@sveltejs/vite-plugin-svelte";
-import tailwindcss from "@tailwindcss/vite";
 import { resolve } from "node:path";
 import { defineConfig } from "vite";
+import { tailwindcss } from "./vite-tailwind-svelte";
 import { versionDefines } from "./version.config";
 
 export default defineConfig({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       "@tauri-apps/api":
         specifier: ^2.5.0
         version: 2.11.0
+      "@tauri-apps/plugin-http":
+        specifier: ^2.5.9
+        version: 2.5.9
       "@xyflow/svelte":
         specifier: ^1.2.0
         version: 1.5.2(svelte@5.55.9)
@@ -2079,6 +2082,12 @@ packages:
       }
     engines: { node: ">= 10" }
     hasBin: true
+
+  "@tauri-apps/plugin-http@2.5.9":
+    resolution:
+      {
+        integrity: sha512-lCiY0+vs4HvIUSvZrBs8TC3TiCB0MOPRmiUjTq4prW7SlcJE2jdLeT6KBsJrT9Tlplufl7W1pY6SFAO3gCWxDA==,
+      }
 
   "@types/cookie@0.6.0":
     resolution:
@@ -6111,6 +6120,10 @@ snapshots:
       "@tauri-apps/cli-win32-arm64-msvc": 2.11.2
       "@tauri-apps/cli-win32-ia32-msvc": 2.11.2
       "@tauri-apps/cli-win32-x64-msvc": 2.11.2
+
+  "@tauri-apps/plugin-http@2.5.9":
+    dependencies:
+      "@tauri-apps/api": 2.11.0
 
   "@types/cookie@0.6.0": {}
 

--- a/scripts/sync-desktop-sidecar.sh
+++ b/scripts/sync-desktop-sidecar.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Provision the bundled `red` sidecar for the host target triple.
+#
+# Tauri's `externalBin` (apps/desktop/src-tauri/binaries/red-<triple>) must
+# exist before `cargo check`, `tauri dev`, or `tauri build` — tauri-build
+# validates the path at compile time. The binary itself is gitignored (it's a
+# ~15MB platform-specific blob), so install reddb's `red` and run this to drop
+# it into place.
+#
+# Usage:
+#   scripts/sync-desktop-sidecar.sh                # copy `red` from PATH
+#   scripts/sync-desktop-sidecar.sh /path/to/red   # copy a specific binary
+#   RED_BIN=/path/to/red scripts/sync-desktop-sidecar.sh
+#
+# Install `red` first if it isn't on PATH:
+#   curl -fsSL https://raw.githubusercontent.com/reddb-io/reddb/main/install.sh | bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST_DIR="$HERE/apps/desktop/src-tauri/binaries"
+
+# Target triple: prefer rustc's host, fall back to a uname mapping so the
+# script works in release jobs that haven't set a toolchain up yet.
+TRIPLE="${TAURI_TARGET_TRIPLE:-}"
+if [ -z "$TRIPLE" ] && command -v rustc >/dev/null 2>&1; then
+  TRIPLE="$(rustc -vV | sed -n 's/^host: //p')"
+fi
+if [ -z "$TRIPLE" ]; then
+  case "$(uname -s)-$(uname -m)" in
+    Linux-x86_64) TRIPLE="x86_64-unknown-linux-gnu" ;;
+    Linux-aarch64) TRIPLE="aarch64-unknown-linux-gnu" ;;
+    Darwin-x86_64) TRIPLE="x86_64-apple-darwin" ;;
+    Darwin-arm64 | Darwin-aarch64) TRIPLE="aarch64-apple-darwin" ;;
+    *) echo "✗ cannot determine target triple; set TAURI_TARGET_TRIPLE" >&2; exit 1 ;;
+  esac
+fi
+
+RED_BIN="${1:-${RED_BIN:-$(command -v red || true)}}"
+if [ -z "$RED_BIN" ] || [ ! -x "$RED_BIN" ]; then
+  echo "✗ 'red' binary not found." >&2
+  echo "  Install it, then re-run:" >&2
+  echo "    curl -fsSL https://raw.githubusercontent.com/reddb-io/reddb/main/install.sh | bash" >&2
+  echo "  or pass a path: scripts/sync-desktop-sidecar.sh /path/to/red" >&2
+  exit 1
+fi
+
+mkdir -p "$DEST_DIR"
+cp "$RED_BIN" "$DEST_DIR/red-$TRIPLE"
+chmod +x "$DEST_DIR/red-$TRIPLE"
+echo "▸ sidecar provisioned: binaries/red-$TRIPLE  (from $RED_BIN)"


### PR DESCRIPTION
## Problem
Connecting to a file-backed DB in the desktop app (`file://./test.rdb`) failed with **"unreachable: Load failed"**. The capability was declared in the transport map (`file` → `unix`, desktop-reachable) but never implemented — so it fell through to an HTTP `fetch("file://…")` that WebKit rejects.

## What this does
The desktop app now opens the file for real, reusing the entire HTTP client:
- **`red` bundled as a Tauri sidecar** (externalBin). New Rust commands `open_embedded`/`close_embedded` spawn `red server --path <file> --http-bind 127.0.0.1:<free-port>` (`RED_HTTP_TLS_DEV=1`), poll `/stats` until ready, return the local URL. One process per canonical path, reused on reconnect, all reaped on app exit.
- **Provider `embeddedResolver` hook**: `connect()` resolves a `file://` target to the local http URL before building the client. The displayed connection keeps its `file://` identity; only the client talks to the local port. Relative/`~` paths resolve against `$HOME`.
- Browser Surface supplies no resolver → `file://` stays unreachable there by design.

## Sidecar provisioning
The binary is **gitignored** (~15MB, platform-specific). `tauri-build` validates `binaries/red-<triple>` at compile time, so it's provisioned via `scripts/sync-desktop-sidecar.sh` — from PATH locally, and via reddb's `install.sh` in the ci.yml/release.yml tauri jobs before the build.

## Verification
- `cargo check` clean; `svelte-check` clean; **505 tests** pass (+3 for the `file://` resolution path).
- Verified the real invocation: `red server --path … --http-bind …` serves `/stats` 200 locally.
- Watch the `tauri` check here — it provisions the sidecar then `cargo check`s.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784421063&installation_id=129708444&pr_number=110&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F110&signature=313fa7d0a673f0fc053ab0e8aa6fb18d34867226189fca6cea8e1a8f3de9622c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop app can now open and manage local file-based databases, exposing them via a local HTTP loopback endpoint and reusing existing sessions per file.
  * UI now resolves embedded `file://` connections on the desktop and routes loopback HTTP(S) through the desktop networking layer when available.
* **Tests**
  * Added coverage for embedded/local URL resolution behavior and failure handling.
* **Chores**
  * Updated desktop build/release packaging to provision and bundle the required sidecar binary; improved CI workflow reliability.
  * Updated git ignore rules for desktop bundled binaries, adjusted deep-link capability permissions, and refreshed UI build tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->