### PR TITLE
merge: #128 Instrumented developer console: every query with timing and row counts

### DIFF
--- a/packages/ui/src/lib/DevConsole.svelte
+++ b/packages/ui/src/lib/DevConsole.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+  // Instrumented developer console panel (#128). A collapsible, bottom-docked
+  // log of every query and HTTP call the client made — verb, target, duration,
+  // row count — copyable and secret-free. It bridges the framework-agnostic
+  // `devConsole` store (deliberately rune-free so the data layer can log
+  // without importing Svelte) into reactivity by subscribing and mirroring the
+  // snapshot into `$state`.
+  //
+  // It never steals the accent: status is carried by ok/danger dots and the
+  // panel chrome uses the neutral surface ramp, so the one-accent-per-screen
+  // rule (design principle #6) holds even while the console is open.
+  import { devConsole as defaultStore, type ConsoleEntry } from '#reddb'
+  import { X, Copy, Trash2, Check } from 'lucide-svelte'
+
+  let {
+    store = defaultStore,
+    open: openProp = false,
+  }: {
+    store?: typeof defaultStore
+    open?: boolean
+  } = $props()
+
+  // Seed the panel's open state from the prop once; thereafter it's toggled
+  // locally by the shell event and the close button.
+  // svelte-ignore state_referenced_locally
+  let open = $state(openProp)
+  let entries = $state<readonly ConsoleEntry[]>([])
+  let copiedId = $state<number | null>(null)
+
+  // Bridge the rune-free store into reactivity: subscribe once, mirror every
+  // snapshot into local `$state`. The subscribe fires immediately, so the
+  // panel paints the current log on mount.
+  $effect(() => store.subscribe((snap) => (entries = snap)))
+
+  // Toggle from anywhere in the shell (the StatusBar button dispatches this).
+  $effect(() => {
+    const toggle = () => (open = !open)
+    window.addEventListener('red:toggle-dev-console', toggle)
+    return () => window.removeEventListener('red:toggle-dev-console', toggle)
+  })
+
+  // Newest first — an operator reads the most recent call at the top.
+  const ordered = $derived([...entries].reverse())
+
+  async function copy(text: string, id: number) {
+    try {
+      await navigator.clipboard?.writeText(text)
+      copiedId = id
+      setTimeout(() => {
+        if (copiedId === id) copiedId = null
+      }, 1200)
+    } catch {
+      // Clipboard denied (insecure context / permissions) — silently no-op.
+    }
+  }
+
+  function entryText(e: ConsoleEntry): string {
+    const head = `${e.verb} ${e.target} → ${e.ok ? (e.status ?? 'ok') : 'error'} · ${e.durationMs}ms${
+      e.rowCount === undefined ? '' : ` · ${e.rowCount} rows`
+    }`
+    const parts = [head]
+    if (e.payload) parts.push(e.payload)
+    if (e.error) parts.push(e.error)
+    return parts.join('\n')
+  }
+
+  function fmtDuration(ms: number): string {
+    return ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms}ms`
+  }
+</script>
+
+{#if open}
+  <div
+    class="fixed inset-x-0 bottom-0 z-[9990] flex max-h-[45vh] flex-col border-t border-line-2 bg-bg-1 shadow-2xl"
+    role="log"
+    aria-label="Developer console"
+    data-testid="dev-console"
+  >
+    <div class="flex items-center justify-between gap-3 border-b border-line-1 bg-bg-2/60 px-3 py-1.5">
+      <div class="flex items-center gap-2 font-mono text-[11px] text-fg-2">
+        <span class="uppercase tracking-wider text-fg-1">Console</span>
+        <span class="text-fg-3" data-testid="dev-console-count">{entries.length} calls</span>
+      </div>
+      <div class="flex items-center gap-1">
+        <button
+          type="button"
+          onclick={() => store.clear()}
+          title="Clear console"
+          aria-label="Clear console"
+          class="inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-mono text-[11px] text-fg-3 hover:bg-bg-3/60 hover:text-fg-1 transition-colors"
+        >
+          <Trash2 class="size-3" />
+          Clear
+        </button>
+        <button
+          type="button"
+          onclick={() => (open = false)}
+          title="Close console"
+          aria-label="Close console"
+          class="inline-flex items-center rounded p-0.5 text-fg-3 hover:bg-bg-3/60 hover:text-fg-1 transition-colors"
+        >
+          <X class="size-3.5" />
+        </button>
+      </div>
+    </div>
+
+    <div class="min-h-0 flex-1 overflow-y-auto">
+      {#if ordered.length === 0}
+        <div class="grid h-24 place-items-center font-mono text-[12px] text-fg-3">
+          No calls yet — the client hasn't asked the database anything.
+        </div>
+      {:else}
+        <ul class="divide-y divide-line-1/60">
+          {#each ordered as entry (entry.id)}
+            <li class="group flex items-start gap-2 px-3 py-1.5 font-mono text-[11px] hover:bg-bg-2/40" data-testid="dev-console-entry">
+              <span
+                class="mt-[5px] h-1.5 w-1.5 shrink-0 rounded-full"
+                class:bg-ok={entry.ok}
+                class:bg-danger={!entry.ok}
+                aria-hidden="true"
+              ></span>
+              <span class="w-11 shrink-0 uppercase text-fg-2">{entry.verb}</span>
+              <span class="min-w-0 flex-1">
+                <span class="text-fg-1">{entry.target}</span>
+                {#if entry.payload}
+                  <span class="ml-1 text-fg-3 break-all">{entry.payload.replace(/\s+/g, ' ').slice(0, 120)}</span>
+                {/if}
+                {#if entry.error}
+                  <span class="ml-1 text-danger break-all">— {entry.error}</span>
+                {/if}
+              </span>
+              {#if entry.rowCount !== undefined}
+                <span class="shrink-0 tabular-nums text-fg-3" title="rows returned">{entry.rowCount}r</span>
+              {/if}
+              <span class="w-12 shrink-0 text-right tabular-nums text-fg-2" title="duration">{fmtDuration(entry.durationMs)}</span>
+              <button
+                type="button"
+                onclick={() => copy(entryText(entry), entry.id)}
+                title="Copy entry"
+                aria-label="Copy entry"
+                class="shrink-0 rounded p-0.5 text-fg-3 opacity-0 transition-opacity hover:bg-bg-3/60 hover:text-fg-1 group-hover:opacity-100 focus:opacity-100"
+              >
+                {#if copiedId === entry.id}
+                  <Check class="size-3 text-ok" />
+                {:else}
+                  <Copy class="size-3" />
+                {/if}
+              </button>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </div>
+  </div>
+{/if}

--- a/packages/ui/src/lib/DevConsole.svelte.test.ts
+++ b/packages/ui/src/lib/DevConsole.svelte.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, expect, test } from 'vitest'
+import { flushSync, mount, unmount } from 'svelte'
+import DevConsole from './DevConsole.svelte'
+import { DevConsoleStore } from '#reddb'
+
+// Locks the developer console panel (#128): it mirrors the rune-free store,
+// renders each call with its timing and row count, toggles from the shell
+// event, and copies entry text without leaking secrets.
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+function render(props: Record<string, unknown> = {}) {
+  const target = document.createElement('div')
+  document.body.appendChild(target)
+  const component = mount(DevConsole, { target, props })
+  flushSync()
+  return { target, component }
+}
+
+test('renders each recorded call with its verb, target, and row count when open', () => {
+  const store = new DevConsoleStore()
+  store.record({
+    kind: 'query',
+    verb: 'POST',
+    target: '/query',
+    startedAt: 0,
+    durationMs: 12,
+    ok: true,
+    rowCount: 5,
+    payload: '{"query":"SELECT 1"}',
+  })
+
+  const { target, component } = render({ store, open: true })
+
+  const panel = target.querySelector('[data-testid="dev-console"]')
+  expect(panel).not.toBeNull()
+  const entries = target.querySelectorAll('[data-testid="dev-console-entry"]')
+  expect(entries.length).toBe(1)
+  expect(target.textContent).toContain('/query')
+  expect(target.textContent).toContain('5r')
+  expect(target.textContent).toContain('12ms')
+
+  unmount(component)
+})
+
+test('stays hidden until the shell toggle event fires, then reveals', () => {
+  const store = new DevConsoleStore()
+  const { target, component } = render({ store, open: false })
+
+  expect(target.querySelector('[data-testid="dev-console"]')).toBeNull()
+
+  window.dispatchEvent(new CustomEvent('red:toggle-dev-console'))
+  flushSync()
+
+  expect(target.querySelector('[data-testid="dev-console"]')).not.toBeNull()
+
+  window.dispatchEvent(new CustomEvent('red:toggle-dev-console'))
+  flushSync()
+
+  expect(target.querySelector('[data-testid="dev-console"]')).toBeNull()
+
+  unmount(component)
+})
+
+test('live-updates as the store records new calls', () => {
+  const store = new DevConsoleStore()
+  const { target, component } = render({ store, open: true })
+
+  expect(target.querySelectorAll('[data-testid="dev-console-entry"]').length).toBe(0)
+  expect(target.textContent).toContain("No calls yet")
+
+  store.record({
+    kind: 'http',
+    verb: 'GET',
+    target: '/stats',
+    startedAt: 0,
+    durationMs: 3,
+    ok: true,
+  })
+  flushSync()
+
+  expect(target.querySelectorAll('[data-testid="dev-console-entry"]').length).toBe(1)
+  expect(target.querySelector('[data-testid="dev-console-count"]')?.textContent).toContain('1')
+
+  unmount(component)
+})
+
+test('clear empties the panel via the store', () => {
+  const store = new DevConsoleStore()
+  store.record({
+    kind: 'http',
+    verb: 'GET',
+    target: '/stats',
+    startedAt: 0,
+    durationMs: 3,
+    ok: true,
+  })
+
+  const { target, component } = render({ store, open: true })
+  expect(target.querySelectorAll('[data-testid="dev-console-entry"]').length).toBe(1)
+
+  const clearBtn = [...target.querySelectorAll('button')].find((b) =>
+    b.textContent?.includes('Clear'),
+  )!
+  clearBtn.click()
+  flushSync()
+
+  expect(target.querySelectorAll('[data-testid="dev-console-entry"]').length).toBe(0)
+  expect(store.size).toBe(0)
+
+  unmount(component)
+})

--- a/packages/ui/src/lib/StatusBar.svelte
+++ b/packages/ui/src/lib/StatusBar.svelte
@@ -2,7 +2,7 @@
   import { useRouter } from './router.svelte'
   import { connection } from './connections.svelte'
   import { pendingChanges } from './pending-changes.svelte'
-  import { ArrowRight, FilePenLine, Lock } from 'lucide-svelte'
+  import { ArrowRight, FilePenLine, Lock, Terminal } from 'lucide-svelte'
   import { readBuildInfo } from './build-info'
 
   const build = readBuildInfo()
@@ -46,6 +46,12 @@
 
   function openConnect() {
     window.dispatchEvent(new CustomEvent('red:open-connect'))
+  }
+
+  // Toggle the instrumented developer console (#128). Neutral chrome — the
+  // console never claims the accent, matching one-accent-per-screen.
+  function toggleConsole() {
+    window.dispatchEvent(new CustomEvent('red:toggle-dev-console'))
   }
 
   function openCluster(e: MouseEvent) {
@@ -153,6 +159,18 @@
       <ArrowRight class="size-3" />
     </button>
   {/if}
+
+  <button
+    type="button"
+    onclick={toggleConsole}
+    data-no-nav
+    aria-label="Toggle developer console"
+    title="Developer console — every query and HTTP call, with timing and row counts"
+    class="inline-flex items-center gap-1 px-3 text-fg-3 hover:text-fg-1 hover:bg-bg-2/60 transition-colors cursor-pointer bg-transparent border-0 border-l border-line-1"
+  >
+    <Terminal class="size-3" />
+    <span>Console</span>
+  </button>
 
   <span
     class="inline-flex items-center px-3 shrink-0 font-mono text-fg-3 border-l border-line-1 select-none"

--- a/packages/ui/src/lib/Workspace.svelte
+++ b/packages/ui/src/lib/Workspace.svelte
@@ -7,6 +7,7 @@
   import { onMount, untrack } from 'svelte'
   import Splash from './Splash.svelte'
   import LoadingOverlay from './LoadingOverlay.svelte'
+  import DevConsole from './DevConsole.svelte'
   import GlobalProgressBar from './GlobalProgressBar.svelte'
   import Topbar from './Topbar.svelte'
   import StatusBar from './StatusBar.svelte'
@@ -315,3 +316,7 @@
      connect/boot; self-hides once the open resolves and never flashes on fast
      opens. -->
 <LoadingOverlay />
+
+<!-- Instrumented developer console (#128): a collapsible, accent-free log of
+     every query/HTTP call the client made, toggled from the StatusBar. -->
+<DevConsole />

--- a/packages/ui/src/lib/reddb/client.ts
+++ b/packages/ui/src/lib/reddb/client.ts
@@ -15,6 +15,7 @@ import type {
 import type { ClusterStatus, ReplicationStatus } from "./cluster-status";
 import type { MetricDescriptor, PromResponse } from "./analytics";
 import type { AskResponse, AskOptions } from "./ask";
+import { devConsole, sanitizePayload } from "./dev-console";
 
 export interface QueryRow {
   values: Record<string, unknown>;
@@ -294,6 +295,25 @@ async function* parseNdjsonFrames(
 const SELECT_RE = /^\s*select\b/i;
 
 /**
+ * Pull a row count out of a parsed response for the developer console (#128).
+ * Recognises the `/query` envelope (`record_count`, else the length of
+ * `result.records`) and a bare array; returns `undefined` when the shape
+ * carries no notion of rows. Purely structural — never throws.
+ */
+export function extractRowCount(data: unknown): number | undefined {
+  if (Array.isArray(data)) return data.length;
+  if (data && typeof data === "object") {
+    const d = data as {
+      record_count?: unknown;
+      result?: { records?: unknown };
+    };
+    if (typeof d.record_count === "number") return d.record_count;
+    if (Array.isArray(d.result?.records)) return d.result.records.length;
+  }
+  return undefined;
+}
+
+/**
  * Extract a human-readable message from any thrown value. Tauri's `invoke` and
  * the HTTP plugin reject with plain strings or bare objects (not `Error`), so
  * `(e as Error).message` is often `undefined` — this never returns that.
@@ -374,14 +394,66 @@ export class RedClient {
     Object.assign(headers, this.headers as Record<string, string> | undefined);
     Object.assign(headers, init?.headers as Record<string, string> | undefined);
 
-    const res = await this.fetcher(url, { ...init, headers });
+    // Developer console instrumentation (#128). Every HTTP call the client
+    // makes is timed and logged from this single seam, so every Surface is
+    // covered without touching each caller. The request body is sanitized
+    // before it lands in an entry — a copy action can never leak a secret.
+    const verb = init?.method ?? "GET";
+    const startedAt = Date.now();
+    const start = performance.now();
+    const payload = sanitizePayload(init?.body);
+    const elapsed = () => Math.round(performance.now() - start);
+
+    let res: Response;
+    try {
+      res = await this.fetcher(url, { ...init, headers });
+    } catch (e) {
+      devConsole.record({
+        kind: "http",
+        verb,
+        target: path,
+        startedAt,
+        durationMs: elapsed(),
+        ok: false,
+        payload,
+        error: errorText(e),
+      });
+      throw e;
+    }
+
     if (!res.ok) {
       const body = await res.text().catch(() => "");
-      throw new Error(
-        `${init?.method ?? "GET"} ${path} → ${res.status} ${body.slice(0, 200)}`
-      );
+      const message = `${verb} ${path} → ${res.status} ${body.slice(0, 200)}`;
+      devConsole.record({
+        kind: "http",
+        verb,
+        target: path,
+        startedAt,
+        durationMs: elapsed(),
+        ok: false,
+        status: res.status,
+        payload,
+        error: message,
+      });
+      throw new Error(message);
     }
-    return res.json() as Promise<T>;
+
+    const data = (await res.json()) as T;
+    const rowCount = extractRowCount(data);
+    devConsole.record({
+      // A response carrying a row count is a query round-trip; everything else
+      // is a plain HTTP call. This is how `/query` entries mark themselves.
+      kind: rowCount === undefined ? "http" : "query",
+      verb,
+      target: path,
+      startedAt,
+      durationMs: elapsed(),
+      ok: true,
+      status: res.status,
+      ...(rowCount === undefined ? {} : { rowCount }),
+      payload,
+    });
+    return data;
   }
 
   async stats(): Promise<Stats> {
@@ -588,17 +660,51 @@ export class RedClient {
     };
     Object.assign(headers, this.headers as Record<string, string> | undefined);
 
-    const res = await this.fetcher(`${this.baseUrl}/query/stream`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({ query }),
-      signal: opts.signal,
-    });
+    // Developer console instrumentation (#128). The streaming endpoint skips
+    // `json()`, so it logs its own query round-trip here (verb `POST`, target
+    // `/query/stream`) with the collected row count.
+    const startedAt = Date.now();
+    const start = performance.now();
+    const body = JSON.stringify({ query });
+    const payload = sanitizePayload(body);
+    const elapsed = () => Math.round(performance.now() - start);
+
+    let res: Response;
+    try {
+      res = await this.fetcher(`${this.baseUrl}/query/stream`, {
+        method: "POST",
+        headers,
+        body,
+        signal: opts.signal,
+      });
+    } catch (e) {
+      devConsole.record({
+        kind: "query",
+        verb: "POST",
+        target: "/query/stream",
+        startedAt,
+        durationMs: elapsed(),
+        ok: false,
+        payload,
+        error: errorText(e),
+      });
+      throw e;
+    }
     if (!res.ok || !res.body) {
-      const body = res.body ? await res.text().catch(() => "") : "";
-      throw new Error(
-        `POST /query/stream → ${res.status} ${body.slice(0, 200)}`
-      );
+      const errBody = res.body ? await res.text().catch(() => "") : "";
+      const message = `POST /query/stream → ${res.status} ${errBody.slice(0, 200)}`;
+      devConsole.record({
+        kind: "query",
+        verb: "POST",
+        target: "/query/stream",
+        startedAt,
+        durationMs: elapsed(),
+        ok: false,
+        status: res.status,
+        payload,
+        error: message,
+      });
+      throw new Error(message);
     }
 
     const out: StreamedQueryResult = {
@@ -625,6 +731,18 @@ export class RedClient {
         break;
       }
     }
+
+    devConsole.record({
+      kind: "query",
+      verb: "POST",
+      target: "/query/stream",
+      startedAt,
+      durationMs: elapsed(),
+      ok: true,
+      status: res.status,
+      rowCount: out.rowCount,
+      payload,
+    });
 
     // We stopped early with more rows on the server — release the pinned cursor.
     if (out.truncated && out.cursor) {

--- a/packages/ui/src/lib/reddb/dev-console-instrumentation.test.ts
+++ b/packages/ui/src/lib/reddb/dev-console-instrumentation.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RedClient } from "./client";
+import { devConsole } from "./dev-console";
+
+// The console is instrumented at the client seam (#128): every query and HTTP
+// call the client issues must append exactly one entry with timing, a row
+// count where the response carries one, and a sanitized (secret-free) payload.
+
+beforeEach(() => {
+  devConsole.clear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  devConsole.clear();
+});
+
+describe("RedClient console instrumentation", () => {
+  it("logs a query round-trip with its row count and sanitized query text", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          ok: true,
+          query: "SELECT 1",
+          record_count: 2,
+          result: { columns: ["n"], records: [{ values: { n: 1 } }, { values: { n: 2 } }] },
+        })
+      )
+    );
+
+    const client = new RedClient("http://reddb.test");
+    await client.query("SELECT * FROM users");
+
+    const entries = devConsole.snapshot();
+    expect(entries).toHaveLength(1);
+    const [entry] = entries;
+    expect(entry.kind).toBe("query");
+    expect(entry.verb).toBe("POST");
+    expect(entry.target).toBe("/query");
+    expect(entry.ok).toBe(true);
+    expect(entry.status).toBe(200);
+    expect(entry.rowCount).toBe(2);
+    expect(typeof entry.durationMs).toBe("number");
+    expect(entry.payload).toContain("SELECT * FROM users");
+  });
+
+  it("marks a plain GET as an http entry without a row count", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ collections: ["a", "b"] }))
+    );
+
+    const client = new RedClient("http://reddb.test");
+    await client.collections();
+
+    const [entry] = devConsole.snapshot();
+    expect(entry.kind).toBe("http");
+    expect(entry.verb).toBe("GET");
+    expect(entry.target).toBe("/collections");
+    expect(entry.rowCount).toBeUndefined();
+  });
+
+  it("redacts secrets in the logged payload", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ ok: true }))
+    );
+
+    const client = new RedClient("http://reddb.test", {
+      fetch: undefined,
+    });
+    // POST with a sensitive field in the body.
+    await client.ask("hello", { token: "super-secret" } as never).catch(() => {});
+
+    const entry = devConsole.snapshot().find((e) => e.target === "/ai/ask");
+    expect(entry).toBeDefined();
+    expect(entry?.payload).toContain("«redacted»");
+    expect(entry?.payload).not.toContain("super-secret");
+  });
+
+  it("logs a failed HTTP call with the error and status", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response("boom", {
+            status: 500,
+            headers: { "Content-Type": "text/plain" },
+          })
+      )
+    );
+
+    const client = new RedClient("http://reddb.test");
+    await expect(client.stats()).rejects.toThrow();
+
+    const [entry] = devConsole.snapshot();
+    expect(entry.ok).toBe(false);
+    expect(entry.status).toBe(500);
+    expect(entry.error).toContain("500");
+  });
+
+  it("logs a network failure (fetch reject) as a failed entry", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      })
+    );
+
+    const client = new RedClient("http://reddb.test");
+    await expect(client.stats()).rejects.toThrow("network down");
+
+    const [entry] = devConsole.snapshot();
+    expect(entry.ok).toBe(false);
+    expect(entry.status).toBeUndefined();
+    expect(entry.error).toContain("network down");
+  });
+
+  it("logs the streaming query endpoint with its collected row count", async () => {
+    const ndjson =
+      JSON.stringify({ descriptor: { columns: ["n"] } }) +
+      "\n" +
+      JSON.stringify({ row: { n: 1 } }) +
+      "\n" +
+      JSON.stringify({ row: { n: 2 } }) +
+      "\n" +
+      JSON.stringify({ end: { row_count: 2 } }) +
+      "\n";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(ndjson, {
+            status: 200,
+            headers: { "Content-Type": "application/x-ndjson" },
+          })
+      )
+    );
+
+    const client = new RedClient("http://reddb.test");
+    await client.queryStreamCollect("SELECT n FROM t");
+
+    const [entry] = devConsole.snapshot();
+    expect(entry.kind).toBe("query");
+    expect(entry.target).toBe("/query/stream");
+    expect(entry.ok).toBe(true);
+    expect(entry.rowCount).toBe(2);
+    expect(entry.payload).toContain("SELECT n FROM t");
+  });
+});

--- a/packages/ui/src/lib/reddb/dev-console.test.ts
+++ b/packages/ui/src/lib/reddb/dev-console.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DevConsoleStore,
+  redactSecrets,
+  sanitizePayload,
+  type ConsoleEntry,
+} from "./dev-console";
+
+describe("redactSecrets", () => {
+  it("masks sensitive keys anywhere in the tree but keeps their shape", () => {
+    const out = redactSecrets({
+      query: "SELECT 1",
+      password: "hunter2",
+      nested: { api_key: "abc", authorization: "Bearer x", keep: 3 },
+      list: [{ token: "t" }, { safe: "y" }],
+    });
+    expect(out).toEqual({
+      query: "SELECT 1",
+      password: "«redacted»",
+      nested: { api_key: "«redacted»", authorization: "«redacted»", keep: 3 },
+      list: [{ token: "«redacted»" }, { safe: "y" }],
+    });
+  });
+
+  it("bounds recursion depth so a deep structure can't blow the console", () => {
+    let deep: Record<string, unknown> = { leaf: 1 };
+    for (let i = 0; i < 20; i++) deep = { child: deep };
+    expect(() => JSON.stringify(redactSecrets(deep))).not.toThrow();
+  });
+});
+
+describe("sanitizePayload", () => {
+  it("parses a JSON body and redacts secrets in the copyable text", () => {
+    const out = sanitizePayload(JSON.stringify({ query: "SELECT 1", token: "secret" }));
+    expect(out).toContain("SELECT 1");
+    expect(out).toContain("«redacted»");
+    expect(out).not.toContain("secret");
+  });
+
+  it("returns undefined for an absent or empty body", () => {
+    expect(sanitizePayload(undefined)).toBeUndefined();
+    expect(sanitizePayload(null)).toBeUndefined();
+    expect(sanitizePayload("")).toBeUndefined();
+  });
+
+  it("passes through a non-JSON string, truncating overly long text", () => {
+    expect(sanitizePayload("not json")).toBe("not json");
+    const long = "x".repeat(5000);
+    const out = sanitizePayload(long)!;
+    expect(out.length).toBeLessThan(long.length);
+    expect(out.endsWith("…")).toBe(true);
+  });
+});
+
+describe("DevConsoleStore", () => {
+  it("assigns monotonic ids and returns a newest-last snapshot", () => {
+    const store = new DevConsoleStore();
+    const a = store.record({
+      kind: "http",
+      verb: "GET",
+      target: "/stats",
+      startedAt: 0,
+      durationMs: 5,
+      ok: true,
+    });
+    const b = store.record({
+      kind: "query",
+      verb: "POST",
+      target: "/query",
+      startedAt: 1,
+      durationMs: 8,
+      ok: true,
+      rowCount: 3,
+    });
+    expect(a.id).toBe(1);
+    expect(b.id).toBe(2);
+    expect(store.snapshot().map((e) => e.id)).toEqual([1, 2]);
+    expect(store.size).toBe(2);
+  });
+
+  it("notifies subscribers immediately and on every change", () => {
+    const store = new DevConsoleStore();
+    const seen: number[] = [];
+    const unsub = store.subscribe((entries) => seen.push(entries.length));
+    expect(seen).toEqual([0]); // immediate snapshot
+    store.record(baseEntry());
+    expect(seen).toEqual([0, 1]);
+    unsub();
+    store.record(baseEntry());
+    expect(seen).toEqual([0, 1]); // no more notifications after unsubscribe
+  });
+
+  it("clears entries and notifies once", () => {
+    const store = new DevConsoleStore();
+    store.record(baseEntry());
+    const spy = vi.fn();
+    store.subscribe(spy);
+    spy.mockClear();
+    store.clear();
+    expect(store.size).toBe(0);
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockClear();
+    store.clear(); // already empty — no notification
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("drops the oldest entries past capacity", () => {
+    const store = new DevConsoleStore(3);
+    for (let i = 0; i < 5; i++) store.record(baseEntry());
+    expect(store.size).toBe(3);
+    // ids 3,4,5 survive; 1,2 were dropped.
+    expect(store.snapshot().map((e) => e.id)).toEqual([3, 4, 5]);
+  });
+});
+
+function baseEntry(): Omit<ConsoleEntry, "id"> {
+  return {
+    kind: "http",
+    verb: "GET",
+    target: "/stats",
+    startedAt: 0,
+    durationMs: 1,
+    ok: true,
+  };
+}

--- a/packages/ui/src/lib/reddb/dev-console.ts
+++ b/packages/ui/src/lib/reddb/dev-console.ts
@@ -1,0 +1,156 @@
+// Instrumented developer console (#128). A deliberately framework-agnostic,
+// rune-free observable store so the data layer (`RedClient`, transports) can
+// log every query and HTTP call *without* importing Svelte — the client seam
+// must not depend on the UI runtime. The Svelte panel bridges this store into
+// reactivity by subscribing and copying the snapshot into `$state`.
+//
+// Every entry is one round-trip the client made: the verb (HTTP method /
+// statement head), the target (path or endpoint), how long it took, how many
+// rows came back, and a *sanitized* payload — secrets are redacted before an
+// entry is ever stored, so a copy action can never leak a token.
+
+/** What kind of round-trip an entry records. */
+export type ConsoleEntryKind = "query" | "http";
+
+export interface ConsoleEntry {
+  /** Monotonic id, assigned on record. Stable for keying/dedup in the panel. */
+  id: number;
+  kind: ConsoleEntryKind;
+  /** HTTP method or statement head, e.g. `POST`, `GET`, `SELECT`. */
+  verb: string;
+  /** Endpoint path or logical target the call hit, e.g. `/query`. */
+  target: string;
+  /** Absolute wall-clock time the call started. */
+  startedAt: number;
+  /** Round-trip duration in milliseconds. */
+  durationMs: number;
+  /** True when the call succeeded (2xx / resolved). */
+  ok: boolean;
+  /** HTTP status code when one is known. */
+  status?: number;
+  /** Rows returned, when the response carries a row/record count. */
+  rowCount?: number;
+  /** Sanitized request payload or query text — copyable, never contains secrets. */
+  payload?: string;
+  /** Error text when the call failed. */
+  error?: string;
+}
+
+/** A record as handed to the store — the store owns `id`. */
+export type ConsoleEntryInput = Omit<ConsoleEntry, "id">;
+
+type Listener = (entries: readonly ConsoleEntry[]) => void;
+
+/** Keys whose values are always masked, matched case-insensitively as substrings. */
+const SENSITIVE_KEY_RE =
+  /pass(word)?|secret|token|api[-_]?key|authorization|auth|credential|cookie|session|bearer|private[-_]?key|mfa/i;
+
+const REDACTED = "«redacted»";
+
+/**
+ * Recursively redact sensitive values from an arbitrary structure, returning a
+ * plain clone safe to stringify. A value under a sensitive key is replaced with
+ * a marker rather than dropped, so the reader still sees *that* a field existed.
+ * Depth- and breadth-bounded so a pathological payload can't blow the console.
+ */
+export function redactSecrets(value: unknown, depth = 0): unknown {
+  if (depth > 6) return "«…»";
+  if (Array.isArray(value)) {
+    return value.slice(0, 100).map((v) => redactSecrets(v, depth + 1));
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = SENSITIVE_KEY_RE.test(k) ? REDACTED : redactSecrets(v, depth + 1);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Turn a request body (a JSON string, an object, or anything else) into a
+ * sanitized, human-readable string for the entry's copyable payload. Parses
+ * JSON so keys can be redacted; falls back to a truncated raw string when the
+ * body isn't JSON. Returns `undefined` for an absent body.
+ */
+export function sanitizePayload(body: unknown): string | undefined {
+  if (body === undefined || body === null) return undefined;
+  let parsed: unknown = body;
+  if (typeof body === "string") {
+    if (body.length === 0) return undefined;
+    try {
+      parsed = JSON.parse(body);
+    } catch {
+      return body.length > 2000 ? `${body.slice(0, 2000)}…` : body;
+    }
+  }
+  try {
+    const json = JSON.stringify(redactSecrets(parsed), null, 2);
+    return json.length > 4000 ? `${json.slice(0, 4000)}…` : json;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The developer console log. A bounded ring of entries with a minimal
+ * subscribe/emit surface — no framework, no runes. `record` is the single
+ * write path the client seam calls; `subscribe` is how the panel observes.
+ */
+export class DevConsoleStore {
+  private entries: ConsoleEntry[] = [];
+  private readonly listeners = new Set<Listener>();
+  private nextId = 1;
+
+  /** Cap on retained entries; oldest are dropped past this. */
+  constructor(private readonly capacity = 500) {}
+
+  /** Append one round-trip. Assigns the id, trims to capacity, notifies. */
+  record(input: ConsoleEntryInput): ConsoleEntry {
+    const entry: ConsoleEntry = { ...input, id: this.nextId++ };
+    this.entries.push(entry);
+    if (this.entries.length > this.capacity) {
+      this.entries.splice(0, this.entries.length - this.capacity);
+    }
+    this.emit();
+    return entry;
+  }
+
+  /** A frozen, newest-last snapshot of the log. */
+  snapshot(): readonly ConsoleEntry[] {
+    return this.entries.slice();
+  }
+
+  /** Number of retained entries. */
+  get size(): number {
+    return this.entries.length;
+  }
+
+  /** Drop every entry and notify. */
+  clear(): void {
+    if (this.entries.length === 0) return;
+    this.entries = [];
+    this.emit();
+  }
+
+  /**
+   * Observe the log. The listener fires immediately with the current snapshot
+   * and again on every change. Returns an unsubscribe.
+   */
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    listener(this.snapshot());
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private emit(): void {
+    const snap = this.snapshot();
+    for (const listener of this.listeners) listener(snap);
+  }
+}
+
+/** The singleton the client seam records into and the panel observes. */
+export const devConsole = new DevConsoleStore();

--- a/packages/ui/src/lib/reddb/index.ts
+++ b/packages/ui/src/lib/reddb/index.ts
@@ -4,6 +4,7 @@ export * from "./cluster-status";
 export * from "./analytics";
 export * from "./ask";
 export * from "./client";
+export * from "./dev-console";
 export * from "./connection-provider";
 export * from "./local-url-provider";
 export * from "./injected-client-provider";


### PR DESCRIPTION
Automated AFK landing for #128. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #128

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785911446&installation_id=129708444&pr_number=137&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F137&signature=034f0df98543dce3bbde3112f8bb9e540f53a6e8be1cf0f71992562dc0998fb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->