### PR TITLE
feat(release): build every platform and publish an installable release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           workspaces: apps/desktop/src-tauri
           # Shared with release.yml's tauri job so the release build
           # warm-starts from CI's cache.
-          shared-key: tauri-${{ runner.os }}-rust-1.95.0
+          shared-key: tauri-x86_64-unknown-linux-gnu-rust-1.95.0
           cache-on-failure: "true"
       - uses: ./.github/actions/tauri-linux-deps
       # The `red` sidecar (Tauri externalBin) is a ~15MB binary, gitignored

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,22 +46,31 @@ jobs:
         run: bash scripts/preflight-release-assets.sh
 
   tauri:
-    name: tauri · ${{ matrix.platform }}
+    name: tauri · ${{ matrix.triple }}
     needs: preflight
     permissions:
       contents: write
     strategy:
       fail-fast: false
       matrix:
-        # macOS and Windows builds are intentionally commented out until
-        # the Linux pipeline is green end-to-end. Uncomment to restore.
+        # One entry per shipped architecture. `triple` drives the sidecar
+        # fetch, the rust-cache key, and (on macOS) the build target. Linux
+        # aarch64 builds natively on a Blacksmith ARM runner rather than
+        # cross-compiling — cross-building webkit2gtk is not worth the pain
+        # (the same call reddb-io/reddb made for its aarch64 leg).
         include:
           - platform: blacksmith-8vcpu-ubuntu-2404
+            triple: x86_64-unknown-linux-gnu
             args: ""
-          # - platform: blacksmith-6vcpu-macos-15
-          #   args: '--target universal-apple-darwin'
-          # - platform: blacksmith-8vcpu-windows-2025
-          #   args: ''
+          - platform: blacksmith-8vcpu-ubuntu-2404-arm
+            triple: aarch64-unknown-linux-gnu
+            args: ""
+          - platform: blacksmith-6vcpu-macos-15
+            triple: universal-apple-darwin
+            args: "--target universal-apple-darwin"
+          - platform: blacksmith-8vcpu-windows-2025
+            triple: x86_64-pc-windows-msvc
+            args: ""
 
     runs-on: ${{ matrix.platform }}
     env:
@@ -100,9 +109,11 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: apps/desktop/src-tauri
-          # Same key as ci.yml's tauri job so the release build warm-starts
-          # from CI's cache.
-          shared-key: tauri-${{ runner.os }}-rust-1.95.0
+          # Keyed by triple, not runner.os — the two Linux legs share an OS but
+          # not an architecture, and one key would have them overwriting each
+          # other's cache. The x86_64-linux key matches ci.yml's tauri job so
+          # the release build warm-starts from CI's cache.
+          shared-key: tauri-${{ matrix.triple }}-rust-1.95.0
           cache-on-failure: "true"
 
       - name: linux deps
@@ -122,6 +133,7 @@ jobs:
         run: pnpm --filter @reddb-io/ui build
 
       - name: verify frontend bundle
+        shell: bash
         run: ls -la packages/ui/build/ && test -f packages/ui/build/index.html
 
       # Provision the `red` sidecar (Tauri externalBin) — gitignored, not
@@ -130,8 +142,13 @@ jobs:
       # dependency), and verifies the sha256 checksum before placing it in
       # apps/desktop/src-tauri/binaries/red-<triple>.
       - name: provision red sidecar
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Explicit, because the runner's host triple isn't always the build
+          # target: the macOS leg builds universal-apple-darwin, for which the
+          # script lipos both Darwin slices together.
+          TAURI_TARGET_TRIPLE: ${{ matrix.triple }}
         run: bash scripts/fetch-sidecar.sh
 
       - name: build tauri
@@ -272,6 +289,30 @@ jobs:
           sha256sum * > checksums.txt
           cat checksums.txt
           gh release upload "$TAG" checksums.txt --clobber --repo "$GITHUB_REPOSITORY"
