### PR TITLE
docs(adr): 0008 — prefer RQL over RedWire; HTTP is bootstrap/fallback

### DIFF
--- a/.red/adr/0008-prefer-rql-over-redwire-http-is-fallback.md
+++ b/.red/adr/0008-prefer-rql-over-redwire-http-is-fallback.md
@@ -1,0 +1,56 @@
+# ADR 0008 — Prefer RQL over RedWire; HTTP is bootstrap/fallback
+
+Status: accepted
+Date: 2026-07-07
+
+## Decision
+
+red-ui's preferred data path is **RQL statements over RedWire-over-binary-WebSocket**
+(`/redwire`, subprotocol `reddb.redwire.v1`). The HTTP-JSON surface
+(`RedClient`'s REST endpoints, `POST /query`, `POST /query/stream`) is demoted
+to a **bootstrap/fallback** role: proof-of-life (`/stats`), capability
+discovery, environments where binary WS is blocked, and operations RQL cannot
+yet express.
+
+This adopts reddb ADR-0049 ("UI canonical transport is RedWire-over-WebSocket",
+accepted 2026-06-08) on the client side, and records the maintainer's product
+direction: *always prefer RQL via redwire over HTTP requests*.
+
+## Why
+
+- **One transport reaches everything.** CDC, replication topology stats, and
+  subscriptions are streaming-native; RedWire-over-WS carries them as one
+  framed, multiplexed, backpressured protocol. The HTTP+SSE pair splits the
+  contract in two.
+- **Version negotiation is native.** The RedWire handshake's
+  `SUPPORTED_VERSION` exchange is a hard negotiation; the HTTP surface
+  advertises no protocol version at all. A mismatch renders a friendly
+  "update" banner — the negotiation is hard, only the presentation is soft.
+- **It works on every Surface.** Browser/PWA cannot open raw TCP (`red://`
+  :5050) or gRPC; WebSocket is the one native conduit all three Surfaces
+  (PWA, desktop webview, embed) share. This is why red-ui does not copy
+  red-request's `red connect` gRPC-REPL model — that fits a Rust-owned
+  sidecar, not a browser bundle.
+- **The client half already exists.** The #94 spike implements the frame
+  codec, handshake, and auth kinds; the server ships the endpoint
+  (`reddb-wire/src/redwire`, served by `reddb-server`).
+
+## Consequences
+
+- The spike is hardened into a production transport module and slotted behind
+  the existing seams (`RedClientOptions.fetch` is *not* abused for this; the
+  query path `query()`/`queryStreamCollect()` switches transport internally,
+  and `transports.ts` learns `ws`/`wss` as a real Surface capability per
+  ADR-0003). Tracked in #141.
+- The HTTP client is **not removed**. Connections to older reddb or through
+  WS-blocking middleboxes keep working, badged honestly as fallback.
+- Dev-console entries look the same on either transport (`kind: "query"`,
+  duration, rows, sanitized statement), so the embed `consoleSink` contract
+  is transport-agnostic.
+
+## Related
+
+- reddb ADR-0049, ADR-0036 (unified async connection model), ADR-0034
+- red-ui ADR-0003 (transport reachability is a Surface capability)
+- Issues #94 (spike), #95 (benchmark), #96 (decision gate — answered), #141
+  (implementation)


### PR DESCRIPTION
Records the transport decision locally, mirroring reddb ADR-0049 and the maintainer's direction (goal 2026-07-07). Companion to #141 (implementation) and the #96 guidance comment. Doc-only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786017375&installation_id=129708444&pr_number=143&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F143&signature=db2493313c4fbe53fa2786e000dba7f36285cbe1c010920f13e0ef100c729da5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->