### PR TITLE
feat(ui): host console sink on the embed surface

### DIFF
--- a/packages/ui/src/lib/embed/index.ts
+++ b/packages/ui/src/lib/embed/index.ts
@@ -1,6 +1,7 @@
 import appCss from "../../app.css?inline";
 import type { Component } from "svelte";
-import type { ConnectionProvider } from "../reddb";
+import type { ConnectionProvider, ConsoleSink } from "../reddb";
+import { devConsole } from "../reddb/dev-console";
 import type { Theme } from "../theme.svelte";
 import { RED_UI_VERSION, readBuildInfo } from "../build-info";
 
@@ -18,6 +19,9 @@ export {
   RedClient,
   type Connection,
   type ConnectionProvider,
+  type ConsoleEntry,
+  type ConsoleEntryKind,
+  type ConsoleSink,
   type InjectedClientOptions,
   type RedClientOptions,
 } from "../reddb";
@@ -27,6 +31,14 @@ export interface RedUiEmbedOptions {
   initialRoute?: string;
   theme?: Theme;
   shadowRoot?: ShadowRootInit;
+  /**
+   * Host tap on red-ui's developer console. When set, every query/HTTP
+   * round-trip the embedded Core records — verb, target, duration, row count,
+   * sanitized payload — is also delivered to the host, so a host app (e.g.
+   * red-request) can mirror red-ui's RQL/SQL traffic into its own developer
+   * bar. Entries are already secret-redacted before they reach the sink.
+   */
+  consoleSink?: ConsoleSink;
 }
 
 export interface RedUiEmbedHandle {
@@ -167,11 +179,16 @@ export async function mountRedUi(
     },
   });
 
