### PR TITLE
merge: #126 Black-screen shield: error boundary around the Workspace

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -81,6 +81,7 @@
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@tailwindcss/vite": "^4.3.0",
     "@types/node": "^25.9.1",
+    "happy-dom": "^20.10.6",
     "svelte": "^5.20.0",
     "svelte-check": "^4.1.4",
     "tailwindcss": "^4.3.0",

--- a/packages/ui/src/lib/ErrorBoundary.fixture.svelte
+++ b/packages/ui/src/lib/ErrorBoundary.fixture.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  // Test-only harness: wraps the crash child in the real ErrorBoundary exactly
+  // as the Workspace root does, so the regression test exercises the shipped
+  // boundary rather than a stand-in.
+  import ErrorBoundary from './ErrorBoundary.svelte'
+  import CrashChild from './ErrorBoundaryCrashChild.fixture.svelte'
+</script>
+
+<ErrorBoundary>
+  <CrashChild />
+</ErrorBoundary>

--- a/packages/ui/src/lib/ErrorBoundary.fixtures.svelte.ts
+++ b/packages/ui/src/lib/ErrorBoundary.fixtures.svelte.ts
@@ -1,0 +1,5 @@
+// Test-only reactive control for the ErrorBoundary regression test. Kept in a
+// `.svelte.ts` module so the `$state` rune is compiled. The crash child reads
+// `crashCtrl.crash` at (re)creation time, so flipping it before a boundary
+// reset models a transient fault that has since cleared.
+export const crashCtrl = $state({ crash: true, message: 'render-crash-test' })

