### PR TITLE
merge: #127 Step-logged loading overlay for connect and boot

### DIFF
--- a/packages/ui/src/lib/LoadingOverlay.svelte
+++ b/packages/ui/src/lib/LoadingOverlay.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  // Step-logged loading overlay (#127). While a connection open is in flight it
+  // shows an elapsed badge and a scrolling log of the real steps the connect
+  // sequence appended (spawn, readiness, handshake, initial stats/schema). A
+  // stalled step reads as stalled — the last (active) step stays on screen and
+  // its elapsed keeps counting. Live-or-empty: it renders only real steps from
+  // the `loading` store, never fabricated progress.
+  //
+  // Flash guard: fast opens never paint the overlay. We only reveal after
+  // `revealAfterMs` of continuous loading; an open that finishes under the
+  // threshold clears the store before the reveal timer fires, so nothing shows.
+  import { loading as defaultStore, formatElapsed, type LoadingStep } from './loading.svelte'
+
+  let {
+    store = defaultStore,
+    revealAfterMs = 400,
+  }: {
+    store?: typeof defaultStore
+    revealAfterMs?: number
+  } = $props()
+
+  let revealed = $state(false)
+  let now = $state(0)
+
+  // Drive the reveal threshold and the ticking elapsed badge off the store's
+  // active flag. Both timers are torn down the instant the open finishes, so a
+  // sub-threshold open never flips `revealed` true.
+  $effect(() => {
+    if (!store.active) {
+      revealed = false
+      return
+    }
+    now = Date.now()
+    const reveal = setTimeout(() => (revealed = true), revealAfterMs)
+    const tick = setInterval(() => (now = Date.now()), 100)
+    return () => {
+      clearTimeout(reveal)
+      clearInterval(tick)
+    }
+  })
+
+  const elapsed = $derived(store.active ? store.elapsedMs(now) : 0)
+
+  function stepElapsed(step: LoadingStep): number {
+    if (step.durationMs !== null) return step.durationMs
+    return Math.max(0, now - step.startedAt)
+  }
+</script>
+
+{#if store.active && revealed}
+  <div
+    class="fixed inset-0 z-[9998] grid place-items-center bg-bg-0/85 backdrop-blur-sm"
+    role="status"
+    aria-live="polite"
+    aria-busy="true"
+    data-testid="loading-overlay"
+  >
+    <div class="w-[min(460px,90vw)] rounded-lg border border-line-2 bg-bg-1 p-5 shadow-2xl">
+      <div class="flex items-center justify-between gap-3">
+        <div class="flex items-center gap-2 min-w-0">
+          <span
+            class="h-2 w-2 shrink-0 animate-pulse rounded-full bg-accent shadow-[0_0_12px_var(--color-accent-glow)] motion-reduce:animate-none"
+          ></span>
+          <span class="truncate font-mono text-[13px] font-semibold text-fg-0">
+            {store.label ?? 'Opening connection'}
+          </span>
+        </div>
+        <span
+          class="shrink-0 rounded bg-bg-2 px-1.5 py-0.5 font-mono text-[12px] tabular-nums text-fg-2"
+          data-testid="loading-elapsed"
+        >
+          {formatElapsed(elapsed)}
+        </span>
+      </div>
+
+      <ol class="mt-4 max-h-[220px] space-y-1.5 overflow-y-auto" data-testid="loading-steps">
+        {#each store.steps as step (step.id)}
+          <li class="flex items-start gap-2 font-mono text-[12px]" data-testid="loading-step">
+            <span
+              class="mt-[3px] h-1.5 w-1.5 shrink-0 rounded-full"
+              class:bg-accent={step.status === 'active'}
+              class:animate-pulse={step.status === 'active'}
+              class:motion-reduce:animate-none={step.status === 'active'}
+              class:bg-ok={step.status === 'done'}
+              class:bg-danger={step.status === 'error'}
+              aria-hidden="true"
+            ></span>
+            <span class="min-w-0 flex-1">
+              <span
+                class="text-fg-1"
+                class:text-fg-0={step.status === 'active'}
+                class:text-danger={step.status === 'error'}
+              >{step.label}</span>
+              {#if step.detail}
+                <span class="ml-1 text-fg-3">{step.detail}</span>
+              {/if}
+              {#if step.error}
+                <span class="ml-1 text-danger">— {step.error}</span>
+              {/if}
+            </span>
+            <span class="shrink-0 tabular-nums text-fg-3" data-testid="loading-step-elapsed">
+              {formatElapsed(stepElapsed(step))}
+            </span>
+          </li>
+        {/each}
+      </ol>
+    </div>
+  </div>
+{/if}

--- a/packages/ui/src/lib/LoadingOverlay.svelte.test.ts
+++ b/packages/ui/src/lib/LoadingOverlay.svelte.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+import { flushSync, mount, unmount } from 'svelte'
+import LoadingOverlay from './LoadingOverlay.svelte'
+import { loading } from './loading.svelte'
+
+// Locks the step-logged loading overlay (#127): real steps render with their
+// elapsed time, a stalled step stays on screen and keeps counting, and a fast
+// open below the reveal threshold never flashes the overlay.
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(0)
+})
+
+afterEach(() => {
+  // Clear the singleton between tests so a leftover open can't bleed across.
+  loading.succeed(0)
+  document.body.innerHTML = ''
+  vi.useRealTimers()
+})
+
+function render(props: Record<string, unknown> = {}) {
+  const target = document.createElement('div')
+  document.body.appendChild(target)
+  const component = mount(LoadingOverlay, { target, props })
+  flushSync()
+  return { target, component }
+}
+
+test('renders the real, timestamped step log once the reveal threshold passes', () => {
+  loading.begin('Opening Docker primary', 0)
+  loading.step('Reaching server', 'http://localhost:15055', 0)
+
+  const { target, component } = render({ revealAfterMs: 400 })
+
+  // Below the threshold nothing is painted — the flash guard holds.
+  expect(target.querySelector('[data-testid="loading-overlay"]')).toBeNull()
+
+  // A second real step lands while still connecting.
+  loading.step('Fetching stats & capabilities', undefined, 200)
+
+  vi.advanceTimersByTime(400)
+  flushSync()
+
+  expect(target.querySelector('[data-testid="loading-overlay"]')).not.toBeNull()
+
+  const steps = target.querySelectorAll('[data-testid="loading-step"]')
+  expect(steps.length).toBe(2)
+  expect(target.textContent).toContain('Reaching server')
+  expect(target.textContent).toContain('http://localhost:15055')
+  expect(target.textContent).toContain('Fetching stats & capabilities')
+
+  // Headline and a ticking elapsed badge are shown.
+  expect(target.textContent).toContain('Opening Docker primary')
+  const elapsed = target.querySelector('[data-testid="loading-elapsed"]')
+  expect(elapsed?.textContent).toContain('0.4s')
+
+  // Every step carries its own elapsed time.
+  const stepTimes = target.querySelectorAll('[data-testid="loading-step-elapsed"]')
+  expect(stepTimes.length).toBe(2)
+  expect(stepTimes[0]?.textContent).toContain('s')
+
+  unmount(component)
+})
+
+test('does not flash the overlay for a fast open below the threshold', () => {
+  loading.begin('Opening Embedded', 0)
+  loading.step('Reaching server', undefined, 0)
+
+  const { target, component } = render({ revealAfterMs: 400 })
+
+  // The open resolves quickly, before the reveal timer would fire.
+  vi.advanceTimersByTime(120)
+  loading.succeed(120)
+  flushSync()
+
+  // Advancing past the old threshold must not resurrect the overlay.
+  vi.advanceTimersByTime(400)
+  flushSync()
+
+  expect(target.querySelector('[data-testid="loading-overlay"]')).toBeNull()
+
+  unmount(component)
+})
+
+test('keeps a stalled step on screen with a growing elapsed time', () => {
+  loading.begin('Opening remote cluster', 0)
+  loading.step('Reaching server', undefined, 0)
+
+  const { target, component } = render({ revealAfterMs: 100 })
+
+  vi.advanceTimersByTime(100)
+  flushSync()
+
+  expect(target.querySelector('[data-testid="loading-overlay"]')).not.toBeNull()
+  const firstElapsed = target.querySelector('[data-testid="loading-elapsed"]')?.textContent
+
+  // No further steps arrive — the step has stalled. Elapsed keeps ticking and
+  // the stalled step stays the one on screen.
+  vi.advanceTimersByTime(2000)
+  flushSync()
+
+  const laterElapsed = target.querySelector('[data-testid="loading-elapsed"]')?.textContent
+  expect(laterElapsed).not.toBe(firstElapsed)
+  expect(laterElapsed).toContain('2.1s')
+  expect(target.querySelectorAll('[data-testid="loading-step"]').length).toBe(1)
+  expect(target.textContent).toContain('Reaching server')
+
+  unmount(component)
+})

--- a/packages/ui/src/lib/Workspace.svelte
+++ b/packages/ui/src/lib/Workspace.svelte
@@ -6,6 +6,7 @@
   // The SvelteKit Surface wraps this same component with a Kit-backed router.
   import { onMount, untrack } from 'svelte'
   import Splash from './Splash.svelte'
+  import LoadingOverlay from './LoadingOverlay.svelte'
   import GlobalProgressBar from './GlobalProgressBar.svelte'
   import Topbar from './Topbar.svelte'
   import StatusBar from './StatusBar.svelte'
@@ -309,3 +310,8 @@
     <PendingChangesPanel open={pendingOpen} onClose={() => (pendingOpen = false)} />
   </div>
 {/if}
+
+<!-- Step-logged loading overlay (#127): sits above the shell during a slow
+     connect/boot; self-hides once the open resolves and never flashes on fast
+     opens. -->
+<LoadingOverlay />

--- a/packages/ui/src/lib/connections.svelte.ts
+++ b/packages/ui/src/lib/connections.svelte.ts
@@ -36,6 +36,7 @@ import {
 } from "./connection-history";
 import { secureStore } from "./secureStore.svelte";
 import { activity } from "./activity.svelte";
+import { loading } from "./loading.svelte";
 
 export type { HistoryEntry } from "./connection-history";
 
@@ -448,7 +449,13 @@ class ConnectionStore {
     // An explicit connect attempt means a target has been chosen — unblocks
     // automatic refresh from here on (#21).
     this.#targetResolved = true;
+    // Step-logged loading (#127): the connect sequence appends real,
+    // timestamped steps so a slow open (sidecar spawn, readiness, handshake,
+    // initial stats/schema fetch) shows honest feedback instead of a frozen
+    // screen. Fast opens finish before the overlay's reveal threshold.
+    loading.begin(`Opening ${preset.label}`);
     try {
+      loading.step("Reaching server", preset.url);
       const active = await activity.track(`connect · ${preset.label}`, () =>
         getConnectionProvider().connect(preset.id)
       );
@@ -459,6 +466,7 @@ class ConnectionStore {
         description: preset.description,
       };
       persist(this.active);
+      loading.step("Fetching stats & capabilities");
       const [stats, replication, capabilities] = await Promise.all([
         activity
           .track(`connect · ${preset.label} stats`, () => active.client.stats())
@@ -483,9 +491,11 @@ class ConnectionStore {
       };
       this.#capabilities = capabilities;
       this.connected = true;
+      loading.succeed();
       return true;
     } catch (e) {
       this.probe = { reachable: false, error: (e as Error).message };
+      loading.fail((e as Error).message);
       return false;
     }
   }

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -9,6 +9,13 @@ export { default as ConnectDropdown } from "./ConnectDropdown.svelte";
 export { default as EmptyState } from "./EmptyState.svelte";
 export { default as GlobalProgressBar } from "./GlobalProgressBar.svelte";
 export { default as LiveChanges } from "./LiveChanges.svelte";
+export { default as LoadingOverlay } from "./LoadingOverlay.svelte";
+export {
+  loading,
+  formatElapsed,
+  type LoadingStep,
+  type LoadingStepStatus,
+} from "./loading.svelte";
 export { default as MasterPasswordDialog } from "./MasterPasswordDialog.svelte";
 export { default as PageHeader } from "./PageHeader.svelte";
 export { default as PendingChangesPanel } from "./PendingChangesPanel.svelte";

--- a/packages/ui/src/lib/loading.svelte.ts
+++ b/packages/ui/src/lib/loading.svelte.ts
@@ -1,0 +1,142 @@
+// Connect/boot loading model (#127). Slow opens (sidecar spawn, readiness,
+// handshake, initial schema/stats fetch) get real, timestamped feedback: a
+// started-at, an ordered log of steps (each with a label, optional detail, and
+// its own start time + outcome), and a "current" step that stays on screen —
+// with its elapsed time — while it's still running (a stalled step reads AS
+// stalled). Live-or-empty applies: steps are appended by the actual connect
+// sequence, never synthesized to fake progress.
+//
+// `$state` is compiled here (`.svelte.ts`), so the model is reactive and the
+// overlay re-renders as steps land. Writes are wrapped in `untrack()` because
+// the connect sequence commonly runs from inside a Svelte `$effect` (the
+// layout's auto-refresh); an untracked write keeps our own mutations from
+// re-firing that effect.
+
+import { untrack } from "svelte";
+
+export type LoadingStepStatus = "active" | "done" | "error";
+
+export interface LoadingStep {
+  id: number;
+  label: string;
+  detail?: string;
+  /** Absolute wall-clock time the step was appended. */
+  startedAt: number;
+  /** Wall-clock duration once the step resolves; null while still active. */
+  durationMs: number | null;
+  status: LoadingStepStatus;
+  error?: string;
+}
+
+/**
+ * Format a millisecond elapsed value for the overlay badge and per-step timing.
+ * Sub-second reads as fractional seconds ("0.4s"); longer as one-decimal
+ * seconds ("12.3s"). Kept pure so the render is unit-testable without a clock.
+ */
+export function formatElapsed(ms: number): string {
+  const clamped = Math.max(0, ms);
+  return `${(clamped / 1000).toFixed(1)}s`;
+}
+
+class LoadingStore {
+  /** Wall-clock time the current open began; null when nothing is opening. */
+  startedAt = $state<number | null>(null);
+  /** Headline for what's being opened, e.g. "Opening Docker primary". */
+  label = $state<string | null>(null);
+  /** Ordered, timestamped step log for the current open. */
+  steps = $state<LoadingStep[]>([]);
+  private nextId = 1;
+
+  /** True while an open is in progress. Gates the overlay. */
+  get active(): boolean {
+    return this.startedAt !== null;
+  }
+
+  /** The step currently on screen — the last appended one, if any. */
+  get current(): LoadingStep | null {
+    return this.steps.length ? this.steps[this.steps.length - 1] : null;
+  }
+
+  /** Elapsed time since the open began, for the ticking badge. */
+  elapsedMs(now = Date.now()): number {
+    return this.startedAt === null ? 0 : Math.max(0, now - this.startedAt);
+  }
+
+  /**
+   * Begin a fresh open. Resets the log and stamps the start. Any subsequent
+   * `step()` calls append to this open until `succeed`/`fail` finishes it.
+   */
+  begin(label: string, now = Date.now()): void {
+    untrack(() => {
+      this.startedAt = now;
+      this.label = label;
+      this.steps = [];
+      this.nextId = 1;
+    });
+  }
+
+  /**
+   * Append a step and mark it the current (active) one, closing out the
+   * previous active step as done. No-op if no open is in progress — steps are
+   * only ever real work inside an open.
+   */
+  step(label: string, detail?: string, now = Date.now()): void {
+    untrack(() => {
+      if (this.startedAt === null) return;
+      const closed = this.steps.map((s) =>
+        s.status === "active"
+          ? { ...s, status: "done" as const, durationMs: now - s.startedAt }
+          : s
+      );
+      this.steps = [
+        ...closed,
+        {
+          id: this.nextId++,
+          label,
+          ...(detail ? { detail } : {}),
+          startedAt: now,
+          durationMs: null,
+          status: "active",
+        },
+      ];
+    });
+  }
+
+  /** Finish the open successfully: close the active step and hide the overlay. */
+  succeed(now = Date.now()): void {
+    untrack(() => {
+      this.#closeActive(now);
+      this.startedAt = null;
+    });
+  }
+
+  /**
+   * Finish the open with a failure: mark the active step errored and hide the
+   * overlay (the Connect flow surfaces the error separately).
+   */
+  fail(error?: string, now = Date.now()): void {
+    untrack(() => {
+      this.steps = this.steps.map((s) =>
+        s.status === "active"
+          ? {
+              ...s,
+              status: "error" as const,
+              durationMs: now - s.startedAt,
+              ...(error ? { error } : {}),
+            }
+          : s
+      );
+      this.startedAt = null;
+    });
+  }
+
+  #closeActive(now: number): void {
+    this.steps = this.steps.map((s) =>
+      s.status === "active"
+        ? { ...s, status: "done" as const, durationMs: now - s.startedAt }
+        : s
+    );
+  }
+}
+
+export const loading = new LoadingStore();


### PR DESCRIPTION
Automated AFK landing for #127. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #127

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785910505&installation_id=129708444&pr_number=136&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F136&signature=3e0cd8aa8bb059b87b9111e3711a361873c9cb9ae38970abe35e8930c10f0425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a connection loading overlay with step-by-step progress, elapsed time, and clearer status messaging.
  * The overlay now appears only when loading takes longer than a short delay, reducing brief flash-ups.
  * Connection attempts now show more detailed progress, including server reachability and stats/capabilities checks.

* **Bug Fixes**
  * Improved failure handling so loading states close correctly and error details are shown when connections fail.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->