### PR TITLE
ci: use local changeset changelog

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,14 +1,8 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "reddb-io/red-ui" }],
+  "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [
-    [
-      "@reddb-io/ui",
-      "@reddb-io/ui-kit",
-      "@reddb-io/ui-mcp"
-    ]
-  ],
+  "fixed": [["@reddb-io/ui", "@reddb-io/ui-kit", "@reddb-io/ui-mcp"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
## Summary
- switch Changesets to the local changelog generator so release versioning no longer depends on GitHub GraphQL
- keep the existing pending changeset for the KV collection preview fix to be versioned by the main release workflow

## Validation
- pnpm release:version (dry-run locally, then restored generated release files)
- pnpm --filter @reddb-io/ui test -- collection-preview.test.ts kv-render.test.ts
- pnpm --filter @reddb-io/ui check
- pnpm -r test (pre-commit hook)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785100078&installation_id=129708444&pr_number=112&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F112&signature=bcf3c482fc38aef0bea8255c6ee20d27377f1998353bc78a66d1ed2134f062a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->