+  const removeSink = opts.consoleSink
+    ? devConsole.addSink(opts.consoleSink)
+    : undefined;
+
   return {
     host,
     shadowRoot,
     portalTarget,
     destroy: () => {
+      removeSink?.();
       void unmount(instance);
       shadowRoot.textContent = "";
     },
@@ -180,6 +197,7 @@ export async function mountRedUi(
 
 export class RedUiElement extends HTMLElement {
   #connectionProvider: ConnectionProvider | null = null;
+  #consoleSink: ConsoleSink | null = null;
   initialRoute: string | undefined;
   theme: Theme | undefined;
   #handle: RedUiEmbedHandle | null = null;
@@ -198,6 +216,20 @@ export class RedUiElement extends HTMLElement {
 
   set connectionProvider(provider: ConnectionProvider | null) {
     this.#connectionProvider = provider;
+    if (this.isConnected) this.#mounting = this.#mount();
+  }
+
+  get consoleSink(): ConsoleSink | null {
+    return this.#consoleSink;
+  }
+
+  /**
+   * Host tap on the embedded Core's developer console (see
+   * `RedUiEmbedOptions.consoleSink`). Setting it after mount remounts, like
+   * `connectionProvider` — hosts normally assign both before attach.
+   */
+  set consoleSink(sink: ConsoleSink | null) {
+    this.#consoleSink = sink;
     if (this.isConnected) this.#mounting = this.#mount();
   }
 
@@ -220,6 +252,7 @@ export class RedUiElement extends HTMLElement {
       connectionProvider: this.#connectionProvider,
       initialRoute: this.initialRoute,
       theme: this.theme,
+      consoleSink: this.#consoleSink ?? undefined,
     });
   }
 }

--- a/packages/ui/src/lib/reddb/dev-console.test.ts
+++ b/packages/ui/src/lib/reddb/dev-console.test.ts
@@ -31,7 +31,9 @@ describe("redactSecrets", () => {
 
 describe("sanitizePayload", () => {
   it("parses a JSON body and redacts secrets in the copyable text", () => {
-    const out = sanitizePayload(JSON.stringify({ query: "SELECT 1", token: "secret" }));
+    const out = sanitizePayload(
+      JSON.stringify({ query: "SELECT 1", token: "secret" })
+    );
     expect(out).toContain("SELECT 1");
     expect(out).toContain("«redacted»");
     expect(out).not.toContain("secret");
@@ -110,6 +112,32 @@ describe("DevConsoleStore", () => {
     expect(store.size).toBe(3);
     // ids 3,4,5 survive; 1,2 were dropped.
     expect(store.snapshot().map((e) => e.id)).toEqual([3, 4, 5]);
+  });
+
+  it("delivers each new entry to sinks exactly once, without replaying history", () => {
+    const store = new DevConsoleStore();
+    store.record(baseEntry()); // recorded before the sink exists — not replayed
+    const seen: number[] = [];
+    const removeSink = store.addSink((entry) => seen.push(entry.id));
+    store.record(baseEntry());
+    store.record(baseEntry());
+    expect(seen).toEqual([2, 3]);
+    removeSink();
+    store.record(baseEntry());
+    expect(seen).toEqual([2, 3]); // detached sink hears nothing
+  });
+
+  it("survives a throwing sink: the entry is still stored and other sinks still fire", () => {
+    const store = new DevConsoleStore();
+    const seen: number[] = [];
+    store.addSink(() => {
+      throw new Error("host sink exploded");
+    });
+    store.addSink((entry) => seen.push(entry.id));
+    const entry = store.record(baseEntry());
+    expect(entry.id).toBe(1);
+    expect(store.size).toBe(1);
+    expect(seen).toEqual([1]);
   });
 });
 

--- a/packages/ui/src/lib/reddb/dev-console.ts
+++ b/packages/ui/src/lib/reddb/dev-console.ts
@@ -39,6 +39,14 @@ export interface ConsoleEntry {
 /** A record as handed to the store — the store owns `id`. */
 export type ConsoleEntryInput = Omit<ConsoleEntry, "id">;
 
+/**
+ * A per-entry tap on the console. Unlike `subscribe` (which observes the whole
+ * snapshot for rendering), a sink receives each entry exactly once, as it is
+ * recorded — the shape an embedding host wants for mirroring red-ui's traffic
+ * into its own developer console.
+ */
+export type ConsoleSink = (entry: ConsoleEntry) => void;
+
 type Listener = (entries: readonly ConsoleEntry[]) => void;
 
 /** Keys whose values are always masked, matched case-insensitively as substrings. */
@@ -61,7 +69,9 @@ export function redactSecrets(value: unknown, depth = 0): unknown {
   if (value && typeof value === "object") {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      out[k] = SENSITIVE_KEY_RE.test(k) ? REDACTED : redactSecrets(v, depth + 1);
+      out[k] = SENSITIVE_KEY_RE.test(k)
+        ? REDACTED
+        : redactSecrets(v, depth + 1);
     }
     return out;
   }
@@ -101,6 +111,7 @@ export function sanitizePayload(body: unknown): string | undefined {
 export class DevConsoleStore {
   private entries: ConsoleEntry[] = [];
   private readonly listeners = new Set<Listener>();
+  private readonly sinks = new Set<ConsoleSink>();
   private nextId = 1;
 
   /** Cap on retained entries; oldest are dropped past this. */
@@ -114,7 +125,26 @@ export class DevConsoleStore {
       this.entries.splice(0, this.entries.length - this.capacity);
     }
     this.emit();
+    for (const sink of this.sinks) {
+      try {
+        sink(entry);
+      } catch {
+        // A host-owned sink must never be able to break the client seam.
+      }
+    }
     return entry;
+  }
+
+  /**
+   * Tap every future entry. Entries recorded before the sink was added are
+   * not replayed — a host mirrors live traffic, it doesn't import history.
+   * Returns an unsubscribe.
+   */
+  addSink(sink: ConsoleSink): () => void {
+    this.sinks.add(sink);
+    return () => {
+      this.sinks.delete(sink);
+    };
   }
 
   /** A frozen, newest-last snapshot of the log. */


### PR DESCRIPTION
## What

Adds a hierarchical developer-console tap to the embed surface, so an embedding host (red-request) can mirror every RQL/HTTP round-trip the embedded `<red-ui-app>` makes into **its own** developer bar.

- `DevConsoleStore.addSink(sink)` — per-entry tap, distinct from `subscribe()`'s snapshot feed. Sinks receive each entry exactly once, live (no history replay). A throwing sink can never break the client seam.
- `RedUiEmbedOptions.consoleSink` + `consoleSink` property on `RedUiElement` — the host assigns it like `connectionProvider`; unhooked on `destroy()`.
- Entry types (`ConsoleEntry`, `ConsoleEntryKind`, `ConsoleSink`) re-exported from `@reddb-io/ui/embed`.

## Why

Today red-request only sees the embedded red-ui's traffic *implicitly*, as generic HTTP entries at its fetch bridge (`embeddedRedUiFetch` → `reddb_request` → `logReddbHttp`) — the RQL text is buried in the request body and never surfaces as a query entry. With this seam, the host gets red-ui's already-classified, secret-redacted entries (verb `SELECT`, target, duration, row count, sanitized payload) and can feed them to `developerConsole.logReddbRql` on its side.

Host wiring (red-request `RedUiDatabaseView.svelte`) becomes:

```ts
host.consoleSink = (entry) => {
  if (entry.kind === "query") {
    developerConsole.logReddbRql({ query: entry.payload ?? entry.target, ok: entry.ok, durationMs: entry.durationMs, rows: entry.rowCount });
  }
};
```

## Testing

- New unit tests: sink delivery/unsubscribe semantics, no history replay, throwing-sink isolation.
- Full `@reddb-io/ui` suite: 578 tests green; `svelte-check`: 0 errors.

Part of the red-request alignment effort (developer bar parity + hierarchical console).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786016860&installation_id=129708444&pr_number=139&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F139&signature=2f88bd51261539db39ac3ac51c1de3248d001779faa40914f7c7d7a57f9ff826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->