### PR TITLE
merge: #115 Structured errors from desktop commands + single frontend error classifier

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -8,6 +8,49 @@ use tauri_plugin_shell::ShellExt;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
+/// Serializable error shape returned by every desktop command (#115). Tauri
+/// serializes an `Err` value to JSON and `invoke` rejects with it, so a
+/// structured `{ code, message, detail? }` lets the frontend classify failures
+/// in one place instead of coercing bare strings. `code` is a stable machine
+/// token; `message` is human-readable; `detail` carries the underlying cause
+/// (an OS/keyring/serde message) when there is one.
+#[derive(Serialize, Debug, Clone, PartialEq)]
+struct CommandError {
+    code: String,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+}
+
+impl CommandError {
+    fn new(code: &str, message: impl Into<String>) -> Self {
+        Self {
+            code: code.to_string(),
+            message: message.into(),
+            detail: None,
+        }
+    }
+
+    fn with_detail(code: &str, message: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self {
+            code: code.to_string(),
+            message: message.into(),
+            detail: Some(detail.into()),
+        }
+    }
+}
+
+/// A poisoned registry mutex is an internal invariant break, not a user error.
+fn lock_err<E: std::fmt::Display>(e: E) -> CommandError {
+    CommandError::with_detail("INTERNAL", "embedded registry lock poisoned", e.to_string())
+}
+
+/// Any keyring failure other than a missing entry (which callers handle as a
+/// normal `None`) maps to a single keychain code with the OS cause attached.
+fn keychain_err(e: keyring::Error) -> CommandError {
+    CommandError::with_detail("KEYCHAIN", "keychain operation failed", e.to_string())
+}
+
 #[derive(Deserialize, Serialize)]
 struct ConnectionBootstrap {
     target: Option<String>,
@@ -16,14 +59,24 @@ struct ConnectionBootstrap {
 }
 
 #[tauri::command]
-fn connection_bootstrap() -> Result<Option<ConnectionBootstrap>, String> {
+fn connection_bootstrap() -> Result<Option<ConnectionBootstrap>, CommandError> {
     match std::env::var("RED_UI_CONNECTION_BOOTSTRAP") {
         Ok(raw) if raw.trim().is_empty() => Ok(None),
         Ok(raw) => serde_json::from_str::<ConnectionBootstrap>(&raw)
             .map(Some)
-            .map_err(|e| e.to_string()),
+            .map_err(|e| {
+                CommandError::with_detail(
+                    "BOOTSTRAP_PARSE",
+                    "failed to parse connection bootstrap payload",
+                    e.to_string(),
+                )
+            }),
         Err(std::env::VarError::NotPresent) => Ok(None),
-        Err(e) => Err(e.to_string()),
+        Err(e) => Err(CommandError::with_detail(
+            "BOOTSTRAP_ENV",
+            "failed to read connection bootstrap environment variable",
+            e.to_string(),
+        )),
     }
 }
 
@@ -35,28 +88,28 @@ fn connection_bootstrap() -> Result<Option<ConnectionBootstrap>, String> {
 // side rather than throwing, matching the WebEncryptedStore contract.
 
 #[tauri::command]
-fn keychain_set(service: String, key: String, value: String) -> Result<(), String> {
-    let entry = keyring::Entry::new(&service, &key).map_err(|e| e.to_string())?;
-    entry.set_password(&value).map_err(|e| e.to_string())
+fn keychain_set(service: String, key: String, value: String) -> Result<(), CommandError> {
+    let entry = keyring::Entry::new(&service, &key).map_err(keychain_err)?;
+    entry.set_password(&value).map_err(keychain_err)
 }
 
 #[tauri::command]
-fn keychain_get(service: String, key: String) -> Result<Option<String>, String> {
-    let entry = keyring::Entry::new(&service, &key).map_err(|e| e.to_string())?;
+fn keychain_get(service: String, key: String) -> Result<Option<String>, CommandError> {
+    let entry = keyring::Entry::new(&service, &key).map_err(keychain_err)?;
     match entry.get_password() {
         Ok(v) => Ok(Some(v)),
         Err(keyring::Error::NoEntry) => Ok(None),
-        Err(e) => Err(e.to_string()),
+        Err(e) => Err(keychain_err(e)),
     }
 }
 
 #[tauri::command]
-fn keychain_delete(service: String, key: String) -> Result<(), String> {
-    let entry = keyring::Entry::new(&service, &key).map_err(|e| e.to_string())?;
+fn keychain_delete(service: String, key: String) -> Result<(), CommandError> {
+    let entry = keyring::Entry::new(&service, &key).map_err(keychain_err)?;
     match entry.delete_credential() {
         Ok(()) => Ok(()),
         Err(keyring::Error::NoEntry) => Ok(()),
-        Err(e) => Err(e.to_string()),
+        Err(e) => Err(keychain_err(e)),
     }
 }
 
@@ -77,10 +130,13 @@ struct EmbeddedRegistry(Mutex<HashMap<String, Embedded>>);
 /// Resolve a user-typed path (from a `file://` URL) to an absolute path. `~`
 /// and relative paths resolve against `$HOME`, so `file://./test.rdb` opens
 /// `~/test.rdb` — a predictable base for a GUI app whose cwd is unspecified.
-fn resolve_embedded_path(input: &str) -> Result<String, String> {
+fn resolve_embedded_path(input: &str) -> Result<String, CommandError> {
     let raw = input.trim();
     let raw = raw.strip_prefix("file://").unwrap_or(raw);
-    let home = || std::env::var("HOME").map_err(|_| "HOME not set".to_string());
+    let home = || {
+        std::env::var("HOME")
+            .map_err(|_| CommandError::new("PATH_RESOLUTION", "HOME environment variable is not set"))
+    };
     let expanded = if let Some(rest) = raw.strip_prefix("~/") {
         format!("{}/{}", home()?, rest)
     } else {
@@ -96,20 +152,25 @@ fn resolve_embedded_path(input: &str) -> Result<String, String> {
 }
 
 /// Grab an ephemeral local port by binding `:0` and reading it back.
-fn free_local_port() -> Result<u16, String> {
+fn free_local_port() -> Result<u16, CommandError> {
     std::net::TcpListener::bind("127.0.0.1:0")
         .and_then(|l| l.local_addr())
         .map(|a| a.port())
-        .map_err(|e| e.to_string())
+        .map_err(|e| {
+            CommandError::with_detail("PORT_UNAVAILABLE", "could not allocate a local port", e.to_string())
+        })
 }
 
 /// Poll `GET /stats` on the embedded server until it answers 200 (it is the
 /// canonical proof-of-life for reddb) or the deadline passes.
-async fn wait_until_ready(bind: &str) -> Result<(), String> {
+async fn wait_until_ready(bind: &str) -> Result<(), CommandError> {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
     loop {
         if std::time::Instant::now() > deadline {
-            return Err("embedded reddb did not become ready within 20s".to_string());
+            return Err(CommandError::new(
+                "EMBEDDED_TIMEOUT",
+                "embedded reddb did not become ready within 20s",
+            ));
         }
         if let Ok(mut stream) = TcpStream::connect(bind).await {
             let req =
@@ -129,7 +190,7 @@ async fn wait_until_ready(bind: &str) -> Result<(), String> {
 
 /// Open (or reuse) an embedded file-backed reddb and return its local HTTP URL.
 #[tauri::command]
-async fn open_embedded(app: tauri::AppHandle, path: String) -> Result<String, String> {
+async fn open_embedded(app: tauri::AppHandle, path: String) -> Result<String, CommandError> {
     let abs = resolve_embedded_path(&path)?;
 
     // Reuse an already-running server for the same file.
@@ -137,7 +198,7 @@ async fn open_embedded(app: tauri::AppHandle, path: String) -> Result<String, St
         .state::<EmbeddedRegistry>()
         .0
         .lock()
-        .map_err(|e| e.to_string())?
+        .map_err(lock_err)?
         .get(&abs)
         .map(|e| e.url.clone())
     {
@@ -165,7 +226,11 @@ async fn open_embedded(app: tauri::AppHandle, path: String) -> Result<String, St
             .env("RED_HTTP_TLS_DEV", "1")
             .spawn()
             .map_err(|e| {
-                format!("failed to spawn `red` (bundled sidecar and PATH both unavailable): {e}")
+                CommandError::with_detail(
+                    "SIDECAR_SPAWN",
+                    "failed to spawn `red` (bundled sidecar and PATH both unavailable)",
+                    e.to_string(),
+                )
             })?,
     };
 
@@ -180,20 +245,20 @@ async fn open_embedded(app: tauri::AppHandle, path: String) -> Result<String, St
     app.state::<EmbeddedRegistry>()
         .0
         .lock()
-        .map_err(|e| e.to_string())?
+        .map_err(lock_err)?
         .insert(abs, Embedded { url: url.clone(), child });
     Ok(url)
 }
 
 /// Stop the embedded server backing `path`, if one is running.
 #[tauri::command]
-fn close_embedded(app: tauri::AppHandle, path: String) -> Result<(), String> {
+fn close_embedded(app: tauri::AppHandle, path: String) -> Result<(), CommandError> {
     let abs = resolve_embedded_path(&path)?;
     if let Some(embedded) = app
         .state::<EmbeddedRegistry>()
         .0
         .lock()
-        .map_err(|e| e.to_string())?
+        .map_err(lock_err)?
         .remove(&abs)
     {
         let _ = embedded.child.kill();
@@ -239,4 +304,54 @@ pub fn run() {
                 }
             }
         });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_error_serializes_without_detail() {
+        let err = CommandError::new("KEYCHAIN", "keychain operation failed");
+        let json = serde_json::to_value(&err).expect("serializable");
+        assert_eq!(json["code"], "KEYCHAIN");
+        assert_eq!(json["message"], "keychain operation failed");
+        // `detail` is skipped entirely when absent, not emitted as null — the
+        // frontend classifier treats a present key as a real cause.
+        assert!(json.get("detail").is_none());
+    }
+
+    #[test]
+    fn command_error_serializes_with_detail() {
+        let err = CommandError::with_detail(
+            "EMBEDDED_TIMEOUT",
+            "embedded reddb did not become ready",
+            "20s elapsed",
+        );
+        let json = serde_json::to_value(&err).expect("serializable");
+        assert_eq!(json["code"], "EMBEDDED_TIMEOUT");
+        assert_eq!(json["message"], "embedded reddb did not become ready");
+        assert_eq!(json["detail"], "20s elapsed");
+    }
+
+    #[test]
+    fn command_error_json_shape_is_stable() {
+        let err = CommandError::new("INTERNAL", "boom");
+        let s = serde_json::to_string(&err).expect("serializable");
+        assert_eq!(s, r#"{"code":"INTERNAL","message":"boom"}"#);
+    }
+
+    #[test]
+    fn keychain_err_maps_no_entry_cause_into_detail() {
+        let err = keychain_err(keyring::Error::NoEntry);
+        assert_eq!(err.code, "KEYCHAIN");
+        assert_eq!(err.message, "keychain operation failed");
+        assert!(err.detail.is_some());
+    }
+
+    #[test]
+    fn resolve_embedded_path_absolute_is_untouched() {
+        let resolved = resolve_embedded_path("file:///tmp/data.rdb").expect("absolute path");
+        assert_eq!(resolved, "/tmp/data.rdb");
+    }
 }

--- a/packages/ui/src/lib/connections.svelte.ts
+++ b/packages/ui/src/lib/connections.svelte.ts
@@ -11,6 +11,7 @@
 import {
   BROWSER_TRANSPORTS,
   DESKTOP_TRANSPORTS,
+  DesktopError,
   EMPTY_SERVER_CAPABILITIES,
   LocalUrlProvider,
   RedClient,
@@ -202,7 +203,14 @@ async function tauriOpenEmbedded(fileUrl: string): Promise<string> {
   }
   const path = fileUrl.replace(/^file:\/\//i, "");
   const { invoke } = await import("@tauri-apps/api/core");
-  return invoke<string>("open_embedded", { path });
+  try {
+    return await invoke<string>("open_embedded", { path });
+  } catch (e) {
+    // The standalone-Surface adapter seam: classify the command's structured
+    // error (or a legacy string/plugin error) in exactly one place, then throw
+    // a plain Error the provider can surface without any further coercion.
+    throw DesktopError.from(e);
+  }
 }
 
 /**

--- a/packages/ui/src/lib/reddb/desktop-error.test.ts
+++ b/packages/ui/src/lib/reddb/desktop-error.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyDesktopError,
+  desktopErrorMessage,
+  isDesktopCommandError,
+  DesktopError,
+  UNKNOWN_DESKTOP_ERROR_CODE,
+} from "./desktop-error";
+
+describe("isDesktopCommandError", () => {
+  it("accepts the structured { code, message } shape", () => {
+    expect(isDesktopCommandError({ code: "KEYCHAIN", message: "boom" })).toBe(
+      true
+    );
+    expect(
+      isDesktopCommandError({ code: "X", message: "m", detail: "d" })
+    ).toBe(true);
+  });
+
+  it("rejects strings, Errors, and partial shapes", () => {
+    expect(isDesktopCommandError("boom")).toBe(false);
+    expect(isDesktopCommandError(new Error("boom"))).toBe(false);
+    expect(isDesktopCommandError({ code: "X" })).toBe(false);
+    expect(isDesktopCommandError({ message: "m" })).toBe(false);
+    expect(isDesktopCommandError({ code: 1, message: 2 })).toBe(false);
+    expect(isDesktopCommandError(null)).toBe(false);
+    expect(isDesktopCommandError(undefined)).toBe(false);
+  });
+});
+
+describe("classifyDesktopError", () => {
+  it("passes a structured command error through", () => {
+    const c = classifyDesktopError({
+      code: "EMBEDDED_TIMEOUT",
+      message: "embedded reddb did not become ready within 20s",
+    });
+    expect(c).toEqual({
+      code: "EMBEDDED_TIMEOUT",
+      message: "embedded reddb did not become ready within 20s",
+    });
+  });
+
+  it("keeps a non-empty detail", () => {
+    const c = classifyDesktopError({
+      code: "SIDECAR_SPAWN",
+      message: "failed to spawn `red`",
+      detail: "No such file",
+    });
+    expect(c).toEqual({
+      code: "SIDECAR_SPAWN",
+      message: "failed to spawn `red`",
+      detail: "No such file",
+    });
+  });
+
+  it("drops an empty detail", () => {
+    const c = classifyDesktopError({ code: "X", message: "m", detail: "" });
+    expect(c.detail).toBeUndefined();
+    expect(c).toEqual({ code: "X", message: "m" });
+  });
+
+  it("classifies a legacy bare string error as UNKNOWN", () => {
+    expect(classifyDesktopError("HOME not set")).toEqual({
+      code: UNKNOWN_DESKTOP_ERROR_CODE,
+      message: "HOME not set",
+    });
+  });
+
+  it("classifies an Error instance as UNKNOWN with its message", () => {
+    expect(classifyDesktopError(new Error("sidecar unavailable"))).toEqual({
+      code: UNKNOWN_DESKTOP_ERROR_CODE,
+      message: "sidecar unavailable",
+    });
+  });
+
+  it("falls back to String() for anything else", () => {
+    expect(classifyDesktopError(42)).toEqual({
+      code: UNKNOWN_DESKTOP_ERROR_CODE,
+      message: "42",
+    });
+    expect(classifyDesktopError(null)).toEqual({
+      code: UNKNOWN_DESKTOP_ERROR_CODE,
+      message: "null",
+    });
+  });
+});
+
+describe("desktopErrorMessage", () => {
+  it("joins message and detail when both present", () => {
+    expect(
+      desktopErrorMessage({
+        code: "PORT_UNAVAILABLE",
+        message: "could not allocate a local port",
+        detail: "Address in use",
+      })
+    ).toBe("could not allocate a local port: Address in use");
+  });
+
+  it("returns the message alone when there is no detail", () => {
+    expect(
+      desktopErrorMessage({ code: "INTERNAL", message: "lock poisoned" })
+    ).toBe("lock poisoned");
+  });
+
+  it("handles legacy string errors", () => {
+    expect(desktopErrorMessage("boom")).toBe("boom");
+  });
+});
+
+describe("DesktopError", () => {
+  it("builds a human-readable Error carrying code and detail", () => {
+    const err = DesktopError.from({
+      code: "SIDECAR_SPAWN",
+      message: "failed to spawn `red`",
+      detail: "No such file",
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("DesktopError");
+    expect(err.code).toBe("SIDECAR_SPAWN");
+    expect(err.detail).toBe("No such file");
+    expect(err.message).toBe("failed to spawn `red`: No such file");
+  });
+
+  it("classifies a legacy string into an UNKNOWN DesktopError", () => {
+    const err = DesktopError.from("Load failed");
+    expect(err.code).toBe(UNKNOWN_DESKTOP_ERROR_CODE);
+    expect(err.message).toBe("Load failed");
+    expect(err.detail).toBeUndefined();
+  });
+
+  it("returns the same instance when given a DesktopError", () => {
+    const original = DesktopError.from("x");
+    expect(DesktopError.from(original)).toBe(original);
+  });
+});

--- a/packages/ui/src/lib/reddb/desktop-error.ts
+++ b/packages/ui/src/lib/reddb/desktop-error.ts
@@ -1,0 +1,89 @@
+// The single classifier for desktop-command failures (#115).
+//
+// Tauri's `invoke` rejects with whatever the Rust `Err` serialized to. Every
+// desktop command now returns a structured `{ code, message, detail? }` shape
+// (see apps/desktop/src-tauri/src/lib.rs), but older builds and Tauri's own
+// plugin/runtime failures can still reject with a bare string or an `Error`.
+// This module is the ONE place that inspects the raw thrown value and
+// normalizes it, so the standalone-Surface adapters never re-implement the
+// `e instanceof Error ? … : String(e)` coercion dance.
+
+/** The serializable error shape returned by Rust desktop commands. */
+export interface DesktopCommandError {
+  /** Stable machine token, e.g. `KEYCHAIN`, `EMBEDDED_TIMEOUT`, `SIDECAR_SPAWN`. */
+  code: string;
+  /** Human-readable summary. */
+  message: string;
+  /** Underlying cause (OS/keyring/serde message) when the command had one. */
+  detail?: string;
+}
+
+/** Code used for legacy string errors and anything not shaped as a command error. */
+export const UNKNOWN_DESKTOP_ERROR_CODE = "UNKNOWN";
+
+/** Type guard for the structured shape a desktop command rejects with. */
+export function isDesktopCommandError(x: unknown): x is DesktopCommandError {
+  return (
+    typeof x === "object" &&
+    x !== null &&
+    typeof (x as DesktopCommandError).code === "string" &&
+    typeof (x as DesktopCommandError).message === "string"
+  );
+}
+
+/**
+ * Normalize any value thrown by a desktop command into a `DesktopCommandError`.
+ * Structured errors pass through (with an empty/absent `detail` dropped); bare
+ * strings, `Error` instances, and everything else collapse to the `UNKNOWN`
+ * code so callers always get a `{ code, message }` pair.
+ */
+export function classifyDesktopError(e: unknown): DesktopCommandError {
+  if (isDesktopCommandError(e)) {
+    const detail = e.detail;
+    return {
+      code: e.code,
+      message: e.message,
+      ...(typeof detail === "string" && detail.length > 0 ? { detail } : {}),
+    };
+  }
+  if (typeof e === "string") {
+    return { code: UNKNOWN_DESKTOP_ERROR_CODE, message: e };
+  }
+  if (e instanceof Error) {
+    return { code: UNKNOWN_DESKTOP_ERROR_CODE, message: e.message || String(e) };
+  }
+  return { code: UNKNOWN_DESKTOP_ERROR_CODE, message: String(e) };
+}
+
+/** Human-readable one-liner for a classified desktop error. */
+export function desktopErrorMessage(e: unknown): string {
+  const c = classifyDesktopError(e);
+  return c.detail ? `${c.message}: ${c.detail}` : c.message;
+}
+
+/**
+ * An `Error` carrying the classified `code`/`detail`, with `message` set to the
+ * human-readable one-liner. Adapters throw this so downstream consumers (e.g.
+ * the connection provider) can read `.message` without any coercion, while
+ * still being able to branch on `.code`.
+ */
+export class DesktopError extends Error {
+  readonly code: string;
+  readonly detail?: string;
+
+  constructor(classified: DesktopCommandError) {
+    super(
+      classified.detail
+        ? `${classified.message}: ${classified.detail}`
+        : classified.message
+    );
+    this.name = "DesktopError";
+    this.code = classified.code;
+    this.detail = classified.detail;
+  }
+
+  /** Classify a raw thrown value and wrap it. */
+  static from(e: unknown): DesktopError {
+    return e instanceof DesktopError ? e : new DesktopError(classifyDesktopError(e));
+  }
+}

--- a/packages/ui/src/lib/reddb/index.ts
+++ b/packages/ui/src/lib/reddb/index.ts
@@ -15,3 +15,4 @@ export * from "./cdc-stream-client";
 export * from "./secure-store";
 export * from "./web-encrypted-store";
 export * from "./tauri-encrypted-store";
+export * from "./desktop-error";

--- a/packages/ui/src/lib/reddb/local-url-provider.ts
+++ b/packages/ui/src/lib/reddb/local-url-provider.ts
@@ -181,14 +181,10 @@ export class LocalUrlProvider implements ConnectionProvider {
       try {
         clientUrl = await this.embeddedResolver(target.url);
       } catch (e) {
-        // Tauri's `invoke` rejects with a plain string (the Rust `Err`), not an
-        // Error — so read the message defensively instead of assuming `.message`.
-        const reason =
-          e instanceof Error
-            ? e.message
-            : typeof e === "string"
-              ? e
-              : String(e);
+        // The resolver (the standalone-Surface adapter) already classified the
+        // command failure into an Error with a human-readable message — no
+        // defensive shape-coercion here; just carry the reason through.
+        const reason = e instanceof Error ? e.message : String(e);
         throw new UnreachableConnectionError(target.id, reason);
       }
     }

--- a/packages/ui/src/lib/reddb/tauri-encrypted-store.ts
+++ b/packages/ui/src/lib/reddb/tauri-encrypted-store.ts
@@ -1,4 +1,5 @@
 import { type EncryptedStore, SecureStoreError } from './secure-store'
+import { desktopErrorMessage } from './desktop-error'
 
 export type TauriInvoke = <T = unknown>(cmd: string, args?: Record<string, unknown>) => Promise<T>
 
@@ -35,7 +36,7 @@ export class TauriEncryptedStore implements EncryptedStore {
     try {
       await this.invoke<void>('keychain_set', { service: this.service, key, value })
     } catch (e) {
-      throw new SecureStoreError('BACKEND_FAILURE', `keychain_set failed: ${stringifyError(e)}`)
+      throw new SecureStoreError('BACKEND_FAILURE', `keychain_set failed: ${desktopErrorMessage(e)}`)
     }
   }
 
@@ -44,7 +45,7 @@ export class TauriEncryptedStore implements EncryptedStore {
       const v = await this.invoke<string | null>('keychain_get', { service: this.service, key })
       return v ?? null
     } catch (e) {
-      throw new SecureStoreError('BACKEND_FAILURE', `keychain_get failed: ${stringifyError(e)}`)
+      throw new SecureStoreError('BACKEND_FAILURE', `keychain_get failed: ${desktopErrorMessage(e)}`)
     }
   }
 
@@ -52,13 +53,7 @@ export class TauriEncryptedStore implements EncryptedStore {
     try {
       await this.invoke<void>('keychain_delete', { service: this.service, key })
     } catch (e) {
-      throw new SecureStoreError('BACKEND_FAILURE', `keychain_delete failed: ${stringifyError(e)}`)
+      throw new SecureStoreError('BACKEND_FAILURE', `keychain_delete failed: ${desktopErrorMessage(e)}`)
     }
   }
-}
-
-function stringifyError(e: unknown): string {
-  if (e instanceof Error) return e.message
-  if (typeof e === 'string') return e
-  try { return JSON.stringify(e) } catch { return String(e) }
 }


### PR DESCRIPTION
Automated AFK landing for #115. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #115

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785903711&installation_id=129708444&pr_number=132&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F132&signature=9e7b4827a4097b96a8d228b0ebbee81f6411eb13439f8c099249b8923edcc5af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->