+
+  # Everything above uploads into a *draft* release, so a half-built tag is
+  # never visible. This job is the gate that makes it real, and it only runs
+  # when every platform in the matrix succeeded (`needs` requires success).
+  #
+  # Publishing is what makes the release installable at all: /releases/latest
+  # and the releases API skip drafts, so install.sh, install.ps1 (and winget,
+  # scoop, homebrew…) cannot see a tag until this step flips it.
+  publish:
+    name: publish · undraft
+    needs: [tauri, pwa-build, checksums]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ github.ref_name }}
+    steps:
+      - name: publish release
+        run: gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest
+
+      - name: assets
+        run: gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name'
 
   # GitHub Pages deployment for https://ui.reddb.io is handled by
   # .github/workflows/pages.yml on pushes to main.

--- a/README.md
+++ b/README.md
@@ -7,10 +7,18 @@ Ships as both a desktop app (Tauri 2) and a PWA built from the same Svelte sourc
 ## Install
 
 ```sh
+# Linux · macOS
 curl -fsSL https://raw.githubusercontent.com/reddb-io/red-ui/main/install.sh | bash
 ```
 
-Detects your platform, downloads the matching release asset, and verifies its sha256 against the release's `checksums.txt`. Linux installs the `.deb` by default (`--appimage` for the portable single-file build); macOS/Windows get the verified installer handed to them. Re-running the same one-liner upgrades in place — it's the update mechanism too. Remove with `uninstall.sh`.
+```powershell
+# Windows
+irm https://raw.githubusercontent.com/reddb-io/red-ui/main/install.ps1 | iex
+```
+
+Detects your platform, downloads the matching release asset, and verifies its sha256 against the release's `checksums.txt`. Linux installs the `.deb` by default (`--appimage` for the portable single-file build); macOS gets the verified installer handed to it. Re-running the same one-liner upgrades in place — it's the update mechanism too. Remove with `uninstall.sh`.
+
+Releases carry Linux x86_64 and aarch64, a universal macOS build, and Windows x86_64.
 
 ## Stack
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -127,18 +127,37 @@ struct Embedded {
 #[derive(Default)]
 struct EmbeddedRegistry(Mutex<HashMap<String, Embedded>>);
 
+/// The user's home directory. `HOME` on unix; Windows sets `USERPROFILE`
+/// instead (and only sets `HOME` under MSYS/Git-Bash-style shells), so try
+/// both before giving up.
+fn home_dir() -> Result<String, CommandError> {
+    std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map_err(|_| CommandError::new("PATH_RESOLUTION", "no HOME or USERPROFILE in the environment"))
+}
+
 /// Resolve a user-typed path (from a `file://` URL) to an absolute path. `~`
-/// and relative paths resolve against `$HOME`, so `file://./test.rdb` opens
-/// `~/test.rdb` — a predictable base for a GUI app whose cwd is unspecified.
+/// and relative paths resolve against the home directory, so `file://./test.rdb`
+/// opens `~/test.rdb` — a predictable base for a GUI app whose cwd is
+/// unspecified.
 fn resolve_embedded_path(input: &str) -> Result<String, CommandError> {
     let raw = input.trim();
     let raw = raw.strip_prefix("file://").unwrap_or(raw);
-    let home = || {
-        std::env::var("HOME")
-            .map_err(|_| CommandError::new("PATH_RESOLUTION", "HOME environment variable is not set"))
+    // A Windows file URL carries its drive behind the URL's own root slash
+    // (`file:///C:/db.rdb` → `/C:/db.rdb`), which `Path::is_absolute` rejects —
+    // the path would then be joined onto the home directory. Drop that slash.
+    let raw = match raw.strip_prefix('/') {
+        Some(rest)
+            if cfg!(windows)
+                && rest.as_bytes().first().is_some_and(u8::is_ascii_alphabetic)
+                && rest[1..].starts_with(':') =>
+        {
+            rest
+        }
+        _ => raw,
     };
     let expanded = if let Some(rest) = raw.strip_prefix("~/") {
-        format!("{}/{}", home()?, rest)
+        format!("{}/{}", home_dir()?, rest)
     } else {
         raw.to_string()
     };
@@ -146,7 +165,7 @@ fn resolve_embedded_path(input: &str) -> Result<String, CommandError> {
     let abs = if path.is_absolute() {
         path.to_path_buf()
     } else {
-        std::path::Path::new(&home()?).join(expanded.trim_start_matches("./"))
+        std::path::Path::new(&home_dir()?).join(expanded.trim_start_matches("./"))
     };
     Ok(abs.to_string_lossy().to_string())
 }
@@ -398,9 +417,29 @@ mod tests {
         assert!(err.detail.is_some());
     }
 
+    #[cfg(unix)]
     #[test]
     fn resolve_embedded_path_absolute_is_untouched() {
         let resolved = resolve_embedded_path("file:///tmp/data.rdb").expect("absolute path");
         assert_eq!(resolved, "/tmp/data.rdb");
+    }
+
+    // The dialog plugin hands back `file:///C:/…` on Windows; the drive has to
+    // survive, rather than the path being treated as relative and joined onto
+    // the user profile.
+    #[cfg(windows)]
+    #[test]
+    fn resolve_embedded_path_keeps_windows_drive() {
+        let resolved =
+            resolve_embedded_path("file:///C:/Users/dev/data.rdb").expect("absolute path");
+        assert_eq!(resolved, "C:/Users/dev/data.rdb");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn resolve_embedded_path_expands_tilde_from_userprofile() {
+        let resolved = resolve_embedded_path("file://~/data.rdb").expect("home-relative path");
+        assert!(resolved.ends_with("data.rdb"));
+        assert!(!resolved.starts_with('~'));
     }
 }

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,112 @@
+# red-ui — one-line installer for Windows.
+#
+#   irm https://raw.githubusercontent.com/reddb-io/red-ui/main/install.ps1 | iex
+#
+# The PowerShell counterpart to install.sh: same repo, same release, same
+# checksum verification. Windows users get this instead of the bash script
+# because `| iex` is the idiom they already have (no Git Bash required).
+#
+# Environment overrides — the only way to pass options through `| iex`:
+#   $env:RED_UI_VERSION       = 'v0.4.0'   # default: latest published release
+#   $env:RED_UI_INSTALLER     = 'msi'      # 'nsis' (default, per-user) | 'msi' (per-machine, elevates)
+#   $env:RED_UI_DOWNLOAD_ONLY = '1'        # fetch + verify, don't run the installer
+#   $env:GITHUB_TOKEN                      # lifts the 60/h anonymous API rate limit
+#
+# Windows PowerShell 5.1 compatible — no PS7-only syntax.
+
+$ErrorActionPreference = 'Stop'
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$Repo = 'reddb-io/red-ui'
+$Version = if ($env:RED_UI_VERSION) { $env:RED_UI_VERSION } else { 'latest' }
+$Kind = if ($env:RED_UI_INSTALLER) { $env:RED_UI_INSTALLER.ToLower() } else { 'nsis' }
+
+function Write-Step($msg) { Write-Host "▸ $msg" }
+
+$arch = $env:PROCESSOR_ARCHITECTURE
+if ($arch -eq 'ARM64') {
+  Write-Warning "No native ARM64 build yet — installing the x64 build (runs under emulation)."
+} elseif ($arch -ne 'AMD64') {
+  throw "Unsupported architecture: $arch"
+}
+
+$headers = @{ 'User-Agent' = 'red-ui-installer' }
+if ($env:GITHUB_TOKEN) { $headers['Authorization'] = "Bearer $env:GITHUB_TOKEN" }
+
+# /releases/latest only ever returns a published, non-draft release — which is
+# what release.yml's publish job produces once every platform has built.
+$apiUrl = if ($Version -eq 'latest') {
+  "https://api.github.com/repos/$Repo/releases/latest"
+} else {
+  "https://api.github.com/repos/$Repo/releases/tags/$Version"
+}
+
+Write-Step "Resolving $Version from $Repo"
+$release = Invoke-RestMethod -Uri $apiUrl -Headers $headers
+Write-Step "Release $($release.tag_name)"
+
+# Prefer the stable, version-free name the release workflow stages (the same
+# one install.sh fetches, and the only one covered by checksums.txt); fall
+# back to Tauri's versioned bundle names.
+$candidates = if ($Kind -eq 'msi') {
+  @('^red-ui-windows-x86_64\.msi$', '_x64.*\.msi$')
+} else {
+  @('^red-ui-windows-x86_64-setup\.exe$', '_x64-setup\.exe$')
+}
+$asset = $null
+foreach ($pattern in $candidates) {
+  $asset = $release.assets | Where-Object { $_.name -match $pattern } | Select-Object -First 1
+  if ($asset) { break }
+}
+if (-not $asset) {
+  $names = ($release.assets | ForEach-Object { $_.name }) -join ', '
+  throw "No Windows $Kind installer in $($release.tag_name). Assets: $names"
+}
+
+$dest = Join-Path ([IO.Path]::GetTempPath()) $asset.name
+Write-Step "Downloading $($asset.name)"
+Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $dest -Headers $headers -UseBasicParsing
+
+# checksums.txt is attached by the release workflow once every platform has
+# uploaded. Absent on releases that predate it — warn rather than fail.
+$sums = $release.assets | Where-Object { $_.name -eq 'checksums.txt' } | Select-Object -First 1
+if ($sums) {
+  # GitHub serves release assets as application/octet-stream, so
+  # Invoke-WebRequest's .Content comes back as Byte[] rather than a string (on
+  # 5.1 and 7 alike) — write it out and read it back as text instead.
+  $sumsPath = Join-Path ([IO.Path]::GetTempPath()) 'red-ui-checksums.txt'
+  Invoke-WebRequest -Uri $sums.browser_download_url -OutFile $sumsPath -Headers $headers -UseBasicParsing
+  $line = Get-Content -Path $sumsPath | Where-Object { $_ -match "\s$([regex]::Escape($asset.name))\s*$" } | Select-Object -First 1
+  Remove-Item $sumsPath -Force -ErrorAction SilentlyContinue
+  if ($line -and $line -match '([0-9a-fA-F]{64})') {
+    $expected = $Matches[1].ToLower()
+    $actual = (Get-FileHash -Path $dest -Algorithm SHA256).Hash.ToLower()
+    if ($actual -ne $expected) {
+      Remove-Item $dest -Force
+      throw "Checksum mismatch for $($asset.name): $actual != $expected"
+    }
+    Write-Step "Checksum verified"
+  } else {
+    Write-Warning "$($asset.name) is not listed in checksums.txt — skipping verification."
+  }
+} else {
+  Write-Warning "No checksums.txt in this release — skipping verification."
+}
+
+if ($env:RED_UI_DOWNLOAD_ONLY) {
+  Write-Step "Downloaded to $dest (RED_UI_DOWNLOAD_ONLY set, not installing)"
+  return
+}
+
+Write-Step "Installing $($asset.name)"
+if ($Kind -eq 'msi') {
+  # WiX bundles install per-machine, so this prompts for elevation.
+  $p = Start-Process msiexec -ArgumentList @('/i', "`"$dest`"", '/qn', '/norestart') -Wait -PassThru
+} else {
+  # Tauri's NSIS bundle is a per-user install; /S is its silent switch.
+  $p = Start-Process $dest -ArgumentList '/S' -Wait -PassThru
+}
+if ($p.ExitCode -ne 0) { throw "Installer exited with code $($p.ExitCode)" }
+
+Remove-Item $dest -Force -ErrorAction SilentlyContinue
+Write-Step "red-ui $($release.tag_name) installed — launch it from the Start menu."

--- a/scripts/fetch-sidecar.sh
+++ b/scripts/fetch-sidecar.sh
@@ -26,12 +26,13 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEST_DIR="$HERE/apps/desktop/src-tauri/binaries"
 
 # ── version pin ──────────────────────────────────────────────────────────────
-# WHY THIS PIN: v1.9.1 is the first release to ship static musl assets and to
-# emit Access-Control-Allow-Origin headers (required for browser fetches from
-# the SvelteKit bundle). Update REDDB_VERSION when reddb ships a newer release
-# that red-ui requires, then confirm the new release has all required assets
-# via: scripts/preflight-release-assets.sh
-REDDB_VERSION="${REDDB_VERSION:-v1.9.1}"
+# WHY THIS PIN: >=1.9.1 emits Access-Control-Allow-Origin headers (required for
+# browser fetches from the SvelteKit bundle); v1.23.2 is the current release and
+# the one whose asset set is verified against the mapping below. Update
+# REDDB_VERSION when reddb ships a newer release that red-ui requires, then
+# confirm the new release has all required assets via:
+#   scripts/preflight-release-assets.sh
+REDDB_VERSION="${REDDB_VERSION:-v1.23.2}"
 REDDB_REPO="reddb-io/reddb"
 
 # ── target triple ────────────────────────────────────────────────────────────
@@ -45,6 +46,7 @@ if [ -z "$TRIPLE" ]; then
     Linux-aarch64)           TRIPLE="aarch64-unknown-linux-gnu" ;;
     Darwin-x86_64)           TRIPLE="x86_64-apple-darwin" ;;
     Darwin-arm64|Darwin-aarch64) TRIPLE="aarch64-apple-darwin" ;;
+    MINGW*-x86_64|MSYS*-x86_64|CYGWIN*-x86_64) TRIPLE="x86_64-pc-windows-msvc" ;;
     *) echo "✗ cannot determine target triple; set TAURI_TARGET_TRIPLE" >&2; exit 1 ;;
   esac
 fi
@@ -72,25 +74,34 @@ fi
 # Maps each Tauri target triple to the reddb GitHub release asset filename.
 # PREFERRED is fetched first; FALLBACK is tried when PREFERRED is absent.
 # Linux: musl static build preferred; glibc build as fallback.
+#
+# These names are reddb's own release convention (`<arch>` as uname reports it,
+# `-static` for the musl link) — verify against a real release before editing:
+#   gh release view v1.23.2 -R reddb-io/reddb --json assets --jq '.assets[].name'
 case "$TRIPLE" in
   x86_64-unknown-linux-*)
-    PREFERRED="red-linux-amd64-musl"
-    FALLBACK="red-linux-amd64"
+    PREFERRED="red-linux-x86_64-static"
+    FALLBACK="red-linux-x86_64"
     ;;
   aarch64-unknown-linux-*)
-    PREFERRED="red-linux-arm64-musl"
-    FALLBACK="red-linux-arm64"
+    PREFERRED="red-linux-aarch64-static"
+    FALLBACK="red-linux-aarch64"
     ;;
   x86_64-apple-darwin)
-    PREFERRED="red-darwin-amd64"
+    PREFERRED="red-macos-x86_64"
     FALLBACK=""
     ;;
   aarch64-apple-darwin)
-    PREFERRED="red-darwin-arm64"
+    PREFERRED="red-macos-aarch64"
     FALLBACK=""
     ;;
   x86_64-pc-windows-msvc)
-    PREFERRED="red-windows-amd64.exe"
+    PREFERRED="red-windows-x86_64.exe"
+    FALLBACK=""
+    ;;
+  universal-apple-darwin)
+    # Handled below by fetching both slices and lipo-ing them together.
+    PREFERRED=""
     FALLBACK=""
     ;;
   *)
@@ -98,6 +109,11 @@ case "$TRIPLE" in
     exit 1
     ;;
 esac
+
+# Tauri appends the host's executable suffix when it resolves an externalBin,
+# so the Windows sidecar has to land as red-<triple>.exe.
+DEST_SUFFIX=""
+case "$TRIPLE" in *-windows-*) DEST_SUFFIX=".exe" ;; esac
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 GH_AUTH=()
@@ -173,6 +189,30 @@ fetch_and_verify() {
   return 0
 }
 
+# ── universal macOS: lipo the two slices ─────────────────────────────────────
+# `tauri build --target universal-apple-darwin` resolves the externalBin as
+# red-universal-apple-darwin, and no such asset exists upstream — reddb ships
+# one binary per arch. Fuse them here. The per-arch files are kept too, so a
+# plain `tauri dev` on the same machine (which resolves the host triple) works.
+if [ "$TRIPLE" = "universal-apple-darwin" ]; then
+  command -v lipo >/dev/null 2>&1 || { echo "✗ lipo not found (macOS only)" >&2; exit 1; }
+  mkdir -p "$DEST_DIR"
+  SLICES=()
+  for pair in "x86_64-apple-darwin:red-macos-x86_64" "aarch64-apple-darwin:red-macos-aarch64"; do
+    slice_triple="${pair%%:*}"
+    slice_asset="${pair##*:}"
+    fetch_and_verify "$slice_asset" "$TMPDIR_LOCAL/$slice_asset" \
+      || { echo "✗ could not fetch $slice_asset from $REDDB_REPO@$REDDB_VERSION" >&2; exit 1; }
+    cp "$TMPDIR_LOCAL/$slice_asset" "$DEST_DIR/red-$slice_triple"
+    chmod +x "$DEST_DIR/red-$slice_triple"
+    SLICES+=("$DEST_DIR/red-$slice_triple")
+  done
+  lipo -create -output "$DEST_DIR/red-universal-apple-darwin" "${SLICES[@]}"
+  chmod +x "$DEST_DIR/red-universal-apple-darwin"
+  echo "▸ sidecar provisioned: binaries/red-universal-apple-darwin  (lipo of both macOS slices, $REDDB_REPO $REDDB_VERSION)"
+  exit 0
+fi
+
 # ── fetch the binary ──────────────────────────────────────────────────────────
 mkdir -p "$DEST_DIR"
 BIN_TMP="$TMPDIR_LOCAL/red-bin"
@@ -194,6 +234,6 @@ if [ -z "$FETCHED_ASSET" ]; then
   exit 1
 fi
 
-cp "$BIN_TMP" "$DEST_DIR/red-$TRIPLE"
-chmod +x "$DEST_DIR/red-$TRIPLE"
-echo "▸ sidecar provisioned: binaries/red-$TRIPLE  ($FETCHED_ASSET from $REDDB_REPO $REDDB_VERSION)"
+cp "$BIN_TMP" "$DEST_DIR/red-$TRIPLE$DEST_SUFFIX"
+chmod +x "$DEST_DIR/red-$TRIPLE$DEST_SUFFIX"
+echo "▸ sidecar provisioned: binaries/red-$TRIPLE$DEST_SUFFIX  ($FETCHED_ASSET from $REDDB_REPO $REDDB_VERSION)"

--- a/scripts/preflight-release-assets.sh
+++ b/scripts/preflight-release-assets.sh
@@ -18,15 +18,19 @@ set -euo pipefail
 
 REDDB_REPO="reddb-io/reddb"
 # Keep in sync with the default in scripts/fetch-sidecar.sh.
-REDDB_VERSION="${REDDB_VERSION:-v1.9.1}"
+REDDB_VERSION="${REDDB_VERSION:-v1.23.2}"
 
-# Assets required for the full release matrix.
-# Update when adding a new platform to the tauri build matrix in release.yml.
+# Assets required for the full release matrix — one per entry in release.yml's
+# tauri matrix (the macOS universal build needs both Darwin slices to lipo).
+# Names follow reddb's release convention; confirm against a real release
+# rather than guessing:
+#   gh release view v1.23.2 -R reddb-io/reddb --json assets --jq '.assets[].name'
 REQUIRED_ASSETS=(
-  "red-linux-amd64-musl"    # Linux x86_64 — static musl (preferred)
-  "red-darwin-arm64"        # macOS Apple Silicon
-  "red-darwin-amd64"        # macOS Intel
-  "red-windows-amd64.exe"   # Windows x86_64
+  "red-linux-x86_64-static"   # Linux x86_64 — static musl (preferred)
+  "red-linux-aarch64-static"  # Linux aarch64 — static musl (preferred)
+  "red-macos-aarch64"         # macOS Apple Silicon
+  "red-macos-x86_64"          # macOS Intel
+  "red-windows-x86_64.exe"    # Windows x86_64
 )
 
 # ── query the GitHub release ─────────────────────────────────────────────────


### PR DESCRIPTION
## Problema

O release matrix buildava **só Linux x86_64** (macOS e Windows comentados) e toda a release ficava como **draft** — `GET /releases/latest` respondia vazio, então o `install.sh` não tinha o que puxar e o Windows não tinha nem artefato.

E o `fetch-sidecar.sh` que entrou em #125 aponta para uma release e assets que **não existem**:

```
$ gh api repos/reddb-io/reddb/releases/tags/v1.9.1   →  404 Not Found
red-linux-amd64-musl   → MISSING      (o real é red-linux-x86_64-static)
red-darwin-arm64       → MISSING      (o real é red-macos-aarch64)
red-windows-amd64.exe  → MISSING      (o real é red-windows-x86_64.exe)
```

O job de preflight teria derrubado a release inteira na próxima tag.

## O que muda

**Matrix completa** — `linux x86_64`, `linux aarch64` (runner ARM nativo, mesma escolha do reddb-io/reddb no leg aarch64), `macOS universal`, `windows x86_64`. O `rust-cache` passa a ser chaveado por triple: os dois legs de Linux compartilham `runner.os` e sobrescreveriam o cache um do outro.

**Job `publish`** — roda só quando todas as plataformas *e* o job de checksums passaram, e então marca a release como published + latest. É o que faltava para qualquer instalador enxergar a tag.

**`fetch-sidecar.sh` corrigido** — pin em `v1.23.2` com os nomes de asset reais (conferidos contra a release), mais os dois casos que a matrix multi-plataforma exige: o sufixo `.exe` que o Tauri resolve no Windows, e o `lipo` das duas slices Darwin para o `--target universal-apple-darwin` (não existe asset universal upstream). O `preflight-release-assets.sh` recebe a mesma lista corrigida.

**`install.ps1`** — contraparte Windows do `install.sh`: resolve a release pela API, prefere o asset de nome estável (o mesmo que o `install.sh` usa, e o único coberto pelo `checksums.txt`), verifica o sha256 e roda o instalador NSIS em modo silencioso.

**`resolve_embedded_path`** — mantinha a barra raiz da URL em `file:///C:/…`, que o `Path::is_absolute` rejeita: todo caminho no Windows virava relativo e era colado no home — que por sua vez falhava, já que o Windows define `USERPROFILE` e não `HOME`. Sem isso o "Open database file…" nasceria quebrado no build que estamos passando a distribuir.

## Verificação

Rodado de verdade nesta máquina, contra releases reais:

- `preflight-release-assets.sh` → ✓ os 5 assets presentes em `v1.23.2`
- `fetch-sidecar.sh` para `x86_64-pc-windows-msvc` → baixou, **checksum verificado**, gravou `red-x86_64-pc-windows-msvc.exe`
- `fetch-sidecar.sh` para `aarch64-unknown-linux-gnu` → baixou o `-static`, checksum verificado
- `fetch-sidecar.sh` para `universal-apple-darwin` → baixou e verificou as duas slices e chamou o `lipo` com ambas (stub de `lipo`, já que a máquina é Linux)
- `install.ps1` executado sob PowerShell 7: resolução via API → download → verificação de checksum OK. Um bug foi encontrado assim: o GitHub serve `checksums.txt` como octet-stream e o `.Content` do `Invoke-WebRequest` volta `Byte[]`, então a verificação passava batido **em silêncio** — corrigido, e o caso "asset não listado" agora avisa em vez de calar.
- YAML dos dois workflows validado; `bash -n` nos scripts.

**Não rodei** `cargo check`/testes aqui (a pedido) — a mudança em `lib.rs` é coberta pelo job `tauri` do CI.

## Notas

- Sem os secrets `WINDOWS_CERTIFICATE` / `APPLE_*`, os instaladores saem **não assinados**: SmartScreen e Gatekeeper vão reclamar. O workflow já os referencia; falta popular.
- Sem `TAURI_SIGNING_PRIVATE_KEY` não há `latest.json` de updater — auto-update segue desligado (o plugin updater nem está no `Cargo.toml`).
- O staging de nomes estáveis só cobre NSIS no Windows; o `install.ps1` cai no nome versionado do MSI se alguém pedir `RED_UI_INSTALLER=msi`.