### PR TITLE
fix(ci): make release.yml valid again and lint workflows on every PR

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,11 @@
+# Runner labels actionlint can't know about: Blacksmith-hosted runners, which
+# are self-hosted from GitHub's point of view. Keep in sync with the `runs-on`
+# values across .github/workflows (grep for "blacksmith-").
+self-hosted-runner:
+  labels:
+    - blacksmith-2vcpu-ubuntu-2404
+    - blacksmith-4vcpu-ubuntu-2404
+    - blacksmith-8vcpu-ubuntu-2404
+    - blacksmith-8vcpu-ubuntu-2404-arm
+    - blacksmith-6vcpu-macos-15
+    - blacksmith-8vcpu-windows-2025

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,17 @@ jobs:
       # so PNGs carrying those extensions sat in the tree until the first
       # Windows build failed on `RC2175: not in 3.00 format`. Check the magic
       # bytes on every PR instead of on every other platform's first release.
+      # An invalid workflow file isn't a normal failure — GitHub creates a run
+      # with zero jobs and no log, so a broken release.yml looks like "the
+      # release didn't happen" rather than an error. That is exactly how a
+      # `secrets` context in a step `if:` (not allowed there) reached a tag.
+      # shellcheck integration is off: this gates workflow *validity*, and the
+      # runner's shellcheck would also start failing CI on existing run blocks.
+      - name: lint workflows
+        run: |
+          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
+          ./actionlint -shellcheck=
+
       - name: verify desktop icon formats
         run: |
           node -e '

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,10 @@ jobs:
       CARGO_INCREMENTAL: "0"
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
+      # Which of the two build steps below runs. The `secrets` context is not
+      # available in a step `if:`, but it is in `env:`, so the decision is made
+      # here and read back as a plain string.
+      HAS_APPLE_CERT: ${{ secrets.APPLE_CERTIFICATE != '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -158,7 +162,7 @@ jobs:
       # and fail the build ("failed to import keychain certificate"). Empty
       # TAURI_SIGNING_* and WINDOWS_CERTIFICATE are tolerated, so those stay put.
       - name: build tauri (unsigned — no Apple certificate configured)
-        if: ${{ secrets.APPLE_CERTIFICATE == '' }}
+        if: env.HAS_APPLE_CERT != 'true'
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -178,7 +182,7 @@ jobs:
           args: ${{ matrix.args }}
 
       - name: build tauri (signed)
-        if: ${{ secrets.APPLE_CERTIFICATE != '' }}
+        if: env.HAS_APPLE_CERT == 'true'
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`if: \${{ secrets.APPLE_CERTIFICATE == '' }}` **não é válido** — o contexto `secrets` não existe em condição de step. E o GitHub responde a um workflow inválido com um run de **zero jobs e nenhum log**, então a tag `v0.3.2` re-empurrada pareceu simplesmente não ter disparado release nenhuma. O gate agora passa por um env var de job, onde `secrets` é permitido:

```yaml
env:
  HAS_APPLE_CERT: ${{ secrets.APPLE_CERTIFICATE != '' }}
...
  - name: build tauri (unsigned …)
    if: env.HAS_APPLE_CERT != 'true'
```

E o actionlint entra no job `check`, para que o próximo erro desses apareça no PR em vez de numa tag. O `.github/actionlint.yaml` declara os labels dos runners Blacksmith (self-hosted do ponto de vista do GitHub), então o linter passa sem flag de ignore. Integração com shellcheck desligada de propósito: isso aqui é gate de *validade* de workflow, e o shellcheck do runner começaria a reprovar run blocks que essa mudança nem toca.

Rodado localmente com o actionlint 1.7.12 — que reproduziu o erro exato antes do fix e passa limpo depois.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-ui/pr/151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788088510&installation_model_id=20659&pr_number=151&repository=reddb-io%2Fred-ui&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-ui%2Fpull%2F151&signature=f21be767fb955f1057d5c1e1d19600a7e9d25e3f4be0bc33abb0c7d663de2212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->