### PR TITLE
fix(desktop): main CI is red — E0638 on CloseRequested destructure

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -335,7 +335,7 @@ pub fn run() {
                 // arm a 500 ms watchdog that force-destroys if the webview hangs
                 // so the OS close button can never be trapped.
                 tauri::RunEvent::WindowEvent { label, event, .. } => {
-                    if let tauri::WindowEvent::CloseRequested { api } = event {
+                    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                         api.prevent_close();
                         if let Some(window) = app_handle.get_webview_window(&label) {
                             let _ = window.emit("close-request", ());


### PR DESCRIPTION
## What

One-line fix: `WindowEvent::CloseRequested { api }` → `{ api, .. }` in `apps/desktop/src-tauri/src/lib.rs:338`.

## Why

The variant is `#[non_exhaustive]`, so the exhaustive pattern from the close-request watchdog (#129 / PR #138) fails `cargo check` with E0638. The `tauri` CI job has been red on `main` since #138 merged, which also fails that job on every open PR (#139, #140 show the same failure).

**Merge this first**, then re-run the `tauri` job on #139/#140 — their failures are this, not their own diffs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786018799&installation_id=129708444&pr_number=144&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F144&signature=4ab9038ae392a95c3b49edf5b3a5dbd16bdabd031076129923cfee4a8c97eb37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window close handling so the desktop app responds more reliably to close requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->