--- a/packages/ui/src/lib/ErrorBoundary.svelte
+++ b/packages/ui/src/lib/ErrorBoundary.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  // Black-screen shield (#126). A render crash inside the Workspace used to
+  // tear down the whole webview and leave a black window with no way back.
+  // This wraps its children in a Svelte error boundary whose `failed` state
+  // shows the message, the stack, and two recovery actions:
+  //   - Retry render: re-runs the boundary's children (`reset`). Recovers when
+  //     the fault was transient — the offending state has since changed.
+  //   - Reload window: hard-reloads the document. Always works, even when the
+  //     fault reproduces on every render.
+  // Styling stays on the dark tokens and keeps a single accent (the primary
+  // Retry action), per the one-accent discipline.
+  import type { Snippet } from 'svelte'
+  import { RotateCw, RefreshCw } from 'lucide-svelte'
+
+  let { children }: { children: Snippet } = $props()
+
+  function reloadWindow() {
+    if (typeof window !== 'undefined') window.location.reload()
+  }
+
+  function messageOf(error: unknown): string {
+    if (error instanceof Error) return error.message || error.name
+    return String(error)
+  }
+
+  function stackOf(error: unknown): string | null {
+    return error instanceof Error && error.stack ? error.stack : null
+  }
+</script>
+
+<svelte:boundary>
+  {@render children()}
+
+  {#snippet failed(error, reset)}
+    <div
+      role="alert"
+      class="flex h-full w-full flex-col items-center justify-center gap-5 overflow-auto bg-bg-0 px-6 py-10 text-center"
+    >
+      <div class="flex flex-col items-center gap-2">
+        <RotateCw class="size-8 text-fg-3" strokeWidth={1.4} />
+        <h1 class="type-h2 m-0 text-fg-0">Something crashed while rendering</h1>
+        <p class="m-0 max-w-lg text-[13px] leading-relaxed text-fg-2">
+          The workspace hit an unexpected error. Your connection is untouched —
+          retry the render, or reload the window to start clean.
+        </p>
+      </div>
+
+      <p class="m-0 max-w-lg break-words font-mono text-[12px] text-accent">
+        {messageOf(error)}
+      </p>
+
+      {#if stackOf(error)}
+        <pre
+          class="m-0 max-h-52 w-full max-w-2xl overflow-auto rounded-lg border border-line-1 bg-bg-1 p-3 text-left font-mono text-[11px] leading-relaxed text-fg-3"
+        >{stackOf(error)}</pre>
+      {/if}
+
+      <div class="flex items-center gap-2">
+        <button
+          type="button"
+          onclick={reset}
+          class="inline-flex h-9 items-center gap-1.5 rounded-lg bg-accent px-3 text-[12px] font-medium text-white hover:bg-accent/90"
+        >
+          <RotateCw class="size-3.5" strokeWidth={2} />
+          Retry render
+        </button>
+        <button
+          type="button"
+          onclick={reloadWindow}
+          class="inline-flex h-9 items-center gap-1.5 rounded-lg border border-line-1 bg-bg-1 px-3 text-[12px] font-medium text-fg-1 hover:bg-bg-2"
+        >
+          <RefreshCw class="size-3.5" strokeWidth={2} />
+          Reload window
+        </button>
+      </div>
+    </div>
+  {/snippet}
+</svelte:boundary>

--- a/packages/ui/src/lib/ErrorBoundary.svelte.test.ts
+++ b/packages/ui/src/lib/ErrorBoundary.svelte.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import { flushSync, mount, unmount } from 'svelte'
+import Fixture from './ErrorBoundary.fixture.svelte'
+import { crashCtrl } from './ErrorBoundary.fixtures.svelte'
+
+// Locks the black-screen shield (#126): a throwing child must surface the
+// recovery UI, retry-render must recover a transient fault, and reload-window
+// must always fire.
+
+afterEach(() => {
+  crashCtrl.crash = true
+  crashCtrl.message = 'render-crash-test'
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+})
+
+function render() {
+  const target = document.createElement('div')
+  document.body.appendChild(target)
+  const component = mount(Fixture, { target })
+  flushSync()
+  return { target, component }
+}
+
+test('a throwing child renders the failure screen, not a black webview', () => {
+  crashCtrl.crash = true
+  const { target, component } = render()
+
+  const alert = target.querySelector('[role="alert"]')
+  expect(alert, 'failure screen should be shown').not.toBeNull()
+  // The crash message and stack are surfaced for the operator.
+  expect(target.textContent).toContain('render-crash-test')
+  expect(target.querySelector('pre'), 'stack trace should be shown').not.toBeNull()
+  // The child never mounted — the boundary contained the fault.
+  expect(target.querySelector('[data-testid="child-alive"]')).toBeNull()
+  // Both recovery actions are present.
+  expect(target.textContent).toContain('Retry render')
+  expect(target.textContent).toContain('Reload window')
+
+  unmount(component)
+})
+
+test('retry-render recovers once the transient fault clears', () => {
+  crashCtrl.crash = true
+  const { target, component } = render()
+  expect(target.querySelector('[role="alert"]')).not.toBeNull()
+
+  // The underlying fault is gone; retrying the render should recover.
+  crashCtrl.crash = false
+  const retry = [...target.querySelectorAll('button')].find((b) =>
+    b.textContent?.includes('Retry render'),
+  )
+  expect(retry, 'retry button should exist').toBeTruthy()
+  retry!.click()
+  flushSync()
+
+  expect(target.querySelector('[data-testid="child-alive"]'), 'child should recover').not.toBeNull()
+  expect(target.querySelector('[role="alert"]'), 'failure screen should be gone').toBeNull()
+
+  unmount(component)
+})
+
+test('retry-render stays on the failure screen while the fault persists', () => {
+  crashCtrl.crash = true
+  const { target, component } = render()
+
+  // Fault still reproduces — retrying re-throws and the shield holds.
+  const retry = [...target.querySelectorAll('button')].find((b) =>
+    b.textContent?.includes('Retry render'),
+  )
+  retry!.click()
+  flushSync()
+
+  expect(target.querySelector('[role="alert"]'), 'failure screen should persist').not.toBeNull()
+  expect(target.querySelector('[data-testid="child-alive"]')).toBeNull()
+
+  unmount(component)
+})
+
+test('reload-window always fires a hard reload', () => {
+  crashCtrl.crash = true
+  const { target, component } = render()
+
+  const reloadSpy = vi.fn()
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...window.location, reload: reloadSpy },
+  })
+
+  const reload = [...target.querySelectorAll('button')].find((b) =>
+    b.textContent?.includes('Reload window'),
+  )
+  expect(reload, 'reload button should exist').toBeTruthy()
+  reload!.click()
+  flushSync()
+
+  expect(reloadSpy).toHaveBeenCalledOnce()
+
+  unmount(component)
+})

