### PR TITLE
Fix KV collection previews

### DIFF
--- a/.changeset/fix-kv-collection-preview.md
+++ b/.changeset/fix-kv-collection-preview.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/ui": patch
+---
+
+Use `LIST KV` when previewing native key-value collections, so embedded red-ui can open legacy Red Request stores such as `rr_requests`.

--- a/packages/ui/src/lib/ResultsPane.svelte
+++ b/packages/ui/src/lib/ResultsPane.svelte
@@ -7,6 +7,7 @@
   import { tabs, type Tab } from '$lib/tabs.svelte'
   import { queryTabs } from '$lib/query-tabs.svelte'
   import { defaultSubpage, subpageCapability } from '$lib/collection-pages'
+  import { collectionPreviewQuery, safeCollectionName } from '$lib/collection-preview'
   import {
     collectionCatalogBadges,
     collectionCatalogFromRow,
@@ -171,10 +172,6 @@
     }
   }
 
-  function safeCollectionName(collection: string): string {
-    return collection.replace(/[^A-Za-z0-9_./-]/g, '')
-  }
-
   function sqlString(s: string): string {
     return `'${s.replace(/'/g, "''")}'`
   }
@@ -242,7 +239,8 @@
       const shouldFetchQueue = subpage === 'queue' || tab.capability === 'queue'
       const shouldFetchVector = subpage === 'vector' || tab.capability === 'vector'
       const shouldFetchStats = subpage === 'stats' || tab.capability === 'stats'
-      const fetchMode = shouldFetchGraph ? 'graph-subgraph' : shouldFetchQueue ? 'queue-peek' : shouldFetchVector ? 'vector-inspector' : shouldFetchStats ? 'stats-info' : tab.capability ?? 'unknown'
+      const shouldFetchKv = subpage === 'kv' || tab.capability === 'kv'
+      const fetchMode = shouldFetchGraph ? 'graph-subgraph' : shouldFetchQueue ? 'queue-peek' : shouldFetchVector ? 'vector-inspector' : shouldFetchStats ? 'stats-info' : shouldFetchKv ? 'kv-list' : tab.capability ?? 'unknown'
       const cacheKey = `${tab.key}:${subpage}:${fetchMode}`
       if (resultKeys[tab.id] && resultKeys[tab.id] !== cacheKey) {
         delete results[tab.id]
@@ -269,9 +267,14 @@
               `${collection} · stats preview`,
               () => fetchStatsCollection(client, collection),
             )
+        : shouldFetchKv
+          ? activity.track(
+              `${collection} · LIST KV (LIMIT 200)`,
+              () => client.query(collectionPreviewQuery(collection, 'kv')),
+            )
         : activity.track(
             `${collection} · SELECT * (LIMIT 200)`,
-            () => client.query(`SELECT * FROM ${collection} LIMIT 200`),
+            () => client.query(collectionPreviewQuery(collection, tab.capability)),
           )
       job
         .then((r) => { results[tab.id] = r })

--- a/packages/ui/src/lib/collection-preview.test.ts
+++ b/packages/ui/src/lib/collection-preview.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { collectionPreviewQuery } from "./collection-preview";
+
+describe("collectionPreviewQuery", () => {
+  it("uses LIST KV for native key-value collections", () => {
+    expect(collectionPreviewQuery("rr_requests", "kv")).toBe(
+      "LIST KV rr_requests LIMIT 200"
+    );
+  });
+
+  it("keeps table-like collections on SELECT preview", () => {
+    expect(collectionPreviewQuery("users", "table")).toBe(
+      "SELECT * FROM users LIMIT 200"
+    );
+  });
+});

--- a/packages/ui/src/lib/collection-preview.ts
+++ b/packages/ui/src/lib/collection-preview.ts
@@ -1,0 +1,14 @@
+import type { Capability } from "./renderers/types";
+
+export function safeCollectionName(collection: string): string {
+  return collection.replace(/[^A-Za-z0-9_./-]/g, "");
+}
+
+export function collectionPreviewQuery(
+  collection: string,
+  capability: Capability | undefined
+): string {
+  const safe = safeCollectionName(collection);
+  if (capability === "kv") return `LIST KV ${safe} LIMIT 200`;
+  return `SELECT * FROM ${safe} LIMIT 200`;
+}


### PR DESCRIPTION
## Summary
- preview native key-value collections with `LIST KV <collection> LIMIT 200` instead of generic `SELECT *`
- keep table-like collections on the existing SELECT preview path
- add a regression test for legacy Red Request stores such as `rr_requests`

## Validation
- `pnpm --filter @reddb-io/ui test -- collection-preview.test.ts kv-render.test.ts` (suite ran: 49 files, 507 tests)
- `pnpm --filter @reddb-io/ui check`
- `pnpm --filter @reddb-io/ui build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785099239&installation_id=129708444&pr_number=111&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F111&signature=4f7a2643c2c4e3731579ab56706b1329141f8f122a772cbe2828fe657d072631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collection previews now support native key-value collections, using the appropriate listing query so legacy stores can open correctly.
* **Bug Fixes**
  * Improved preview query generation for non-KV collections and added safer collection-name handling.
* **Tests**
  * Added coverage for preview queries to verify the correct output for both KV and table-like collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->