### PR TITLE
merge: #129 Workspace autosave with close-request flush and native close watchdog

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -318,16 +318,39 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(|app_handle, event| {
-            // Reap any embedded reddb sidecars when the app exits so we never
-            // leak a file-backed server holding the database open.
-            if let tauri::RunEvent::Exit = event {
-                if let Some(registry) = app_handle.try_state::<EmbeddedRegistry>() {
-                    if let Ok(mut map) = registry.0.lock() {
-                        for (_, embedded) in map.drain() {
-                            let _ = embedded.child.kill();
+            match event {
+                // Reap any embedded reddb sidecars when the app exits so we never
+                // leak a file-backed server holding the database open.
+                tauri::RunEvent::Exit => {
+                    if let Some(registry) = app_handle.try_state::<EmbeddedRegistry>() {
+                        if let Ok(mut map) = registry.0.lock() {
+                            for (_, embedded) in map.drain() {
+                                let _ = embedded.child.kill();
+                            }
                         }
                     }
                 }
+                // Close-request watchdog (#129): prevent the OS close, signal
+                // the webview to flush its session and destroy the window, then
+                // arm a 500 ms watchdog that force-destroys if the webview hangs
+                // so the OS close button can never be trapped.
+                tauri::RunEvent::WindowEvent { label, event, .. } => {
+                    if let tauri::WindowEvent::CloseRequested { api } = event {
+                        api.prevent_close();
+                        if let Some(window) = app_handle.get_webview_window(&label) {
+                            let _ = window.emit("close-request", ());
+                            let win = window.clone();
+                            tauri::async_runtime::spawn(async move {
+                                tokio::time::sleep(
+                                    std::time::Duration::from_millis(500),
+                                )
+                                .await;
+                                let _ = win.destroy();
+                            });
+                        }
+                    }
+                }
+                _ => {}
             }
         });
 }

--- a/packages/ui/src/lib/Workspace.svelte
+++ b/packages/ui/src/lib/Workspace.svelte
@@ -32,6 +32,7 @@
   import { detectCapability } from './capability'
   import { defaultSubpage } from './collection-pages'
   import { createStateRouter, pathToLocation, setRouter, type Router, type View } from './router.svelte'
+  import { workspaceSession, type WorkspaceSnapshot } from './workspace-session'
 
   let {
     router: injectedRouter,
@@ -83,6 +84,27 @@
     }
   }
 
+  function buildSnapshot(): WorkspaceSnapshot {
+    return {
+      view: router.view,
+      collection: router.collection,
+      subpage: router.subpage,
+      tabs: tabs.tabs,
+      activeTabId: tabs.activeId,
+    }
+  }
+
+  function applySnapshot(snap: WorkspaceSnapshot): void {
+    if (snap.tabs.length > 0) tabs.hydrate(snap.tabs, snap.activeTabId)
+    router.go(
+      snap.collection
+        ? { view: 'collection', collection: snap.collection, subpage: snap.subpage ?? 'table' }
+        : { view: snap.view },
+      undefined,
+      true,
+    )
+  }
+
   onMount(() => {
     if (connectionProvider) {
       // Host-injected provider (#33): adopt its authenticated connection.
@@ -93,7 +115,13 @@
       // Connection Bootstrap: one boot resolver handles Tauri IPC, host globals,
       // the Open Contract URL/hash, and finally persisted standalone state.
       void connection.bootstrap().then((route) => {
-        if (route) navigateToBootRoute(route)
+        if (route) {
+          navigateToBootRoute(route)
+        } else {
+          // No explicit boot route — restore the last workspace session.
+          const snap = workspaceSession.restore()
+          if (snap) applySnapshot(snap)
+        }
       })
     }
   })
@@ -201,6 +229,47 @@
   // history URLs from the encrypted store so the dropdown can reconnect.
   $effect(() => {
     if (secureStore.store) connection.hydrateUrls()
+  })
+
+  // Autosave: debounce-schedule a snapshot on every router/tab state change.
+  // Guard on `booted` so we don't snapshot the blank pre-splash state.
+  $effect(() => {
+    if (!booted) return
+    const snap = buildSnapshot()
+    workspaceSession.schedule(snap)
+  })
+
+  // Flush immediately on page hide / window blur so an edit made
+  // right before closing is never lost to the debounce window.
+  onMount(() => {
+    const flush = () => { if (booted) workspaceSession.flush(buildSnapshot()) }
+    document.addEventListener('visibilitychange', flush)
+    window.addEventListener('blur', flush)
+    return () => {
+      document.removeEventListener('visibilitychange', flush)
+      window.removeEventListener('blur', flush)
+    }
+  })
+
+  // Tauri close-request: flush, then destroy the window. The Rust watchdog
+  // races this — if the webview hangs, it force-destroys after its bound.
+  onMount(() => {
+    if (typeof window === 'undefined') return
+    if (!('__TAURI_INTERNALS__' in window || '__TAURI__' in window)) return
+
+    let unlisten: (() => void) | undefined
+
+    void import('@tauri-apps/api/event')
+      .then(({ listen }) =>
+        listen<void>('close-request', async () => {
+          workspaceSession.flush(buildSnapshot())
+          const { getCurrentWindow } = await import('@tauri-apps/api/window')
+          await getCurrentWindow().destroy()
+        }),
+      )
+      .then((fn) => { unlisten = fn })
+
+    return () => { unlisten?.() }
   })
 
   function openNewQuery() {

--- a/packages/ui/src/lib/tabs.svelte.ts
+++ b/packages/ui/src/lib/tabs.svelte.ts
@@ -106,6 +106,11 @@ class TabsStore {
     )
   }
 
+  hydrate(savedTabs: Tab[], savedActiveId: string | null): void {
+    this.tabs = savedTabs
+    this.activeId = savedActiveId
+  }
+
   clear(): void {
     this.tabs = []
     this.activeId = null

--- a/packages/ui/src/lib/workspace-session.test.ts
+++ b/packages/ui/src/lib/workspace-session.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { WorkspaceSession, type WorkspaceSnapshot, type KeyValueStorage } from './workspace-session'
+
+class MemStorage implements KeyValueStorage {
+  private map = new Map<string, string>()
+  getItem(k: string) { return this.map.get(k) ?? null }
+  setItem(k: string, v: string) { this.map.set(k, v) }
+}
+
+const makeSnap = (view: WorkspaceSnapshot['view'] = 'collections'): WorkspaceSnapshot => ({
+  view,
+  collection: null,
+  subpage: null,
+  tabs: [],
+  activeTabId: null,
+})
+
+describe('WorkspaceSession', () => {
+  let storage: MemStorage
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    storage = new MemStorage()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('restore() returns null when nothing has been saved', () => {
+    const s = new WorkspaceSession(200, storage)
+    expect(s.restore()).toBeNull()
+  })
+
+  it('flush() saves immediately without waiting for the debounce', () => {
+    const s = new WorkspaceSession(500, storage)
+    s.flush(makeSnap('cluster'))
+    expect(s.restore()?.view).toBe('cluster')
+  })
+
+  it('flush() without a prior schedule still saves', () => {
+    const s = new WorkspaceSession(200, storage)
+    s.flush(makeSnap('settings'))
+    expect(s.restore()?.view).toBe('settings')
+  })
+
+  it('schedule() does not save before the debounce window elapses', () => {
+    const s = new WorkspaceSession(200, storage)
+    s.schedule(makeSnap('cluster'))
+    vi.advanceTimersByTime(100)
+    expect(s.restore()).toBeNull()
+  })
+
+  it('schedule() saves after the debounce window elapses', () => {
+    const s = new WorkspaceSession(200, storage)
+    s.schedule(makeSnap('cluster'))
+    vi.advanceTimersByTime(200)
+    expect(s.restore()?.view).toBe('cluster')
+  })
+
+  it('schedule() debounces — multiple calls reset the timer; only the last snapshot is saved', () => {
+    const s = new WorkspaceSession(200, storage)
+    s.schedule(makeSnap('cluster'))
+    vi.advanceTimersByTime(100)
+    s.schedule(makeSnap('security'))
+    vi.advanceTimersByTime(100)
+    // Only 100ms past the second call — timer should not have fired yet
+    expect(s.restore()).toBeNull()
+    vi.advanceTimersByTime(100)
+    expect(s.restore()?.view).toBe('security')
+  })
+
+  it('flush() cancels a pending debounce — the debounced snapshot is never written', () => {
+    const s = new WorkspaceSession(200, storage)
+    s.schedule(makeSnap('cluster'))   // debounce armed with 'cluster'
+    vi.advanceTimersByTime(50)
+    s.flush(makeSnap('security'))     // close-request fires — flush 'security'
+    expect(s.restore()?.view).toBe('security')
+    // Advancing past the original debounce window must NOT overwrite with 'cluster'
+    vi.advanceTimersByTime(200)
+    expect(s.restore()?.view).toBe('security')
+  })
+
+  it('close-request ordering: flush wins over pending debounce (simulates close before autosave fires)', () => {
+    const s = new WorkspaceSession(1000, storage)
+    s.schedule(makeSnap('cluster'))  // autosave at t+1000
+    vi.advanceTimersByTime(300)
+    s.flush(makeSnap('ask'))         // close-request at t=300
+    expect(s.restore()?.view).toBe('ask')
+    vi.advanceTimersByTime(1000)     // debounce would have fired here — must be cancelled
+    expect(s.restore()?.view).toBe('ask')
+  })
+
+  it('restore() returns null for corrupted storage', () => {
+    const s = new WorkspaceSession(200, storage)
+    storage.setItem('red-ui-workspace-session', '{not: valid json}')
+    expect(s.restore()).toBeNull()
+  })
+
+  it('restore() returns null when the stored payload lacks a view field', () => {
+    const s = new WorkspaceSession(200, storage)
+    storage.setItem('red-ui-workspace-session', JSON.stringify({ tabs: [] }))
+    expect(s.restore()).toBeNull()
+  })
+
+  it('restore() roundtrips tabs and activeTabId', () => {
+    const s = new WorkspaceSession(200, storage)
+    const snap: WorkspaceSnapshot = {
+      view: 'collections',
+      collection: 'users',
+      subpage: 'table',
+      tabs: [{ id: 't1', kind: 'collection', label: 'users', key: 'users' }],
+      activeTabId: 't1',
+    }
+    s.flush(snap)
+    const restored = s.restore()
+    expect(restored?.tabs).toHaveLength(1)
+    expect(restored?.tabs[0].id).toBe('t1')
+    expect(restored?.activeTabId).toBe('t1')
+    expect(restored?.collection).toBe('users')
+  })
+})

--- a/packages/ui/src/lib/workspace-session.ts
+++ b/packages/ui/src/lib/workspace-session.ts
@@ -1,0 +1,81 @@
+// Workspace session persistence — snapshot the active view, open tabs, and
+// router location to localStorage so the app can restore on next launch.
+//
+// The class is injectable (pass a `storage` in tests) and pure — no Svelte
+// runes, no browser globals at import time — so the node vitest suite can
+// exercise it directly with a MemStorage.
+
+import type { Tab } from './tabs.svelte'
+import type { View } from './router.svelte'
+
+export interface WorkspaceSnapshot {
+  view: View
+  collection: string | null
+  subpage: string | null
+  tabs: Tab[]
+  activeTabId: string | null
+}
+
+export interface KeyValueStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+}
+
+const STORAGE_KEY = 'red-ui-workspace-session'
+
+export class WorkspaceSession {
+  private _timer: ReturnType<typeof setTimeout> | null = null
+  readonly debounceMs: number
+  private readonly _storage: KeyValueStorage | null
+
+  constructor(debounceMs = 1000, storage: KeyValueStorage | null = null) {
+    this.debounceMs = debounceMs
+    this._storage = storage
+  }
+
+  private _store(): KeyValueStorage | null {
+    if (this._storage) return this._storage
+    return typeof localStorage !== 'undefined' ? localStorage : null
+  }
+
+  private _write(snapshot: WorkspaceSnapshot): void {
+    try {
+      this._store()?.setItem(STORAGE_KEY, JSON.stringify(snapshot))
+    } catch {
+      // SSR or storage quota — silently skip
+    }
+  }
+
+  /** Debounced save — resets the timer on every call. */
+  schedule(snapshot: WorkspaceSnapshot): void {
+    if (this._timer !== null) clearTimeout(this._timer)
+    this._timer = setTimeout(() => {
+      this._timer = null
+      this._write(snapshot)
+    }, this.debounceMs)
+  }
+
+  /** Cancel any pending debounce and save immediately. */
+  flush(snapshot: WorkspaceSnapshot): void {
+    if (this._timer !== null) {
+      clearTimeout(this._timer)
+      this._timer = null
+    }
+    this._write(snapshot)
+  }
+
+  /** Read the last persisted snapshot, or null if none or corrupted. */
+  restore(): WorkspaceSnapshot | null {
+    try {
+      const raw = this._store()?.getItem(STORAGE_KEY)
+      if (!raw) return null
+      const parsed = JSON.parse(raw) as WorkspaceSnapshot
+      if (typeof parsed.view !== 'string') return null
+      return parsed
+    } catch {
+      return null
+    }
+  }
+}
+
+export const workspaceSession = new WorkspaceSession()


### PR DESCRIPTION
Automated AFK landing for #129. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #129

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785912305&installation_id=129708444&pr_number=138&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F138&signature=91f8ee7ef8d5ba9cdf249b50691f3257a0fdc4fa53a9aa994c37d428f95810c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->