### PR TITLE
fix(ci): publish to npm even when the bump landed via PR

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -10,6 +10,11 @@ name: Changesets
 #   (@reddb-io/ui + ui-kit + ui-mcp), commits "chore(release): version packages",
 #   pushes it to main, and runs `changeset publish`.
 #
+# The publish step runs on every push to main, not only when this workflow did
+# the versioning: a bump that landed through a PR would otherwise never reach
+# npm. `changeset publish` skips versions already on the registry, so the extra
+# runs are no-ops.
+#
 # Auth: GITHUB_TOKEN (contents:write to push the bump) + NPM_TOKEN (registry).
 # Runs github-hosted because npm provenance only verifies there. The bot's own
 # bump commit is skipped by the actor guard, so it never loops.
@@ -65,14 +70,17 @@ jobs:
         run: |
           set -euo pipefail
           # `release:version` = changeset version (+ sync-desktop-version.mjs).
-          # No pending changesets ⇒ no file changes ⇒ we skip the publish.
           pnpm release:version
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "No pending changesets — nothing to version or publish."
-            exit 0
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git commit -m "chore(release): version packages"
+            git push origin HEAD:main
+          else
+            echo "No pending changesets — nothing to version."
           fi
-          git add -A
-          git commit -m "chore(release): version packages"
-          git push origin HEAD:main
-          # changeset publish is idempotent: it skips versions already on npm.
+          # Publish unconditionally. `changeset publish` is idempotent (it skips
+          # versions already on the registry), and running it even when nothing
+          # was versioned here is what lets npm catch up after a bump that
+          # landed through a PR instead of through this workflow — otherwise
+          # that version is simply never published.
           pnpm release:publish


### PR DESCRIPTION
O step de publish do `changesets.yml` só rodava quando o próprio workflow tinha feito o bump. O 0.3.2, versionado no #148, portanto **nunca chegaria ao npm** — o registry ficaria em 0.3.1 até que algum changeset futuro caísse na main.

`changeset publish` já pula versões que existem no registry, então rodar em todo push para main é no-op exceto quando o npm está atrás.

Ao mergear, o run na main publica o 0.3.2. Depois disso empurro a tag `v0.3.2` para os binários.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788086948&installation_model_id=20659&pr_number=149&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F149&signature=c6a5b05f97f139dcb87eb35fe41a6b076de653791daec18200d809c4ee2f9fd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->