--- a/packages/ui/src/lib/ErrorBoundaryCrashChild.fixture.svelte
+++ b/packages/ui/src/lib/ErrorBoundaryCrashChild.fixture.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  // Test-only child that throws during render when `crashCtrl.crash` is set,
+  // reproducing a component regression that would otherwise black out the
+  // webview. On a boundary reset it is recreated and re-reads the flag.
+  import { crashCtrl } from './ErrorBoundary.fixtures.svelte'
+  if (crashCtrl.crash) throw new Error(crashCtrl.message)
+</script>
+
+<div data-testid="child-alive">child rendered</div>

--- a/packages/ui/src/lib/embed/RedUiEmbedRoot.svelte
+++ b/packages/ui/src/lib/embed/RedUiEmbedRoot.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { BitsConfig } from 'bits-ui'
   import Workspace from '../Workspace.svelte'
+  import ErrorBoundary from '../ErrorBoundary.svelte'
   import type { ConnectionProvider } from '../reddb'
   import type { Theme } from '../theme.svelte'
 
@@ -20,12 +21,16 @@
 </script>
 
 <BitsConfig defaultPortalTo={portalTarget}>
-  <Workspace
-    {connectionProvider}
-    {initialRoute}
-    showConnect={false}
-    themeTarget={shadowHost}
-    persistTheme={false}
-    {initialTheme}
-  />
+  <!-- Black-screen shield (#126): keep an embed render crash inside the boundary
+       rather than blanking the host's mount point. -->
+  <ErrorBoundary>
+    <Workspace
+      {connectionProvider}
+      {initialRoute}
+      showConnect={false}
+      themeTarget={shadowHost}
+      persistTheme={false}
+      {initialTheme}
+    />
+  </ErrorBoundary>
 </BitsConfig>

--- a/packages/ui/src/routes/+layout.svelte
+++ b/packages/ui/src/routes/+layout.svelte
@@ -9,6 +9,7 @@
   import { page } from '$app/state'
   import '../app.css'
   import Workspace from '$lib/Workspace.svelte'
+  import ErrorBoundary from '$lib/ErrorBoundary.svelte'
   import { createKitRouter } from './kit-router.svelte'
 
   let { children }: { children: Snippet } = $props()
@@ -23,5 +24,9 @@
 {#if renderRouteContent}
   {@render children()}
 {:else}
-  <Workspace {router} />
+  <!-- Black-screen shield (#126): a render crash in the Workspace shows the
+       recovery screen instead of tearing down the webview to black. -->
+  <ErrorBoundary>
+    <Workspace {router} />
+  </ErrorBoundary>
 {/if}

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -2,10 +2,12 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { defineConfig } from "vitest/config";
 import { resolve } from "node:path";
 
-// Vitest-only config — avoids the SvelteKit plugin (which boots routing
-// machinery we don't need for unit tests). The svelte plugin is here so
-// that `.svelte.ts` files using runes (`$state`, `$derived`) are
-// preprocessed correctly.
+// Shared base for the vitest workspace (see vitest.workspace.ts). Avoids the
+// SvelteKit plugin (which boots routing machinery we don't need for unit
+// tests). The svelte plugin is here so that `.svelte.ts` files using runes
+// (`$state`, `$derived`) are preprocessed correctly. Per-project `test`
+// settings (environment, include, resolve conditions) live in the workspace
+// so the browser-only condition never leaks onto the node/SSR suite.
 export default defineConfig({
   plugins: [svelte({ hot: false })],
   resolve: {
@@ -16,9 +18,5 @@ export default defineConfig({
       $lib: resolve(__dirname, "src/lib"),
       "@reddb-io/ui-kit": resolve(__dirname, "../ui-kit/src/lib/index.ts"),
     },
-  },
-  test: {
-    environment: "node",
-    include: ["src/**/*.test.ts"],
   },
 });

--- a/packages/ui/vitest.workspace.ts
+++ b/packages/ui/vitest.workspace.ts
@@ -1,0 +1,31 @@
+import { defineWorkspace } from "vitest/config";
+
+// Two projects share one base config (vitest.config.ts):
+//   - node:    the default logic/SSR suite. Renders components with
+//              `svelte/server` to a string; must NOT resolve Svelte's browser
+//              entry or the server renderer trips over `document`.
+//   - browser: component tests that `mount()` into a real DOM (happy-dom) to
+//              exercise interaction — e.g. the ErrorBoundary shield (#126).
+//              These need Svelte's browser entry via `resolve.conditions`.
+// The split keeps the browser-only condition off the node suite, which would
+// otherwise break the `svelte/server` render tests.
+export default defineWorkspace([
+  {
+    extends: "./vitest.config.ts",
+    test: {
+      name: "node",
+      environment: "node",
+      include: ["src/**/*.test.ts"],
+      exclude: ["src/**/*.svelte.test.ts"],
+    },
+  },
+  {
+    extends: "./vitest.config.ts",
+    resolve: { conditions: ["browser"] },
+    test: {
+      name: "browser",
+      environment: "happy-dom",
+      include: ["src/**/*.svelte.test.ts"],
+    },
+  },
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
+      happy-dom:
+        specifier: ^20.10.6
+        version: 20.10.6
       svelte:
         specifier: ^5.20.0
         version: 5.55.9
@@ -181,7 +184,7 @@ importers:
         version: 6.4.2(@types/node@25.9.1)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@25.9.1)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@25.9.1)(happy-dom@20.10.6)(lightningcss@1.32.0)
 
   packages/ui-kit:
     dependencies:
@@ -1452,6 +1455,12 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
@@ -1591,6 +1600,10 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1909,6 +1922,10 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -2138,6 +2155,10 @@ packages:
 
   guid-typescript@1.0.9:
     resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
+
+  happy-dom@20.10.6:
+    resolution: {integrity: sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==}
+    engines: {node: '>=20.0.0'}
 
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
@@ -3176,6 +3197,10 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
@@ -3199,6 +3224,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -4207,6 +4244,12 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.9.1
+
   '@vitest/expect@2.1.9':
     dependencies:
       '@vitest/spy': 2.1.9
@@ -4358,6 +4401,10 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 25.9.1
 
   bytes@3.1.2: {}
 
@@ -4642,6 +4689,8 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  entities@7.0.1: {}
 
   environment@1.1.0: {}
 
@@ -4960,6 +5009,19 @@ snapshots:
       graphology-types: 0.24.8
 
   guid-typescript@1.0.9: {}
+
+  happy-dom@20.10.6:
+    dependencies:
+      '@types/node': 25.9.1
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-property-descriptors@1.0.2:
     dependencies:
@@ -5960,7 +6022,7 @@ snapshots:
     optionalDependencies:
       vite: 6.4.2(@types/node@25.9.1)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
 
-  vitest@2.1.9(@types/node@25.9.1)(lightningcss@1.32.0):
+  vitest@2.1.9(@types/node@25.9.1)(happy-dom@20.10.6)(lightningcss@1.32.0):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.9.1)(lightningcss@1.32.0))
@@ -5984,6 +6046,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.1
+      happy-dom: 20.10.6
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -5996,6 +6059,8 @@ snapshots:
       - terser
 
   webidl-conversions@3.0.1: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-url@5.0.0:
     dependencies:
@@ -6024,6 +6089,8 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
+
+  ws@8.21.0: {}
 
   yaml@2.9.0:
     optional: true


### PR DESCRIPTION
Automated AFK landing for #126. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #126

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785909677&installation_id=129708444&pr_number=135&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F135&signature=56beab8781c93e440a0304d2ab898f4cc3874119c57a1b955a801eb807e95592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->