### PR TITLE
merge: #114 Remove unused privileged desktop commands (docker_exec, tcp_ping)

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -8,12 +8,6 @@ use tauri_plugin_shell::ShellExt;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
-#[derive(Serialize)]
-struct PingResult {
-    ok: bool,
-    rtt_ms: u128,
-}
-
 #[derive(Deserialize, Serialize)]
 struct ConnectionBootstrap {
     target: Option<String>,
@@ -31,24 +25,6 @@ fn connection_bootstrap() -> Result<Option<ConnectionBootstrap>, String> {
         Err(std::env::VarError::NotPresent) => Ok(None),
         Err(e) => Err(e.to_string()),
     }
-}
-
-#[tauri::command]
-async fn tcp_ping(host: String, port: u16) -> Result<PingResult, String> {
-    let start = std::time::Instant::now();
-    let mut stream = TcpStream::connect((host.as_str(), port))
-        .await
-        .map_err(|e| e.to_string())?;
-    stream
-        .write_all(b"PING\r\n")
-        .await
-        .map_err(|e| e.to_string())?;
-    let mut buf = [0u8; 64];
-    let _ = stream.read(&mut buf).await.map_err(|e| e.to_string())?;
-    Ok(PingResult {
-        ok: true,
-        rtt_ms: start.elapsed().as_millis(),
-    })
 }
 
 // OS keychain bridge for the EncryptedStore (issue #5). Three commands —
@@ -82,21 +58,6 @@ fn keychain_delete(service: String, key: String) -> Result<(), String> {
         Err(keyring::Error::NoEntry) => Ok(()),
         Err(e) => Err(e.to_string()),
     }
-}
-
-#[tauri::command]
-async fn docker_exec(container: String, cmd: Vec<String>) -> Result<String, String> {
-    let output = tokio::process::Command::new("docker")
-        .arg("exec")
-        .arg(&container)
-        .args(&cmd)
-        .output()
-        .await
-        .map_err(|e| e.to_string())?;
-    if !output.status.success() {
-        return Err(String::from_utf8_lossy(&output.stderr).to_string());
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 // Embedded file-backed reddb (the desktop-only "open a .rdb file" capability).
@@ -257,8 +218,6 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             connection_bootstrap,
-            tcp_ping,
-            docker_exec,
             keychain_set,
             keychain_get,
             keychain_delete,


### PR DESCRIPTION
Automated AFK landing for #114. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #114

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785902769&installation_id=129708444&pr_number=131&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F131&signature=a7038f9123f7ecc0f9a780e3399f476edcb69ac3398c8d6e02485d0716e64964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->