### PR TITLE
chore: #125 Sidecar provisioning: pinned fetch with musl-static preference, checksum verification, release preflight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,12 @@ jobs:
       # The `red` sidecar (Tauri externalBin) is a ~15MB binary, gitignored
       # rather than committed. tauri-build validates `binaries/red-<triple>`
       # exists at compile time, so provision it before `cargo check`.
+      # fetch-sidecar.sh downloads the pinned release asset for the host triple,
+      # preferring the static musl build on Linux, and verifies the sha256.
       - name: provision red sidecar
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/reddb-io/reddb/main/install.sh | bash
-          bash scripts/sync-desktop-sidecar.sh "$HOME/.local/bin/red"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/fetch-sidecar.sh
       - run: cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml
       - name: sccache stats
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,22 @@ concurrency:
 # tauri + pwa, triggered by a manually-pushed v* tag when you want a desktop/PWA
 # release. This keeps npm with exactly one publisher (no double-publish).
 jobs:
+  # Preflight: verify the pinned reddb release has all required sidecar assets
+  # before the Tauri build matrix starts. A missing asset fails here in seconds
+  # rather than after each platform runner has warmed up and run Rust compilation.
+  preflight:
+    name: preflight · reddb assets
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+      - name: check reddb release assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/preflight-release-assets.sh
+
   tauri:
     name: tauri · ${{ matrix.platform }}
+    needs: preflight
     permissions:
       contents: write
     strategy:
@@ -111,11 +125,14 @@ jobs:
         run: ls -la packages/ui/build/ && test -f packages/ui/build/index.html
 
       # Provision the `red` sidecar (Tauri externalBin) — gitignored, not
-      # committed. Must exist before tauri-action bundles the app.
+      # committed. fetch-sidecar.sh downloads the pinned release asset for
+      # the build target, preferring the static musl build on Linux (no glibc
+      # dependency), and verifies the sha256 checksum before placing it in
+      # apps/desktop/src-tauri/binaries/red-<triple>.
       - name: provision red sidecar
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/reddb-io/reddb/main/install.sh | bash
-          bash scripts/sync-desktop-sidecar.sh "$HOME/.local/bin/red"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/fetch-sidecar.sh
 
       - name: build tauri
         uses: tauri-apps/tauri-action@v0

