### PR TITLE
ci: use free public runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,8 @@ jobs:
     # POST-MERGE on push to main only — never on an open PR. Rust shell
     # breakage surfaces after merge; release.yml still hard-gates on tags.
     if: github.event_name != 'pull_request'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Public repo: the post-merge compile check is free on GitHub-hosted Linux.
+    runs-on: ubuntu-latest
     env:
       # sccache object-cache; CARGO_INCREMENTAL must be 0 (incremental and
       # sccache are mutually exclusive). Harvested from reddb-io/reddb.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@ on:
     tags: ["v*"]
   workflow_dispatch:
 
-# Runners: Blacksmith-hosted, matching reddb-io/reddb's setup.
-# 8vcpu for the heavy Rust+webview Tauri builds; 4vcpu elsewhere.
+# Runners: free standard GitHub-hosted runners for this public repository.
+# Blacksmith remains available for explicit Testbox/performance investigations.
 #
 # Signing secrets (all optional — the workflow falls back to unsigned
 # builds when a secret is missing):
@@ -55,20 +55,19 @@ jobs:
       matrix:
         # One entry per shipped architecture. `triple` drives the sidecar
         # fetch, the rust-cache key, and (on macOS) the build target. Linux
-        # aarch64 builds natively on a Blacksmith ARM runner rather than
-        # cross-compiling — cross-building webkit2gtk is not worth the pain
-        # (the same call reddb-io/reddb made for its aarch64 leg).
+        # aarch64 builds natively on GitHub's public ARM runner rather than
+        # cross-compiling — cross-building webkit2gtk is not worth the pain.
         include:
-          - platform: blacksmith-8vcpu-ubuntu-2404
+          - platform: ubuntu-24.04
             triple: x86_64-unknown-linux-gnu
             args: ""
-          - platform: blacksmith-8vcpu-ubuntu-2404-arm
+          - platform: ubuntu-24.04-arm
             triple: aarch64-unknown-linux-gnu
             args: ""
-          - platform: blacksmith-6vcpu-macos-15
+          - platform: macos-15
             triple: universal-apple-darwin
             args: "--target universal-apple-darwin"
-          - platform: blacksmith-8vcpu-windows-2025
+          - platform: windows-2025
             triple: x86_64-pc-windows-msvc
             args: ""
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
   # rather than after each platform runner has warmed up and run Rust compilation.
   preflight:
     name: preflight · reddb assets
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: check reddb release assets
@@ -248,7 +248,7 @@ jobs:
 
   pwa-build:
     name: pwa · build + zip
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     env:
@@ -302,7 +302,7 @@ jobs:
   checksums:
     name: checksums.txt
     needs: [tauri, pwa-build]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     env:
@@ -330,7 +330,7 @@ jobs:
     name: publish · undraft
     needs: [tauri, pwa-build, checksums]
     if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     env:


### PR DESCRIPTION
## Why

This public repository can use free standard GitHub-hosted Linux, ARM, macOS, and Windows runners instead of paying Blacksmith for regular checks and release builds.

## What changes

- run the post-main Tauri check on GitHub-hosted Linux
- run the release Tauri matrix on `ubuntu-24.04`, `ubuntu-24.04-arm`, `macos-15`, and `windows-2025`
- move release preflight, PWA, checksum, and publish jobs to GitHub-hosted runners
- preserve the four shipped desktop architectures and signing behavior

## Validation

- actionlint across active workflows
- live draft CI passed before this release-runner update
- `git diff --check`

No release was invoked.