### PR TITLE
ci: run tauri check post-merge only, pnpm lane on free runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,9 @@ concurrency:
 
 jobs:
   check:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Public repo — ubuntu-latest is free; this pnpm lane is light enough
+    # that a paid Blacksmith runner buys nothing (cost policy, July 2026).
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -45,8 +47,10 @@ jobs:
     # Verify the Rust shell still compiles on every PR; doesn't bundle
     # installers (that's the release workflow's job) — just runs
     # `cargo check` against the same workspace tauri-action will later use.
-    # Skipped on draft PRs (the slowest job; don't burn it on WIP).
-    if: github.event.pull_request.draft != true
+    # Cost policy (July 2026, Blacksmith bill): the slowest job runs
+    # POST-MERGE on push to main only — never on an open PR. Rust shell
+    # breakage surfaces after merge; release.yml still hard-gates on tags.
+    if: github.event_name != 'pull_request'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       # sccache object-cache; CARGO_INCREMENTAL must be 0 (incremental and


### PR DESCRIPTION
Parte do corte de custos Blacksmith (conta de junho: $8200 — ver reddb-io/reddb#1905).

- Job `check` (pnpm check/test/build, leve) → `ubuntu-latest` grátis (repo público)
- Job `tauri` (cargo check do shell Tauri, o mais lento) → roda **pós-merge** no push pra main, nunca em PR aberto. O release (tag) continua hard-gate buildando tudo.
- Cache do tauri continua sendo salvo na main (mesma `shared-key` que o release.yml usa pra warm-start)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786036887&installation_id=129708444&pr_number=145&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F145&signature=e0000c75abad90257947e7b981a8105c253ab3b85573620169ce76fdb112b05f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->