--- a/scripts/fetch-sidecar.sh
+++ b/scripts/fetch-sidecar.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Fetch the pinned `red` sidecar binary for the current build target and
+# verify the published sha256 checksum.
+#
+# On Linux the static musl build is preferred over the glibc-linked build.
+# The glibc build crash-loops on older distributions (glibc version mismatch),
+# while the musl build is self-contained and runs everywhere.
+#
+# Usage:
+#   scripts/fetch-sidecar.sh              # fetch pinned release for host triple
+#   scripts/fetch-sidecar.sh --source     # build from source (unreleased changes)
+#
+# Options:
+#   --source  Build from a local reddb source tree instead of downloading a
+#             release asset. Requires the reddb repo checked out at ../reddb
+#             or at the path in $REDDB_SRC.
+#
+# Environment:
+#   REDDB_VERSION       Release tag to fetch (default: see pin below).
+#   TAURI_TARGET_TRIPLE Override the detected host triple.
+#   REDDB_SRC           Path to a reddb source tree (for --source builds).
+#   GITHUB_TOKEN        Optional — avoids GitHub API rate limits (60/h unauth).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST_DIR="$HERE/apps/desktop/src-tauri/binaries"
+
+# ── version pin ──────────────────────────────────────────────────────────────
+# WHY THIS PIN: v1.9.1 is the first release to ship static musl assets and to
+# emit Access-Control-Allow-Origin headers (required for browser fetches from
+# the SvelteKit bundle). Update REDDB_VERSION when reddb ships a newer release
+# that red-ui requires, then confirm the new release has all required assets
+# via: scripts/preflight-release-assets.sh
+REDDB_VERSION="${REDDB_VERSION:-v1.9.1}"
+REDDB_REPO="reddb-io/reddb"
+
+# ── target triple ────────────────────────────────────────────────────────────
+TRIPLE="${TAURI_TARGET_TRIPLE:-}"
+if [ -z "$TRIPLE" ] && command -v rustc >/dev/null 2>&1; then
+  TRIPLE="$(rustc -vV | sed -n 's/^host: //p')"
+fi
+if [ -z "$TRIPLE" ]; then
+  case "$(uname -s)-$(uname -m)" in
+    Linux-x86_64)            TRIPLE="x86_64-unknown-linux-gnu" ;;
+    Linux-aarch64)           TRIPLE="aarch64-unknown-linux-gnu" ;;
+    Darwin-x86_64)           TRIPLE="x86_64-apple-darwin" ;;
+    Darwin-arm64|Darwin-aarch64) TRIPLE="aarch64-apple-darwin" ;;
+    *) echo "✗ cannot determine target triple; set TAURI_TARGET_TRIPLE" >&2; exit 1 ;;
+  esac
+fi
+
+# ── source-build path ────────────────────────────────────────────────────────
+if [[ "${1:-}" == "--source" ]]; then
+  REDDB_SRC="${REDDB_SRC:-}"
+  if [ -z "$REDDB_SRC" ] && [ -d "$HERE/../reddb" ]; then
+    REDDB_SRC="$(cd "$HERE/../reddb" && pwd)"
+  fi
+  if [ -z "$REDDB_SRC" ] || [ ! -d "$REDDB_SRC" ]; then
+    echo "✗ --source requires a reddb checkout at ../reddb or REDDB_SRC=<path>" >&2
+    exit 1
+  fi
+  echo "▸ building red from source: $REDDB_SRC"
+  (cd "$REDDB_SRC" && cargo build --release)
+  mkdir -p "$DEST_DIR"
+  cp "$REDDB_SRC/target/release/red" "$DEST_DIR/red-$TRIPLE"
+  chmod +x "$DEST_DIR/red-$TRIPLE"
+  echo "▸ sidecar provisioned from source: binaries/red-$TRIPLE"
+  exit 0
+fi
+
+# ── asset name mapping ────────────────────────────────────────────────────────
+# Maps each Tauri target triple to the reddb GitHub release asset filename.
+# PREFERRED is fetched first; FALLBACK is tried when PREFERRED is absent.
+# Linux: musl static build preferred; glibc build as fallback.
+case "$TRIPLE" in
+  x86_64-unknown-linux-*)
+    PREFERRED="red-linux-amd64-musl"
+    FALLBACK="red-linux-amd64"
+    ;;
+  aarch64-unknown-linux-*)
+    PREFERRED="red-linux-arm64-musl"
+    FALLBACK="red-linux-arm64"
+    ;;
+  x86_64-apple-darwin)
+    PREFERRED="red-darwin-amd64"
+    FALLBACK=""
+    ;;
+  aarch64-apple-darwin)
+    PREFERRED="red-darwin-arm64"
+    FALLBACK=""
+    ;;
+  x86_64-pc-windows-msvc)
+    PREFERRED="red-windows-amd64.exe"
+    FALLBACK=""
+    ;;
+  *)
+    echo "✗ no asset mapping for triple '$TRIPLE'; add it to scripts/fetch-sidecar.sh" >&2
+    exit 1
+    ;;
+esac
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+GH_AUTH=()
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  GH_AUTH=(-H "Authorization: Bearer $GITHUB_TOKEN")
+fi
+
+BASE_URL="https://github.com/$REDDB_REPO/releases/download/$REDDB_VERSION"
+
+sha256_of() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print $1}'
+  else
+    echo "✗ neither sha256sum nor shasum found" >&2; exit 1
+  fi
+}
+
+# ── fetch checksums file ──────────────────────────────────────────────────────
+TMPDIR_LOCAL="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_LOCAL"' EXIT
+
+CHECKSUMS_FILE="$TMPDIR_LOCAL/checksums.txt"
+echo "▸ fetching checksums for $REDDB_REPO $REDDB_VERSION …"
+if ! curl -fsSL "${GH_AUTH[@]}" "$BASE_URL/checksums.txt" -o "$CHECKSUMS_FILE" 2>/dev/null; then
+  echo "  (checksums.txt not found — will try per-file .sha256)" >&2
+  CHECKSUMS_FILE=""
+fi
+
+lookup_sha() {
+  local asset="$1"
+  # checksums.txt format: "<hex>  <filename>" or "<hex> <filename>"
+  if [ -n "$CHECKSUMS_FILE" ]; then
+    grep -m1 "[[:space:]]${asset}$" "$CHECKSUMS_FILE" 2>/dev/null | awk '{print $1}' || true
+  fi
+}
+
+fetch_and_verify() {
+  local asset="$1"
+  local dest="$2"
+
+  echo "▸ downloading $asset …"
+  if ! curl -fsSL "${GH_AUTH[@]}" "$BASE_URL/$asset" -o "$dest"; then
+    return 1
+  fi
+
+  # Look for expected checksum: first in checksums.txt, then in a .sha256 file.
+  local expected_sha=""
+  expected_sha="$(lookup_sha "$asset")"
+
+  if [ -z "$expected_sha" ]; then
+    local sha_file="$TMPDIR_LOCAL/${asset}.sha256"
+    if curl -fsSL "${GH_AUTH[@]}" "$BASE_URL/${asset}.sha256" -o "$sha_file" 2>/dev/null; then
+      expected_sha="$(awk '{print $1}' "$sha_file")"
+    fi
+  fi
+
+  if [ -n "$expected_sha" ]; then
+    local actual_sha
+    actual_sha="$(sha256_of "$dest")"
+    if [ "$actual_sha" != "$expected_sha" ]; then
+      echo "✗ checksum mismatch for $asset" >&2
+      echo "  expected: $expected_sha" >&2
+      echo "  actual:   $actual_sha" >&2
+      return 1
+    fi
+    echo "▸ checksum verified"
+  else
+    echo "  ⚠ no checksum found for $asset — skipping verification" >&2
+  fi
+  return 0
+}
+
+# ── fetch the binary ──────────────────────────────────────────────────────────
+mkdir -p "$DEST_DIR"
+BIN_TMP="$TMPDIR_LOCAL/red-bin"
+FETCHED_ASSET=""
+
+if fetch_and_verify "$PREFERRED" "$BIN_TMP"; then
+  FETCHED_ASSET="$PREFERRED"
+elif [ -n "$FALLBACK" ]; then
+  echo "  ▸ preferred asset unavailable; trying fallback: $FALLBACK" >&2
+  if fetch_and_verify "$FALLBACK" "$BIN_TMP"; then
+    FETCHED_ASSET="$FALLBACK"
+  fi
+fi
+
+if [ -z "$FETCHED_ASSET" ]; then
+  echo "✗ could not fetch sidecar from $REDDB_REPO@$REDDB_VERSION" >&2
+  echo "  tried: $PREFERRED${FALLBACK:+", $FALLBACK"}" >&2
+  echo "  to build from source: scripts/fetch-sidecar.sh --source" >&2
+  exit 1
+fi
+
+cp "$BIN_TMP" "$DEST_DIR/red-$TRIPLE"
+chmod +x "$DEST_DIR/red-$TRIPLE"
+echo "▸ sidecar provisioned: binaries/red-$TRIPLE  ($FETCHED_ASSET from $REDDB_REPO $REDDB_VERSION)"

