### PR TITLE
chore(release): version packages 0.3.2

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/ui-desktop",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2970,7 +2970,7 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "red-ui"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "keyring",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "red-ui"
-version = "0.3.1"
+version = "0.3.2"
 description = "reddb universal client"
 authors = ["reddb-io"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "red-ui",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "io.reddb.ui",
   "build": {
     "beforeDevCommand": "pnpm --filter @reddb-io/ui dev",
@@ -28,7 +28,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "externalBin": ["binaries/red"],
+    "externalBin": [
+      "binaries/red"
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -43,7 +45,13 @@
   "plugins": {
     "deep-link": {
       "desktop": {
-        "schemes": ["red", "red+tls", "red+unix", "red+http", "red+https"]
+        "schemes": [
+          "red",
+          "red+tls",
+          "red+unix",
+          "red+http",
+          "red+https"
+        ]
       }
     }
   }

--- a/apps/embed-host/CHANGELOG.md
+++ b/apps/embed-host/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reddb-io/embed-host
 
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @reddb-io/ui@0.3.2
+
 ## 0.1.3
 
 ### Patch Changes

--- a/apps/embed-host/package.json
+++ b/apps/embed-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/embed-host",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @reddb-io/ui-mcp
 
+## 0.3.2
+
+### Patch Changes
+
+- Release binaries for every supported platform and publish them where installers can find them.
+
+  Tags now build Linux x86_64 and aarch64, a universal macOS bundle, and Windows
+  x86_64, and the release is published (not left as a draft) once every platform
+  and the checksum job succeed — `/releases/latest` skips drafts, so nothing could
+  install a tag before. `install.ps1` joins `install.sh` as the Windows one-liner.
+
+  Also fixes the sidecar fetch, which pointed at a reddb release and asset names
+  that do not exist, and `resolve_embedded_path`, which could not resolve a
+  Windows `file:///C:/…` path or find the home directory on Windows.
+
 ## 0.3.1
 
 ## 0.3.0

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/ui-mcp",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": false,
   "description": "MCP Apps server for embedding RedDB UI in MCP clients.",
   "type": "module",

--- a/packages/ui-kit/CHANGELOG.md
+++ b/packages/ui-kit/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @reddb-io/ui-kit
 
+## 0.3.2
+
+### Patch Changes
+
+- Release binaries for every supported platform and publish them where installers can find them.
+
+  Tags now build Linux x86_64 and aarch64, a universal macOS bundle, and Windows
+  x86_64, and the release is published (not left as a draft) once every platform
+  and the checksum job succeed — `/releases/latest` skips drafts, so nothing could
+  install a tag before. `install.ps1` joins `install.sh` as the Windows one-liner.
+
+  Also fixes the sidecar fetch, which pointed at a reddb release and asset names
+  that do not exist, and `resolve_embedded_path`, which could not resolve a
+  Windows `file:///C:/…` path or find the home directory on Windows.
+
 ## 0.3.1
 
 ## 0.3.0

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/ui-kit",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": false,
   "description": "Low-level RedDB UI design-system primitives.",
   "type": "module",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @reddb-io/ui
 
+## 0.3.2
+
+### Patch Changes
+
+- Release binaries for every supported platform and publish them where installers can find them.
+
+  Tags now build Linux x86_64 and aarch64, a universal macOS bundle, and Windows
+  x86_64, and the release is published (not left as a draft) once every platform
+  and the checksum job succeed — `/releases/latest` skips drafts, so nothing could
+  install a tag before. `install.ps1` joins `install.sh` as the Windows one-liner.
+
+  Also fixes the sidecar fetch, which pointed at a reddb release and asset names
+  that do not exist, and `resolve_embedded_path`, which could not resolve a
+  Windows `file:///C:/…` path or find the home directory on Windows.
+
+- Updated dependencies
+  - @reddb-io/ui-kit@0.3.2
+  - @reddb-io/ui-mcp@0.3.2
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/ui",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": false,
   "description": "RedDB UI components and standalone web application.",
   "type": "module",

--- a/scripts/sync-desktop-version.mjs
+++ b/scripts/sync-desktop-version.mjs
@@ -57,6 +57,22 @@ const edits = [];
   }
 }
 
+// Cargo.lock — the red-ui package entry. Cargo would rewrite this itself on the
+// next build, but leaving it stale means the release tag and the committed
+// lockfile disagree about what version was built.
+{
+  const path = join(root, "apps/desktop/src-tauri/Cargo.lock");
+  const lock = readFileSync(path, "utf8");
+  const updated = lock.replace(
+    /(name = "red-ui"\nversion = ")[^"]*(")/,
+    `$1${version}$2`
+  );
+  if (updated !== lock) {
+    writeFileSync(path, updated);
+    edits.push(`Cargo.lock → ${version}`);
+  }
+}
+
 if (edits.length === 0) {
   console.log(`sync-desktop-version: desktop already at ${version}`);
 } else {


### PR DESCRIPTION
Patch bump em cima do #147, para cortar a primeira release que exercita a matrix multi-plataforma ponta a ponta.

- `@reddb-io/ui`, `ui-kit`, `ui-mcp` e o app desktop → **0.3.2** (grupo `fixed` do changesets + `sync-desktop-version.mjs`)
- `sync-desktop-version.mjs` passa a sincronizar o `Cargo.lock` também: o cargo reescreve a entrada `red-ui` no próximo build de qualquer forma, mas deixá-la para trás faz a tag da release e o lockfile commitado discordarem sobre o que foi buildado (estava travado em 0.3.1). Rodei duas vezes — idempotente.

Depois do merge, empurro a tag `v0.3.2` para disparar o `release.yml`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788086725&installation_model_id=20659&pr_number=148&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F148&signature=1d129903b70b926d936ec5c2367cd0cf062ce6952c921a995cd60ca2d19b0f7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->