--- a/scripts/preflight-release-assets.sh
+++ b/scripts/preflight-release-assets.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Preflight check: verify that the pinned reddb release has all required
+# sidecar assets before the Tauri build matrix starts.
+#
+# Run this as a required job that gates the build matrix. A missing asset
+# surfaces immediately (before any Rust compilation) rather than after each
+# platform runner has been provisioned and has spent its warmup time.
+#
+# Usage:
+#   scripts/preflight-release-assets.sh
+#   REDDB_VERSION=v1.10.0 scripts/preflight-release-assets.sh
+#
+# Environment:
+#   REDDB_VERSION  Release tag to check. Must match the pin in fetch-sidecar.sh.
+#   GITHUB_TOKEN   Strongly recommended — unauthenticated GitHub API is capped
+#                  at 60 requests/hour (easily exhausted in active CI).
+set -euo pipefail
+
+REDDB_REPO="reddb-io/reddb"
+# Keep in sync with the default in scripts/fetch-sidecar.sh.
+REDDB_VERSION="${REDDB_VERSION:-v1.9.1}"
+
+# Assets required for the full release matrix.
+# Update when adding a new platform to the tauri build matrix in release.yml.
+REQUIRED_ASSETS=(
+  "red-linux-amd64-musl"    # Linux x86_64 — static musl (preferred)
+  "red-darwin-arm64"        # macOS Apple Silicon
+  "red-darwin-amd64"        # macOS Intel
+  "red-windows-amd64.exe"   # Windows x86_64
+)
+
+# ── query the GitHub release ─────────────────────────────────────────────────
+GH_AUTH=()
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  GH_AUTH=(-H "Authorization: Bearer $GITHUB_TOKEN")
+fi
+
+echo "▸ preflight: checking $REDDB_REPO release $REDDB_VERSION …"
+API_URL="https://api.github.com/repos/$REDDB_REPO/releases/tags/$REDDB_VERSION"
+
+HTTP_STATUS="$(curl -o /dev/null -sw '%{http_code}' "${GH_AUTH[@]}" "$API_URL")"
+if [ "$HTTP_STATUS" = "404" ]; then
+  echo "✗ release $REDDB_VERSION not found in $REDDB_REPO" >&2
+  echo "  Check: https://github.com/$REDDB_REPO/releases" >&2
+  exit 1
+fi
+if [ "$HTTP_STATUS" != "200" ]; then
+  echo "✗ GitHub API returned HTTP $HTTP_STATUS for $API_URL" >&2
+  exit 1
+fi
+
+RELEASE_JSON="$(curl -fsSL "${GH_AUTH[@]}" "$API_URL")"
+
+# Extract asset names. Works with both `jq` and a grep fallback.
+if command -v jq >/dev/null 2>&1; then
+  AVAILABLE_ASSETS="$(echo "$RELEASE_JSON" | jq -r '.assets[].name')"
+else
+  # Fallback: parse the JSON asset name fields without jq.
+  # GitHub asset JSON lines look like:  "name": "red-linux-amd64-musl",
+  AVAILABLE_ASSETS="$(echo "$RELEASE_JSON" \
+    | grep -o '"name": "[^"]*"' \
+    | sed 's/"name": "//;s/"$//' \
+    | grep -v '^red-ui')"
+fi
+
+# ── check for missing assets ─────────────────────────────────────────────────
+MISSING=()
+for asset in "${REQUIRED_ASSETS[@]}"; do
+  if ! echo "$AVAILABLE_ASSETS" | grep -qxF "$asset"; then
+    MISSING+=("$asset")
+  fi
+done
+
+if [ "${#MISSING[@]}" -gt 0 ]; then
+  echo "✗ release $REDDB_VERSION is missing required sidecar assets:" >&2
+  for m in "${MISSING[@]}"; do
+    echo "  ✗ $m" >&2
+  done
+  echo "" >&2
+  echo "  Available assets in $REDDB_VERSION:" >&2
+  echo "$AVAILABLE_ASSETS" | sed 's/^/    /' >&2
+  echo "" >&2
+  echo "  To fix: wait for the release to publish all assets, or update" >&2
+  echo "  REDDB_VERSION in scripts/fetch-sidecar.sh to a complete release." >&2
+  exit 1
+fi
+
+echo "✓ all required assets present in $REDDB_VERSION:"
+for asset in "${REQUIRED_ASSETS[@]}"; do
+  echo "  ✓ $asset"
+done


### PR DESCRIPTION
Automated AFK landing for #125. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #125

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786217113&installation_id=129708444&pr_number=146&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F146&signature=63623a2bb9917321faf0dcb80030530c74d0212e6c8c838eb66f152ba3d47e50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->